### PR TITLE
Use the cluster client object to create the apb pod

### DIFF
--- a/pkg/apb/bind.go
+++ b/pkg/apb/bind.go
@@ -31,12 +31,12 @@ func Bind(
 		return nil, err
 	}
 
-	output, err := client.RunImage("bind", clusterConfig, instance.Spec, instance.Context, parameters)
+	podname, err := client.RunImage("bind", clusterConfig, instance.Spec, instance.Context, parameters)
 
 	if err != nil {
 		log.Error("Problem running image", err)
 		return nil, err
 	}
 
-	return extractCredentials(output, log)
+	return extractCredentials(podname, log)
 }

--- a/pkg/apb/client.go
+++ b/pkg/apb/client.go
@@ -8,11 +8,13 @@ import (
 
 	docker "github.com/fsouza/go-dockerclient"
 	logging "github.com/op/go-logging"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	restclient "k8s.io/client-go/rest"
 
 	"github.com/pborman/uuid"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/homedir"
+	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
 )
 
@@ -113,44 +115,15 @@ func (c *Client) RunImage(
 	spec *Spec,
 	context *Context,
 	p *Parameters,
-) ([]byte, error) {
+) (string, error) {
 	// HACK: We're expecting to run containers via go APIs rather than cli cmds
 	// TODO: Expecting parameters to be passed here in the future as well
 
 	extraVars, err := createExtraVars(context, p)
+
 	if err != nil {
-		return nil, err
+		return "", err
 	}
-
-	////////////////////////////////////////////////////////////////////////////////
-	// This needs a lot of cleanup. Broker was originally written to run
-	// inside a machine that also had a running dockerd available on /var/run/docker.sock
-	// If the broker is running inside of a container on ocp or k8s, this docker runtime
-	// is not available to the broker's environment in the same way. This requires
-	// the broker to run the apb metacontainer remotely...somehow.
-	// * options for docker are ugly:
-	// -> Nested docker? (bad)
-	// -> Remote docker (not a ton of options?) TCP socket?
-	// * We know we've got an available ocp cluster _somewhere_. Use oc run instead of
-	// docker? Requires an auth'd oc client available to the broker, but that can
-	// be baked into the broker's container runtime. This is done as a temporary soln.
-	//
-	// TODO: Need to figure out the right way to accomplish running metacontainers
-	// in remote runtimes longterm.
-	////////////////////////////////////////////////////////////////////////////////
-	//oc run ansible-service-broker-apb --env "OPENSHIFT_TARGET=10.1.2.2:8443"
-	//--env "OPENSHIFT_USER=admin" --env "OPENSHIFT_PASS=derp"
-	//--image=apb/ansible-service-broker-ansibleapp --restart=Never --
-	//provision -e "dockerhub_user=eriknelson" -e "dockerhub_pass=derp"
-	//-e "openshift_target=10.1.2.2:8443" -e "openshift_user=admin" -e "openshift_pass=derp"
-
-	// NOTE: Older approach when docker is easily available to the broker to run
-	// metacontainers, i.e., just running on
-	//return RunCommand("docker", "run",
-	//"-e", fmt.Sprintf("OPENSHIFT_TARGET=%s", clusterConfig.Target),
-	//"-e", fmt.Sprintf("OPENSHIFT_USER=%s", clusterConfig.User),
-	//"-e", fmt.Sprintf("OPENSHIFT_PASS=%s", clusterConfig.Password),
-	//spec.Name, action, "--extra-vars", string(params))
 
 	if !clusterConfig.InCluster {
 		err = c.refreshLoginToken(clusterConfig)
@@ -158,12 +131,11 @@ func (c *Client) RunImage(
 		if err != nil {
 			c.log.Error("Error occurred while refreshing login token! Aborting apb run.")
 			c.log.Error(err.Error())
-			return nil, err
+			return "", err
 		}
 		c.log.Notice("Login token successfully refreshed.")
 	}
 
-	c.log.Debug("Running OC run...")
 	c.log.Debug("clusterConfig:")
 	if !clusterConfig.InCluster {
 		c.log.Debug("target: [ %s ]", clusterConfig.Target)
@@ -175,20 +147,69 @@ func (c *Client) RunImage(
 	c.log.Debug("action:[ %s ]", action)
 	c.log.Debug("extra-vars:[ %s ]", extraVars)
 
+	//TODO(rhallisey): The Kubernetes API objects should be in JSON structs
+	// so it's easier to manipulate them. This is for a rebase so we don't
+	// block the service account work.  I'll come back after and clean this
+	// up.
+	var pod *v1.Pod
 	if clusterConfig.InCluster {
-		return RunCommand("oc", "run", fmt.Sprintf("aa-%s", uuid.New()),
-			fmt.Sprintf("--image-pull-policy=Always"),
-			fmt.Sprintf("--image=%s", spec.Image), "--restart=Never",
-			"--", action, "--extra-vars", extraVars)
+		pod = &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: fmt.Sprintf("apb-%s", uuid.New()),
+			},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Name:  "apb",
+						Image: spec.Image,
+						Args: []string{
+							action,
+							"--extra-vars",
+							extraVars,
+						},
+						ImagePullPolicy: v1.PullAlways,
+					},
+				},
+				RestartPolicy: v1.RestartPolicyNever,
+			},
+		}
 	} else {
-		return RunCommand("oc", "run", fmt.Sprintf("aa-%s", uuid.New()),
-			"--env", fmt.Sprintf("OPENSHIFT_TARGET=%s", clusterConfig.Target),
-			"--env", fmt.Sprintf("OPENSHIFT_USER=%s", clusterConfig.User),
-			"--env", fmt.Sprintf("OPENSHIFT_PASS=%s", clusterConfig.Password),
-			fmt.Sprintf("--image-pull-policy=Always"),
-			fmt.Sprintf("--image=%s", spec.Image), "--restart=Never",
-			"--", action, "--extra-vars", extraVars)
+		pod = &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: fmt.Sprintf("apb-%s", uuid.New()),
+			},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Name:  "apb",
+						Image: spec.Image,
+						Args: []string{
+							action,
+							"--extra-vars",
+							extraVars,
+						},
+						Env: []v1.EnvVar{{
+							Name:  "OPENSHIFT_TARGET",
+							Value: clusterConfig.Target,
+						}, {
+							Name:  "OPENSHIFT_USER",
+							Value: clusterConfig.User,
+						}, {
+							Name:  "OPENSHIFT_PASS",
+							Value: clusterConfig.Password,
+						}},
+						ImagePullPolicy: v1.PullAlways,
+					},
+				},
+				RestartPolicy: v1.RestartPolicyNever,
+			},
+		}
 	}
+
+	c.log.Notice(fmt.Sprintf("Creating pod %q in the %s namespace", pod.Name, context.Namespace))
+	_, err = c.ClusterClient.CoreV1().Pods(context.Namespace).Create(pod)
+
+	return pod.Name, err
 }
 
 func (c *Client) PullImage(imageName string) error {

--- a/pkg/apb/deprovision.go
+++ b/pkg/apb/deprovision.go
@@ -29,7 +29,7 @@ func Deprovision(instance *ServiceInstance, log *logging.Logger) error {
 	}
 
 	// Might need to change up this interface to feed in instance ids
-	output, err := client.RunImage(
+	podname, err := client.RunImage(
 		"deprovision", HardcodedClusterConfig, instance.Spec, instance.Context, instance.Parameters)
 
 	if err != nil {
@@ -37,6 +37,6 @@ func Deprovision(instance *ServiceInstance, log *logging.Logger) error {
 		return err
 	}
 
-	log.Info(string(output))
+	log.Info(podname)
 	return nil
 }

--- a/pkg/apb/ext_creds.go
+++ b/pkg/apb/ext_creds.go
@@ -4,7 +4,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
-	"regexp"
 	"strings"
 	"time"
 

--- a/pkg/apb/ext_creds.go
+++ b/pkg/apb/ext_creds.go
@@ -21,12 +21,8 @@ var TotalTimeout = 900 // 15min
 // to be thrown out and redone asap.
 
 func extractCredentials(
-	output []byte, log *logging.Logger,
+	podname string, log *logging.Logger,
 ) (*ExtractedCredentials, error) {
-	log.Info("{%s}", string(output))
-
-	log.Debug("Calling getPodName")
-	podname, _ := getPodName(output, log)
 	log.Debug("Calling monitorOutput on " + podname)
 	credOut, _ := monitorOutput(podname)
 	log.Debug("oc log output: %s", string(credOut))
@@ -76,23 +72,6 @@ func extractCredentials(
 	}
 
 	return creds, err
-}
-
-// HACK: this really is a crappy way of getting output
-func getPodName(output []byte, log *logging.Logger) (string, error) {
-	r, err := regexp.Compile(`^pod[ \"]*(.*?)[ \"]*created`)
-	if err != nil {
-		return "", err
-	}
-
-	podname := r.FindStringSubmatch(string(output))
-
-	if log != nil {
-		log.Debug("%v", podname)
-		log.Debug("%d", len(podname)-1)
-	}
-
-	return podname[len(podname)-1], nil
 }
 
 func monitorOutput(podname string) ([]byte, error) {

--- a/pkg/apb/ext_creds_test.go
+++ b/pkg/apb/ext_creds_test.go
@@ -206,11 +206,3 @@ func assertError(t *testing.T, err error, verifystr string) {
 		t.Fatal(fmt.Sprintf("method should return '%s' error", verifystr))
 	}
 }
-
-func TestGetPodName(t *testing.T) {
-	output := []byte(`pod "aa-03be586b-25fc-4d68-8591-51deed8765a1" created`)
-
-	podname, _ := getPodName(output, nil)
-
-	ft.AssertEqual(t, podname, "aa-03be586b-25fc-4d68-8591-51deed8765a1", "podname does not match")
-}

--- a/pkg/apb/provision.go
+++ b/pkg/apb/provision.go
@@ -48,14 +48,14 @@ func Provision(
 		return nil, err
 	}
 
-	output, err := client.RunImage("provision", clusterConfig, spec, context, parameters)
+	podname, err := client.RunImage("provision", clusterConfig, spec, context, parameters)
 
 	if err != nil {
 		log.Error("Problem running image")
-		log.Error(string(output))
+		log.Error(string(podname))
 		log.Error(err.Error())
 		return nil, err
 	}
 
-	return extractCredentials(output, log)
+	return extractCredentials(podname, log)
 }


### PR DESCRIPTION
Using oc run relies on the oc client. Instead, let's use
the cluster client to talk directly with kubernetes to spawn
the apb pod.