### PR TITLE
Broker bind output rework

### DIFF
--- a/pkg/apb/bind.go
+++ b/pkg/apb/bind.go
@@ -32,7 +32,6 @@ func Bind(
 		return podName, nil, err
 	}
 
-	ns := instance.Context.Namespace
-	creds, err := ExtractCredentials(podName, ns, log)
+	creds, err := ExtractCredentials(podName, instance.Context.Namespace, log)
 	return podName, creds, err
 }

--- a/pkg/apb/deprovision.go
+++ b/pkg/apb/deprovision.go
@@ -40,9 +40,5 @@ func Deprovision(instance *ServiceInstance, clusterConfig ClusterConfig, log *lo
 	}
 
 	log.Info(string(podName))
-
-	// Using ExtractCredentials to display output from the apb run
-	// TODO: breakout the output logic from the credentials logic
-	_, err = ExtractCredentials(podName, instance.Context.Namespace, log)
 	return podName, err
 }

--- a/pkg/apb/ext_creds.go
+++ b/pkg/apb/ext_creds.go
@@ -22,7 +22,7 @@ func ExtractCredentials(
 	credOut := make(chan []byte)
 
 	log.Debug("Calling monitorOutput on " + podname)
-	go monitorOutput(podname, credOut, log)
+	go monitorOutput(namespace, podname, credOut, log)
 
 	var bindOutput []byte
 	for msg := range credOut {
@@ -32,14 +32,14 @@ func ExtractCredentials(
 	return buildExtractedCredentials(bindOutput)
 }
 
-func monitorOutput(podname string, mon chan []byte, log *logging.Logger) {
+func monitorOutput(namespace string, podname string, mon chan []byte, log *logging.Logger) {
 	// TODO: Error handling here
 	// It would also be nice to gather the script output that exec runs
 	// instead of only getting the credentials
 	retries := 20
 
 	for r := 1; r <= retries; r++ {
-		output, _ := RunCommand("oc", "exec", podname, "broker-bind-creds")
+		output, _ := RunCommand("oc", "exec", podname, "broker-bind-creds", "--namespace="+namespace)
 
 		stillWaiting := strings.Contains(string(output), "ContainerCreating") ||
 			strings.Contains(string(output), "NotFound") ||

--- a/pkg/apb/ext_creds.go
+++ b/pkg/apb/ext_creds.go
@@ -15,6 +15,7 @@ var stillWaitingError = "status: still waiting to start"
 var timeoutFreq = 6    // Seconds
 var totalTimeout = 900 // 15min
 
+// ExtractCredentials - Extract credentials from pod in a certain namespace.
 func ExtractCredentials(
 	podname string, namespace string, log *logging.Logger,
 ) (*ExtractedCredentials, error) {
@@ -38,7 +39,7 @@ func monitorOutput(podname string, mon chan []byte, log *logging.Logger) {
 	retries := 20
 
 	for r := 1; r <= retries; r++ {
-		output, _ := runCommand("oc", "exec", podname, "broker-bind-creds")
+		output, _ := RunCommand("oc", "exec", podname, "broker-bind-creds")
 
 		stillWaiting := strings.Contains(string(output), "ContainerCreating") ||
 			strings.Contains(string(output), "NotFound") ||

--- a/pkg/apb/provision.go
+++ b/pkg/apb/provision.go
@@ -67,6 +67,11 @@ func Provision(
 	}
 
 	creds, err := ExtractCredentials(podName, instance.Context.Namespace, log)
+	if !instance.Spec.Bindable {
+		log.Warningf("APB %s is not bindable", instance.Spec.Name)
+		log.Warningf("Ignoring Credentials")
+		creds = nil
+	}
 	return podName, creds, err
 }
 

--- a/pkg/apb/provision.go
+++ b/pkg/apb/provision.go
@@ -67,7 +67,9 @@ func Provision(
 	}
 
 	creds, err := ExtractCredentials(podName, instance.Context.Namespace, log)
-	if !instance.Spec.Bindable {
+	// We should not save credentials from an app that finds them and isn't
+	// bindable
+	if creds != nil && !instance.Spec.Bindable {
 		log.Warningf("APB %s is not bindable", instance.Spec.Name)
 		log.Warningf("Ignoring Credentials")
 		creds = nil

--- a/pkg/apb/types.go
+++ b/pkg/apb/types.go
@@ -100,6 +100,10 @@ const (
 	// NOTE: Applied to APB ServiceAccount via RoleBinding, not ClusterRoleBinding
 	// cluster-admin scoped to the project the apb is operating in
 	ApbRole = "cluster-admin"
+
+	// Bind credential gathering constants
+	CredentialRetries    = 20
+	GatherCredentialsCMD = "broker-bind-creds"
 )
 
 func specLogDump(spec *Spec, log *logging.Logger) {

--- a/pkg/apb/types.go
+++ b/pkg/apb/types.go
@@ -102,7 +102,9 @@ const (
 	ApbRole = "cluster-admin"
 
 	// Bind credential gathering constants
-	CredentialRetries    = 20
+	// 5 seconds x 60 retries = 5 minute timout
+	WaitTime             = 5
+	CredentialRetries    = 60
 	GatherCredentialsCMD = "broker-bind-creds"
 )
 

--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -464,24 +464,6 @@ func (a AnsibleBroker) Provision(instanceUUID uuid.UUID, req *ProvisionRequest, 
 		// TODO: do we want to do synchronous provisioning?
 		a.log.Info("reverting to synchronous provisioning in progress")
 		podName, extCreds, err := apb.Provision(serviceInstance, a.clusterConfig, a.log)
-
-		sm := apb.NewServiceAccountManager(a.log)
-		a.log.Info("Destroying APB sandbox...")
-		sm.DestroyApbSandbox(podName, context.Namespace)
-		if err != nil {
-			a.log.Error("broker::Provision error occurred.")
-			a.log.Error("%s", err.Error())
-			return nil, err
-		}
-
-		// TODO: do we need podname for synchronous provisions?
-		extCreds, extErr := apb.ExtractCredentials(podName, context.Namespace, a.log)
-		if extErr != nil {
-			a.log.Error("broker::Provision error occurred.")
-			a.log.Error("%s", extErr.Error())
-			return nil, extErr
-		}
-
 		if extCreds != nil {
 			a.log.Debug("broker::Provision, got ExtractedCredentials!")
 			err = a.dao.SetExtractedCredentials(instanceUUID.String(), extCreds)
@@ -490,6 +472,15 @@ func (a AnsibleBroker) Provision(instanceUUID uuid.UUID, req *ProvisionRequest, 
 				a.log.Error("%s", err.Error())
 				return nil, err
 			}
+		}
+
+		sm := apb.NewServiceAccountManager(a.log)
+		a.log.Info("Destroying APB sandbox...")
+		sm.DestroyApbSandbox(podName, context.Namespace)
+		if err != nil {
+			a.log.Error("broker::Provision error occurred.")
+			a.log.Error("%s", err.Error())
+			return nil, err
 		}
 	}
 

--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -272,6 +272,9 @@ func (a AnsibleBroker) Recover() (string, error) {
 			// YES, we have a podname
 			a.log.Info(fmt.Sprintf("We have a pod to recover: %s", rs.State.Podname))
 
+			// TODO: ExtractCredentials is doing more than it should
+			// be and it needs to be broken up.
+
 			// did the pod finish?
 			extCreds, extErr := apb.ExtractCredentials(rs.State.Podname, instance.Context.Namespace, a.log)
 

--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -467,15 +467,6 @@ func (a AnsibleBroker) Provision(instanceUUID uuid.UUID, req *ProvisionRequest, 
 		// TODO: do we want to do synchronous provisioning?
 		a.log.Info("reverting to synchronous provisioning in progress")
 		podName, extCreds, err := apb.Provision(serviceInstance, a.clusterConfig, a.log)
-		if extCreds != nil {
-			a.log.Debug("broker::Provision, got ExtractedCredentials!")
-			err = a.dao.SetExtractedCredentials(instanceUUID.String(), extCreds)
-			if err != nil {
-				a.log.Error("Could not persist extracted credentials")
-				a.log.Error("%s", err.Error())
-				return nil, err
-			}
-		}
 
 		sm := apb.NewServiceAccountManager(a.log)
 		a.log.Info("Destroying APB sandbox...")
@@ -484,6 +475,16 @@ func (a AnsibleBroker) Provision(instanceUUID uuid.UUID, req *ProvisionRequest, 
 			a.log.Error("broker::Provision error occurred.")
 			a.log.Error("%s", err.Error())
 			return nil, err
+		}
+
+		if extCreds != nil {
+			a.log.Debug("broker::Provision, got ExtractedCredentials!")
+			err = a.dao.SetExtractedCredentials(instanceUUID.String(), extCreds)
+			if err != nil {
+				a.log.Error("Could not persist extracted credentials")
+				a.log.Error("%s", err.Error())
+				return nil, err
+			}
 		}
 	}
 


### PR DESCRIPTION
Change the broker bind output from trailing the logs of
the provision or bind container to exec'ing into the container.