### PR TITLE
Remove jq since PR#121 merged

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Our dependencies currently require development headers for btrfs and dev-mapper.
 
 CentOS/RHEL/Fedora (sub dnf for Fedora):
 
-`sudo yum install device-mapper-devel btrfs-progs-devel jq etcd`
+`sudo yum install device-mapper-devel btrfs-progs-devel etcd`
 
 ## Setup
 


### PR DESCRIPTION
PR #121  removed the get_images_from_org scripts which used
jq.