### PR TITLE
Rename fusor to openshift

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ REGISTRY         ?= docker.io
 PROJECT          ?= ansibleplaybookbundle
 TAG              ?= latest
 BROKER_APB_IMAGE = $(REGISTRY)/$(PROJECT)/ansible-service-broker-apb
-BUILD_DIR        = "${GOPATH}/src/github.com/fusor/ansible-service-broker/build"
+BUILD_DIR        = "${GOPATH}/src/github.com/openshift/ansible-service-broker/build"
 
 install: $(shell find cmd pkg)
 	go install -ldflags="-s -w" ./cmd/broker
@@ -12,13 +12,13 @@ ${GOPATH}/bin/mock-registry: $(shell find cmd/mock-registry)
 
 # Will default run to dev profile
 run: install vendor
-	@${GOPATH}/src/github.com/fusor/ansible-service-broker/scripts/runbroker.sh dev
+	@${GOPATH}/src/github.com/openshift/ansible-service-broker/scripts/runbroker.sh dev
 
 deploy:
-	@${GOPATH}/src/github.com/fusor/ansible-service-broker/scripts/deploy.sh
+	@${GOPATH}/src/github.com/openshift/ansible-service-broker/scripts/deploy.sh
 
 run-mock-registry: ${GOPATH}/bin/mock-registry vendor
-	@${GOPATH}/src/github.com/fusor/ansible-service-broker/cmd/mock-registry/run.sh
+	@${GOPATH}/src/github.com/openshift/ansible-service-broker/cmd/mock-registry/run.sh
 
 prepare-build: install
 	cp "${GOPATH}"/bin/broker build/broker

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Ansible Service Broker
-[![Build Status](https://travis-ci.org/fusor/ansible-service-broker.svg?branch=master)](https://travis-ci.org/fusor/ansible-service-broker)
-[![Code Climate](https://codeclimate.com/github/fusor/ansible-service-broker/badges/gpa.svg)](https://codeclimate.com/github/fusor/ansible-service-broker)
-[![Issue Count](https://codeclimate.com/github/fusor/ansible-service-broker/badges/issue_count.svg)](https://codeclimate.com/github/fusor/ansible-service-broker)
+[![Build Status](https://travis-ci.org/openshift/ansible-service-broker.svg?branch=master)](https://travis-ci.org/openshift/ansible-service-broker)
+[![Code Climate](https://codeclimate.com/github/openshift/ansible-service-broker/badges/gpa.svg)](https://codeclimate.com/github/openshift/ansible-service-broker)
+[![Issue Count](https://codeclimate.com/github/openshift/ansible-service-broker/badges/issue_count.svg)](https://codeclimate.com/github/openshift/ansible-service-broker)
 
 Ansible Service Broker is an implementation of the [Open Service Broker API](https://github.com/openservicebrokerapi/servicebroker) that will manage applications defined by [Ansible Playbook Bundles](https://github.com/openshift/ansible-playbook-bundle).  
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Code Climate](https://codeclimate.com/github/fusor/ansible-service-broker/badges/gpa.svg)](https://codeclimate.com/github/fusor/ansible-service-broker)
 [![Issue Count](https://codeclimate.com/github/fusor/ansible-service-broker/badges/issue_count.svg)](https://codeclimate.com/github/fusor/ansible-service-broker)
 
-Ansible Service Broker is an implementation of the [Open Service Broker API](https://github.com/openservicebrokerapi/servicebroker) that will manage applications defined by [Ansible Playbook Bundles](https://github.com/fusor/ansible-playbook-bundle).  
+Ansible Service Broker is an implementation of the [Open Service Broker API](https://github.com/openservicebrokerapi/servicebroker) that will manage applications defined by [Ansible Playbook Bundles](https://github.com/openshift/ansible-playbook-bundle).  
 
 
 An Ansible Playbook Bundle (APB) is a new method for defining and distributing container applications in OpenShift consisting of a bundle of Ansible Playbooks built into a container with an Ansible runtime.
@@ -17,10 +17,10 @@ Read more about the Ansible Service Broker and Ansible Playbook Bundles in this 
 * IRC (Freenode): #asbroker
 * [Trello](https://trello.com/b/50JhiC5v/ansible-service-broker)
 * Github:
-    * [ansible service broker](https://github.com/fusor/ansible-service-broker)
-    * [ansible playbook bundle](https://github.com/fusor/ansible-playbook-bundle)
-* [Demo environment with oc cluster up](https://github.com/fusor/catasb)
-* [Library of example APBs](https://github.com/fusor/apb-examples)
+    * [ansible service broker](https://github.com/openshift/ansible-service-broker)
+    * [ansible playbook bundle](https://github.com/openshift/ansible-playbook-bundle)
+* [Demo environment with oc cluster up](https://github.com/openshift/catasb)
+* [Library of example APBs](https://github.com/openshift/apb-examples)
     * ManageIQ
     * PostgreSQL
     * Wordpress
@@ -56,9 +56,9 @@ CentOS/RHEL/Fedora (sub dnf for Fedora):
 
 ```
 sudo /sbin/service etcd restart # start etcd
-mkdir -p $GOPATH/src/github.com/fusor
-git clone https://github.com/fusor/ansible-service-broker.git $GOPATH/src/github.com/fusor/ansible-service-broker
-cd $GOPATH/src/github.com/fusor/ansible-service-broker && glide install
+mkdir -p $GOPATH/src/github.com/openshift
+git clone https://github.com/openshift/ansible-service-broker.git $GOPATH/src/github.com/openshift/ansible-service-broker
+cd $GOPATH/src/github.com/openshift/ansible-service-broker && glide install
 ```
 
 **Config**

--- a/ansible/main.yml
+++ b/ansible/main.yml
@@ -6,7 +6,7 @@
 - hosts: asb
   gather_facts: true
   vars:
-    asb_checkout: /opt/go/src/github.com/fusor/ansible-service-broker
+    asb_checkout: /opt/go/src/github.com/openshift/ansible-service-broker
     etc_dest: /etc/ansible-service-broker
     bin_dest: /usr/local/ansible-service-broker/bin
   environment:
@@ -39,7 +39,7 @@
       with_items:
         - { dest: "/var/log/ansible-service-broker.log", mode: "g+rw", state: touch }
         - { dest: "/.kube", mode: "g+rw", state: directory }
-        - { dest: "/opt/go/src/github.com/fusor", mode: "g+rw", state: directory }
+        - { dest: "/opt/go/src/github.com/openshift", mode: "g+rw", state: directory }
         - { dest: "{{ etc_dest }}", mode: "g+rw", state: directory }
         - { dest: "{{ bin_dest }}", mode: "ug+x", state: directory }
 
@@ -69,25 +69,25 @@
         warn: false
     - name: Checkout ansible-service-broker
       git:
-        repo: https://github.com/fusor/ansible-service-broker.git
+        repo: https://github.com/openshift/ansible-service-broker.git
         dest: "{{asb_checkout}}"
         version: master
     - name: Install ansible-service-broker dependencies
       shell: glide install
       args:
-        chdir: /opt/go/src/github.com/fusor/ansible-service-broker
+        chdir: /opt/go/src/github.com/openshift/ansible-service-broker
       environment:
         PATH: "{{ansible_env.PATH}}:/usr/local/go/bin"
     - name: Build ansible-service-broker
       make:
-        chdir: /opt/go/src/github.com/fusor/ansible-service-broker
+        chdir: /opt/go/src/github.com/openshift/ansible-service-broker
         target: build
       environment:
         PATH: "{{ansible_env.PATH}}:/usr/local/go/bin"
     - name: Record broker sha
       shell: git rev-parse HEAD > /usr/local/ansible-service-broker/sha
       args:
-        chdir: /opt/go/src/github.com/fusor/ansible-service-broker
+        chdir: /opt/go/src/github.com/openshift/ansible-service-broker
     - name: Install ansible-service-broker
       copy: remote_src=True src={{item.src}} dest={{item.dest}} mode={{item.mode}}
       with_items:

--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/fusor/ansible-service-broker/pkg/app"
+import "github.com/openshift/ansible-service-broker/pkg/app"
 
 func main() {
 	app := app.CreateApp()

--- a/cmd/mock-registry/mock_registry.go
+++ b/cmd/mock-registry/mock_registry.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/fusor/ansible-service-broker/pkg/apb"
+	"github.com/openshift/ansible-service-broker/pkg/apb"
 	flags "github.com/jessevdk/go-flags"
 	yaml "gopkg.in/yaml.v1"
 )

--- a/cmd/mock-registry/mock_registry.go
+++ b/cmd/mock-registry/mock_registry.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/openshift/ansible-service-broker/pkg/apb"
 	flags "github.com/jessevdk/go-flags"
+	"github.com/openshift/ansible-service-broker/pkg/apb"
 	yaml "gopkg.in/yaml.v1"
 )
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@
   * [Introduction](introduction.md)
   * [Design](design.md)
 * Ansible Playbook Bundle
-  * [Design](https://github.com/fusor/ansible-playbook-bundle/blob/master/docs/design.md)
+  * [Design](https://github.com/openshift/ansible-playbook-bundle/blob/master/docs/design.md)
 * Bind Operation
   * [Data Transmission](bind-data-transmission.md)
   * [Use Cases](usecases.md)

--- a/docs/apb_integration.md
+++ b/docs/apb_integration.md
@@ -9,7 +9,7 @@ Ansible Playbook Bundles (APB) should be executed by the broker via the docker c
 > TODO: Document the docker client API code used to create and run these containers.
 > For now, we are running the docker cli tool via scripts until this can be sorted.
 
-See [APB design](#https://github.com/fusor/ansible-playbook-bundle/blob/master/docs/design.md)
+See [APB design](#https://github.com/openshift/ansible-playbook-bundle/blob/master/docs/design.md)
 for details for argument requirements and expectations
 
 ## Targeting a cluster for APB deployment
@@ -18,7 +18,7 @@ for details for argument requirements and expectations
 
 ![Integration0.1](images/apb_integration.png)
 
-Seen in the [APB design](#https://github.com/fusor/ansible-playbook-bundle/blob/master/docs/design.md), an `ArgumentsObject` requires a `ClusterObject`
+Seen in the [APB design](#https://github.com/openshift/ansible-playbook-bundle/blob/master/docs/design.md), an `ArgumentsObject` requires a `ClusterObject`
 intended to provide details for connecting and authenticating with a targeted
 cluster.
 

--- a/extras/ansible-service-broker.spec
+++ b/extras/ansible-service-broker.spec
@@ -178,8 +178,8 @@ unit-test for %{name}
 
 %prep
 %setup -q -n %{repo}-%{version}
-mkdir -p src/github.com/fusor/ansible-service-broker
-cp -r pkg src/github.com/fusor/ansible-service-broker
+mkdir -p src/github.com/openshift/ansible-service-broker
+cp -r pkg src/github.com/openshift/ansible-service-broker
 
 %build
 export GOPATH=$(pwd):%{gopath}

--- a/extras/ansible-service-broker.spec
+++ b/extras/ansible-service-broker.spec
@@ -21,7 +21,7 @@
 
 %global	provider github
 %global	provider_tld com
-%global project fusor
+%global project openshift
 %global repo ansible-service-broker
 
 %global provider_prefix %{provider}.%{provider_tld}/%{project}/%{repo}

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,4 +1,4 @@
-package: github.com/fusor/ansible-service-broker
+package: github.com/openshift/ansible-service-broker
 import:
 - package: github.com/gorilla/mux
   version: ^1.3.0

--- a/pkg/apb/bind_test.go
+++ b/pkg/apb/bind_test.go
@@ -3,7 +3,7 @@ package apb
 import (
 	"testing"
 
-	ft "github.com/fusor/ansible-service-broker/pkg/fusortest"
+	ft "github.com/openshift/ansible-service-broker/pkg/fusortest"
 )
 
 func TestBind(t *testing.T) {

--- a/pkg/apb/deprovision.go
+++ b/pkg/apb/deprovision.go
@@ -2,6 +2,7 @@ package apb
 
 import (
 	"fmt"
+
 	"github.com/op/go-logging"
 )
 

--- a/pkg/apb/ext_creds_test.go
+++ b/pkg/apb/ext_creds_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	ft "github.com/fusor/ansible-service-broker/pkg/fusortest"
+	ft "github.com/openshift/ansible-service-broker/pkg/fusortest"
 )
 
 func TestDecodeOutput(t *testing.T) {

--- a/pkg/apb/types_test.go
+++ b/pkg/apb/types_test.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"testing"
 
-	ft "github.com/fusor/ansible-service-broker/pkg/fusortest"
+	ft "github.com/openshift/ansible-service-broker/pkg/fusortest"
 )
 
 // array can't be const

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -9,10 +9,10 @@ import (
 	kapierrors "k8s.io/apimachinery/pkg/api/errors"
 	kubeversiontypes "k8s.io/apimachinery/pkg/version"
 
-	"github.com/fusor/ansible-service-broker/pkg/apb"
-	"github.com/fusor/ansible-service-broker/pkg/broker"
-	"github.com/fusor/ansible-service-broker/pkg/dao"
-	"github.com/fusor/ansible-service-broker/pkg/handler"
+	"github.com/openshift/ansible-service-broker/pkg/apb"
+	"github.com/openshift/ansible-service-broker/pkg/broker"
+	"github.com/openshift/ansible-service-broker/pkg/dao"
+	"github.com/openshift/ansible-service-broker/pkg/handler"
 )
 
 const MsgBufferSize = 20

--- a/pkg/app/config.go
+++ b/pkg/app/config.go
@@ -6,8 +6,8 @@ import (
 
 	yaml "gopkg.in/yaml.v2"
 
-	"github.com/fusor/ansible-service-broker/pkg/apb"
-	"github.com/fusor/ansible-service-broker/pkg/dao"
+	"github.com/openshift/ansible-service-broker/pkg/apb"
+	"github.com/openshift/ansible-service-broker/pkg/dao"
 )
 
 type Config struct {

--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -6,8 +6,8 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/fusor/ansible-service-broker/pkg/apb"
-	"github.com/fusor/ansible-service-broker/pkg/dao"
+	"github.com/openshift/ansible-service-broker/pkg/apb"
+	"github.com/openshift/ansible-service-broker/pkg/dao"
 	logging "github.com/op/go-logging"
 	"github.com/pborman/uuid"
 )

--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -6,9 +6,9 @@ import (
 	"reflect"
 	"strings"
 
+	logging "github.com/op/go-logging"
 	"github.com/openshift/ansible-service-broker/pkg/apb"
 	"github.com/openshift/ansible-service-broker/pkg/dao"
-	logging "github.com/op/go-logging"
 	"github.com/pborman/uuid"
 )
 

--- a/pkg/broker/broker_test.go
+++ b/pkg/broker/broker_test.go
@@ -3,8 +3,8 @@ package broker
 import (
 	"testing"
 
-	"github.com/fusor/ansible-service-broker/pkg/apb"
-	ft "github.com/fusor/ansible-service-broker/pkg/fusortest"
+	"github.com/openshift/ansible-service-broker/pkg/apb"
+	ft "github.com/openshift/ansible-service-broker/pkg/fusortest"
 	"github.com/pborman/uuid"
 )
 

--- a/pkg/broker/provision_job.go
+++ b/pkg/broker/provision_job.go
@@ -3,7 +3,7 @@ package broker
 import (
 	"encoding/json"
 
-	"github.com/fusor/ansible-service-broker/pkg/apb"
+	"github.com/openshift/ansible-service-broker/pkg/apb"
 	logging "github.com/op/go-logging"
 	"github.com/pborman/uuid"
 )

--- a/pkg/broker/provision_job.go
+++ b/pkg/broker/provision_job.go
@@ -3,8 +3,8 @@ package broker
 import (
 	"encoding/json"
 
-	"github.com/openshift/ansible-service-broker/pkg/apb"
 	logging "github.com/op/go-logging"
+	"github.com/openshift/ansible-service-broker/pkg/apb"
 	"github.com/pborman/uuid"
 )
 

--- a/pkg/broker/provision_subscriber.go
+++ b/pkg/broker/provision_subscriber.go
@@ -3,9 +3,9 @@ package broker
 import (
 	"encoding/json"
 
+	logging "github.com/op/go-logging"
 	"github.com/openshift/ansible-service-broker/pkg/apb"
 	"github.com/openshift/ansible-service-broker/pkg/dao"
-	logging "github.com/op/go-logging"
 )
 
 type ProvisionWorkSubscriber struct {

--- a/pkg/broker/provision_subscriber.go
+++ b/pkg/broker/provision_subscriber.go
@@ -3,8 +3,8 @@ package broker
 import (
 	"encoding/json"
 
-	"github.com/fusor/ansible-service-broker/pkg/apb"
-	"github.com/fusor/ansible-service-broker/pkg/dao"
+	"github.com/openshift/ansible-service-broker/pkg/apb"
+	"github.com/openshift/ansible-service-broker/pkg/dao"
 	logging "github.com/op/go-logging"
 )
 

--- a/pkg/broker/types.go
+++ b/pkg/broker/types.go
@@ -1,7 +1,7 @@
 package broker
 
 import (
-	"github.com/fusor/ansible-service-broker/pkg/apb"
+	"github.com/openshift/ansible-service-broker/pkg/apb"
 	"github.com/pborman/uuid"
 )
 

--- a/pkg/broker/util.go
+++ b/pkg/broker/util.go
@@ -6,7 +6,7 @@ import (
 	"os/exec"
 	"path"
 
-	"github.com/fusor/ansible-service-broker/pkg/apb"
+	"github.com/openshift/ansible-service-broker/pkg/apb"
 	"github.com/pborman/uuid"
 )
 

--- a/pkg/broker/util.go
+++ b/pkg/broker/util.go
@@ -26,7 +26,7 @@ func RunCommand(bin string, args ...string) {
 
 func ProjectRoot() string {
 	gopath := os.Getenv("GOPATH")
-	rootPath := path.Join(gopath, "src", "github.com", "fusor",
+	rootPath := path.Join(gopath, "src", "github.com", "openshift",
 		"ansible-service-broker")
 	return rootPath
 }

--- a/pkg/broker/util_test.go
+++ b/pkg/broker/util_test.go
@@ -5,8 +5,8 @@ import (
 	"path"
 	"testing"
 
-	"github.com/fusor/ansible-service-broker/pkg/apb"
-	ft "github.com/fusor/ansible-service-broker/pkg/fusortest"
+	"github.com/openshift/ansible-service-broker/pkg/apb"
+	ft "github.com/openshift/ansible-service-broker/pkg/fusortest"
 	"github.com/pborman/uuid"
 )
 
@@ -47,7 +47,7 @@ func TestSpecToService(t *testing.T) {
 
 func TestProjectRoot(t *testing.T) {
 	gopath := os.Getenv("GOPATH")
-	rootpath := path.Join(gopath, "src/github.com/fusor/ansible-service-broker")
+	rootpath := path.Join(gopath, "src/github.com/openshift/ansible-service-broker")
 	ft.AssertEqual(t, ProjectRoot(), rootpath, "paths not equal")
 }
 

--- a/pkg/dao/dao.go
+++ b/pkg/dao/dao.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/coreos/etcd/client"
 	"github.com/coreos/etcd/version"
-	"github.com/fusor/ansible-service-broker/pkg/apb"
+	"github.com/openshift/ansible-service-broker/pkg/apb"
 	logging "github.com/op/go-logging"
 )
 

--- a/pkg/dao/dao.go
+++ b/pkg/dao/dao.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/coreos/etcd/client"
 	"github.com/coreos/etcd/version"
-	"github.com/openshift/ansible-service-broker/pkg/apb"
 	logging "github.com/op/go-logging"
+	"github.com/openshift/ansible-service-broker/pkg/apb"
 )
 
 // Config - confg holds etcd host and port.

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -6,10 +6,10 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/openshift/ansible-service-broker/pkg/broker"
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
 	logging "github.com/op/go-logging"
+	"github.com/openshift/ansible-service-broker/pkg/broker"
 	"github.com/pborman/uuid"
 	"k8s.io/apimachinery/pkg/api/errors"
 )

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/fusor/ansible-service-broker/pkg/broker"
+	"github.com/openshift/ansible-service-broker/pkg/broker"
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
 	logging "github.com/op/go-logging"

--- a/pkg/handler/handler_test.go
+++ b/pkg/handler/handler_test.go
@@ -8,10 +8,10 @@ import (
 	"os"
 	"testing"
 
-	"github.com/openshift/ansible-service-broker/pkg/broker"
-	ft "github.com/openshift/ansible-service-broker/pkg/fusortest"
 	"github.com/gorilla/mux"
 	logging "github.com/op/go-logging"
+	"github.com/openshift/ansible-service-broker/pkg/broker"
+	ft "github.com/openshift/ansible-service-broker/pkg/fusortest"
 	"github.com/pborman/uuid"
 )
 

--- a/pkg/handler/handler_test.go
+++ b/pkg/handler/handler_test.go
@@ -8,8 +8,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/fusor/ansible-service-broker/pkg/broker"
-	ft "github.com/fusor/ansible-service-broker/pkg/fusortest"
+	"github.com/openshift/ansible-service-broker/pkg/broker"
+	ft "github.com/openshift/ansible-service-broker/pkg/fusortest"
 	"github.com/gorilla/mux"
 	logging "github.com/op/go-logging"
 	"github.com/pborman/uuid"

--- a/pkg/handler/io.go
+++ b/pkg/handler/io.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/fusor/ansible-service-broker/pkg/broker"
+	"github.com/openshift/ansible-service-broker/pkg/broker"
 )
 
 func readRequest(r *http.Request, obj interface{}) error {

--- a/pkg/handler/io_test.go
+++ b/pkg/handler/io_test.go
@@ -6,8 +6,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/fusor/ansible-service-broker/pkg/broker"
-	ft "github.com/fusor/ansible-service-broker/pkg/fusortest"
+	"github.com/openshift/ansible-service-broker/pkg/broker"
+	ft "github.com/openshift/ansible-service-broker/pkg/fusortest"
 )
 
 // test object to marshall in the request

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -8,7 +8,7 @@
 action=$1
 
 export GLIDE_TARBALL="https://github.com/Masterminds/glide/releases/download/v0.12.3/glide-v0.12.3-linux-amd64.tar.gz"
-export PROJECT_ROOT=$GOPATH/src/github.com/fusor/ansible-service-broker
+export PROJECT_ROOT=$GOPATH/src/github.com/openshift/ansible-service-broker
 
 if [[ "$action" == "install" ]]; then
   # dash? wtf is dash? UGH! use a real shell


### PR DESCRIPTION
rename the packages and code references to openshift. fusortest will remain fusortest. there are some other references to fusor in apb names, etc which I left alone.