### PR TITLE
Fix build deploy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,9 +25,13 @@ prepare-build: install
 
 build: prepare-build
 	docker build ${BUILD_DIR} -t ${BROKER_APB_IMAGE}:${TAG}
+	@echo
+	@echo "Remember you need to push your image before calling make deploy"
+	@echo "    docker push ${BROKER_APB_IMAGE}:${TAG}"
 
 clean:
 	@rm -f ${GOPATH}/bin/broker
+	@rm -f build/broker
 
 vendor:
 	@glide install -v
@@ -35,13 +39,13 @@ vendor:
 test: vendor
 	go test ./pkg/...
 
-asb-image:
-	ansible-container build
-	ansible-container push --username $(DOCKERHUB_USER) --password $(DOCKERHUB_PASS) --push-to $(REGISTRY)/$(PROJECT) --tag $(TAG)
-	ansible-container shipit openshift --pull-from $(REGISTRY)/$(PROJECT) --tag $(TAG)
-	# fix bug in ansible-container
-	sed -i 's/-TCP//g' ./ansible/roles/ansible-service-broker-openshift/tasks/main.yml
-	docker build -t $(BROKER_APB_IMAGE) .
-	docker push $(BROKER_APB_IMAGE)
+#asb-image:
+#	ansible-container build
+#	ansible-container push --username $(DOCKERHUB_USER) --password $(DOCKERHUB_PASS) --push-to $(REGISTRY)/$(PROJECT) --tag $(TAG)
+#	ansible-container shipit openshift --pull-from $(REGISTRY)/$(PROJECT) --tag $(TAG)
+#	# fix bug in ansible-container
+#	sed -i 's/-TCP//g' ./ansible/roles/ansible-service-broker-openshift/tasks/main.yml
+#	docker build -t $(BROKER_APB_IMAGE) .
+#	docker push $(BROKER_APB_IMAGE)
 
 .PHONY: run run-mock-registry clean test build asb-image install prepare-build

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 REGISTRY         ?= docker.io
 PROJECT          ?= ansibleplaybookbundle
 TAG              ?= latest
-BROKER_APB_IMAGE = $(REGISTRY)/$(PROJECT)/ansible-service-broker-apb
+BROKER_IMAGE     = $(REGISTRY)/$(PROJECT)/ansible-service-broker
 BUILD_DIR        = "${GOPATH}/src/github.com/openshift/ansible-service-broker/build"
 
 install: $(shell find cmd pkg)
@@ -24,10 +24,10 @@ prepare-build: install
 	cp "${GOPATH}"/bin/broker build/broker
 
 build: prepare-build
-	docker build ${BUILD_DIR} -t ${BROKER_APB_IMAGE}:${TAG}
+	docker build ${BUILD_DIR} -t ${BROKER_IMAGE}:${TAG}
 	@echo
 	@echo "Remember you need to push your image before calling make deploy"
-	@echo "    docker push ${BROKER_APB_IMAGE}:${TAG}"
+	@echo "    docker push ${BROKER_IMAGE}:${TAG}"
 
 clean:
 	@rm -f ${GOPATH}/bin/broker

--- a/Makefile
+++ b/Makefile
@@ -39,13 +39,4 @@ vendor:
 test: vendor
 	go test ./pkg/...
 
-#asb-image:
-#	ansible-container build
-#	ansible-container push --username $(DOCKERHUB_USER) --password $(DOCKERHUB_PASS) --push-to $(REGISTRY)/$(PROJECT) --tag $(TAG)
-#	ansible-container shipit openshift --pull-from $(REGISTRY)/$(PROJECT) --tag $(TAG)
-#	# fix bug in ansible-container
-#	sed -i 's/-TCP//g' ./ansible/roles/ansible-service-broker-openshift/tasks/main.yml
-#	docker build -t $(BROKER_APB_IMAGE) .
-#	docker push $(BROKER_APB_IMAGE)
-
 .PHONY: run run-mock-registry clean test build asb-image install prepare-build

--- a/ansible-service-broker-all.yaml
+++ b/ansible-service-broker-all.yaml
@@ -120,7 +120,7 @@ spec:
     spec:
       restartPolicy: Always
       containers:
-        - image: "ansibleplaybookbundle/ansible-service-broker-asb:latest"
+        - image: "ansibleplaybookbundle/ansible-service-broker:latest"
           name: asb
           imagePullPolicy: Always
           ports:

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,7 +1,9 @@
 FROM centos:7
 MAINTAINER Ansible Service Broker Community
 
-RUN useradd -M -s /usr/sbin/nologin -u 1001 -g 0 ansibleapp
+RUN mkdir /opt/ansibleapp
+RUN useradd -M -b /opt/ansibleapp -s /usr/sbin/nologin -u 1001 -g 0 ansibleapp
+RUN chown -R 1001:0 /opt/ansibleapp
 
 RUN yum -y update \
  && yum -y install epel-release centos-release-openshift-origin \

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -3,6 +3,12 @@ MAINTAINER Ansible Service Broker Community
 
 RUN useradd -M -s /usr/sbin/nologin -u 1001 -g 0 ansibleapp
 
+RUN yum -y update \
+ && yum -y install epel-release centos-release-openshift-origin \
+ && yum -y install origin origin-clients net-tools bind-utils ansible jq \
+ && yum clean all
+
+
 RUN mkdir /var/log/ansible-service-broker \
     && touch /var/log/ansible-service-broker/asb.log \
     && mkdir /etc/ansible-service-broker \

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -7,7 +7,7 @@ RUN chown -R 1001:0 /opt/ansibleapp
 
 RUN yum -y update \
  && yum -y install epel-release centos-release-openshift-origin \
- && yum -y install origin origin-clients net-tools bind-utils ansible jq \
+ && yum -y install origin origin-clients net-tools bind-utils ansible \
  && yum clean all
 
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,9 +1,9 @@
 FROM centos:7
 MAINTAINER Ansible Service Broker Community
 
-RUN mkdir /opt/ansibleapp
-RUN useradd -M -b /opt/ansibleapp -s /usr/sbin/nologin -u 1001 -g 0 ansibleapp
-RUN chown -R 1001:0 /opt/ansibleapp
+RUN mkdir /opt/ansibleservicebroker
+RUN useradd -M -b /opt/ansibleservicebroker -s /usr/sbin/nologin -u 1001 -g 0 ansibleservicebroker
+RUN chown -R 1001:0 /opt/ansibleservicebroker
 
 RUN yum -y update \
  && yum -y install epel-release centos-release-openshift-origin \
@@ -16,13 +16,13 @@ RUN mkdir /var/log/ansible-service-broker \
     && mkdir /etc/ansible-service-broker \
     && mkdir -p /usr/local/ansible-service-broker/bin
 
-RUN chown -R ansibleapp: /var/log/ansible-service-broker \
-    && chown -R ansibleapp: /etc/ansible-service-broker
+RUN chown -R ansibleservicebroker: /var/log/ansible-service-broker \
+    && chown -R ansibleservicebroker: /etc/ansible-service-broker
 
 COPY config.yaml /etc/ansible-service-broker/config.yaml
 COPY entrypoint.sh ansible-service-broker /usr/bin/
 COPY broker /usr/bin/asbd
 
-USER ansibleapp
+USER ansibleservicebroker
 
 ENTRYPOINT ["entrypoint.sh"]

--- a/templates/broker-deployment_template.yaml
+++ b/templates/broker-deployment_template.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       restartPolicy: Always
       containers:
-        - image: "ansibleplaybookbundle/ansible-service-broker-asb:latest"
+        - image: "{{dockerhub_org}}/ansible-service-broker-asb:latest"
           name: asb
           imagePullPolicy: Always
           ports:

--- a/templates/broker-deployment_template.yaml
+++ b/templates/broker-deployment_template.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       restartPolicy: Always
       containers:
-        - image: "{{dockerhub_org}}/ansible-service-broker-asb:latest"
+        - image: "{{dockerhub_org}}/ansible-service-broker:latest"
           name: asb
           imagePullPolicy: Always
           ports:


### PR DESCRIPTION
This change allows the following workflow to work:

```
make clean # remove broker from build now
make build PROJECT=YOUR_DOCKER_HUB_ORG
docker push docker.io/YOUR_DOCKER_HUB_ORG/ansible-service-broker-apb:latest
make deploy # deploys to local oc cluster
```
This workflow uses the settings found in `etc/dev.config.yaml`. 