### PR TITLE
Non version interface will be deprecated

### DIFF
--- a/pkg/apb/client.go
+++ b/pkg/apb/client.go
@@ -93,7 +93,7 @@ func NewClient(log *logging.Logger) (*Client, error) {
 		return nil, err
 	}
 
-	rest := clientset.Core().RESTClient()
+	rest := clientset.CoreV1().RESTClient()
 
 	client := &Client{
 		dockerClient:  dockerClient,


### PR DESCRIPTION
The interface Core() will be deprecated in favor of
CoreV1().