### PR TITLE
create persistent volume claim for etcd data

### DIFF
--- a/ansible-service-broker-all.yaml
+++ b/ansible-service-broker-all.yaml
@@ -62,6 +62,19 @@ spec:
   port:
     targetPort: port-1338
 
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: etcd
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -98,7 +111,13 @@ spec:
           env:
           - name: ETCDCTL_API
             value: "3"
-
+          volumeMounts:
+            - mountPath: /data
+              name: etcd
+      volumes:
+        - name: etcd
+          persistentVolumeClaim:
+            claimName: etcd
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment

--- a/templates/etcd-deployment.yaml
+++ b/templates/etcd-deployment.yaml
@@ -1,3 +1,16 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: etcd
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -33,3 +46,11 @@ spec:
           env:
           - name: ETCDCTL_API
             value: "3"
+          volumeMounts:
+            - mountPath: /data
+              name: etcd
+      volumes:
+        - name: etcd
+          persistentVolumeClaim:
+            claimName: etcd
+


### PR DESCRIPTION
Verified that data persists after destroying the pod and allowing the deployment to recreate it.