### PR TITLE
Add Endpoint for ABP Tool to push Specs

### DIFF
--- a/etc/ex.dev.config.yaml
+++ b/etc/ex.dev.config.yaml
@@ -17,3 +17,4 @@ openshift:
   target: localhost:8443
   user: OPENSHIFT_USER
   pass: OPENSHIFT_PASS
+devbroker: true

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -135,7 +135,7 @@ func (a *App) Start() {
 	a.log.Notice("Ansible Service Broker Started")
 	listeningAddress := "0.0.0.0:1338"
 	a.log.Notice("Listening on http://%s", listeningAddress)
-	err := http.ListenAndServe(":1338", handler.NewHandler(a.broker, a.log.Logger))
+	err := http.ListenAndServe(":1338", handler.NewHandler(a.broker, a.log.Logger, a.config.DevBroker))
 	if err != nil {
 		a.log.Error("Failed to start HTTP server")
 		a.log.Error(err.Error())

--- a/pkg/app/config.go
+++ b/pkg/app/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	Log        LogConfig
 	Openshift  apb.ClusterConfig
 	ConfigFile string
+	DevBroker  bool
 }
 
 func CreateConfig(configFile string) (Config, error) {

--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -435,3 +435,12 @@ func (a AnsibleBroker) LastOperation(instanceUUID uuid.UUID, req *LastOperationR
 	state := StateToLastOperation(jobstate.State)
 	return &LastOperationResponse{State: state, Description: ""}, err
 }
+
+//AddSpec - adding the spec to the catalog for local developement
+func (a AnsibleBroker) AddSpec(spec apb.Spec) (*CatalogResponse, error) {
+	if err := a.dao.SetSpec(spec.Id, &spec); err != nil {
+		return nil, err
+	}
+	service := SpecToService(&spec)
+	return &CatalogResponse{Services: []Service{service}}, nil
+}

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -278,7 +278,7 @@ func (h handler) apbAddSpec(w http.ResponseWriter, r *http.Request, params map[s
 	// create helper method from MockRegistry
 	ansibleBroker, ok := h.broker.(*broker.AnsibleBroker)
 	if !ok {
-		h.log.Errorf("unable to use broker - %T as ansbile service broker", h.broker)
+		h.log.Errorf("unable to use broker - %T as ansible service broker", h.broker)
 		writeResponse(w, http.StatusInternalServerError, broker.ErrorResponse{Description: "Internal server error"})
 		return
 	}


### PR DESCRIPTION
Adding ability for local APB developers to push their own specs to the Broker to be included in the catalog

Added config value ```devbroker: true``` to turn this on. If that value does not exist in the config it will keep this endpoint off. 

This is needed for https://github.com/fusor/ansible-playbook-bundle/pull/47