### PR TITLE
Added an OpenShift template for deploying broker & etcd

### DIFF
--- a/templates/deploy-ansible-service-broker.template.yaml
+++ b/templates/deploy-ansible-service-broker.template.yaml
@@ -1,0 +1,177 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: ansible-service-broker
+objects:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: asb
+    labels:
+      app: ansible-service-broker
+      service: asb
+  spec:
+    ports:
+      - name: port-1338
+        port: 1338
+        targetPort: 1338
+        protocol: TCP
+    selector:
+      app: ansible-service-broker
+      service: asb
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: etcd
+    labels:
+      app: ansible-service-broker
+      service: etcd
+  spec:
+    ports:
+      - name: etcd-advertise
+        port: 2379
+    selector:
+      app: ansible-service-broker
+      service: etcd
+- apiVersion: v1
+  kind: Route
+  metadata:
+    name: asb-1338
+    labels:
+      app: ansible-service-broker
+      service: asb
+  spec:
+    to:
+      kind: Service
+      name: asb
+    port:
+      targetPort: port-1338
+- apiVersion: extensions/v1beta1
+  kind: Deployment
+  metadata:
+    name: asb
+    labels:
+      app: ansible-service-broker
+      service: asb
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: ansible-service-broker
+    strategy:
+      rollingUpdate:
+        maxSurge: 1
+        maxUnavailable: 1
+      type: RollingUpdate
+    template:
+      metadata:
+        labels:
+          app: ansible-service-broker
+          service: asb
+      spec:
+        containers:
+        - image: ${BROKER_IMAGE}
+          name: asb
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 1338
+              protocol: TCP
+          args:
+            - -c
+            - ${BROKER_CONFIG}
+          env:
+          - name: DOCKERHUB_PASS
+            value: ${DOCKERHUB_PASS}
+          - name: DOCKERHUB_USER
+            value: ${DOCKERHUB_USER}
+          - name: DOCKERHUB_ORG
+            value: ${DOCKERHUB_ORG}
+          - name: OPENSHIFT_PASS
+            value: ${OPENSHIFT_PASS}
+          - name: OPENSHIFT_TARGET
+            value: ${OPENSHIFT_TARGET}
+          - name: OPENSHIFT_USER
+            value: ${OPENSHIFT_USER}
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+- apiVersion: extensions/v1beta1
+  kind: Deployment
+  metadata:
+    name: etcd
+    labels:
+      app: ansible-service-broker
+      service: etcd
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: ansible-service-broker
+        service: etcd
+    strategy:
+      rollingUpdate:
+        maxSurge: 1
+        maxUnavailable: 1
+      type: RollingUpdate
+    template:
+      metadata:
+        labels:
+          app: ansible-service-broker
+          service: etcd
+      spec:
+        containers:
+        - image: ansibleapp/ansible-service-broker-etcd:latest
+          name: etcd
+          imagePullPolicy: IfNotPresent
+          workingDir: /etcd
+          args:
+            - ./etcd
+            - --data-dir=/data
+            - --listen-client-urls=http://0.0.0.0:2379
+            - --advertise-client-urls=http://0.0.0.0:2379
+          ports:
+          - containerPort: 2379
+            protocol: TCP
+          env:
+          - name: ETCDCTL_API
+            value: "3"
+
+parameters:
+- description: Container Image to use for Ansible Service Broker in format of imagename:tag
+  displayname: Ansible Service Broker Image
+  name: BROKER_IMAGE
+  value: ansible-service-broker:latest
+
+- description: Configuration filepath for Ansible Service Broker
+  displayname: Ansible Service Broker Configuration File
+  name: BROKER_CONFIG
+  value: /etc/ansible-service-broker/config.yaml
+
+- description: Dockerhub user password
+  displayname: Dockerhub user password
+  name: DOCKERHUB_PASS
+  value: changeme
+
+- description: Dockerhub user name
+  displayname: Dockerhub user name
+  name: DOCKERHUB_USER
+  value: changeme
+
+- description: Dockerhub organization
+  displayname: Dockerhub organization
+  name: DOCKERHUB_ORG
+  value: ansibleplaybookbundle
+
+- description: OpenShift User Password
+  displayname: OpenShift User Password
+  name: OPENSHIFT_PASS
+  value: admin
+
+- description: OpenShift User Name
+  displayname: OpenShift User Name
+  name: OPENSHIFT_USER
+  value: admin
+
+- description: OpenShift Target URL
+  displayname: OpenShift Target URL
+  name: OPENSHIFT_TARGET
+  value: kubernetes.default

--- a/templates/run_template.sh
+++ b/templates/run_template.sh
@@ -1,0 +1,24 @@
+PROJECT="ansible-service-broker"
+BROKER_IMAGE="ansibleplaybookbundle/ansible-service-broker:latest"
+OPENSHIFT_TARGET="https://kubernetes.default"
+OPENSHIFT_USER="admin"
+OPENSHIFT_PASS="admin"
+DOCKERHUB_USER="CHANGEME"
+DOCKERHUB_PASS="CHANGEME"
+DOCKERHUB_ORG="ansibleplaybookbundle"
+
+
+VARS="-p BROKER_IMAGE=${BROKER_IMAGE} -p OPENSHIFT_TARGET=${OPENSHIFT_TARGET} -p OPENSHIFT_PASS=${OPENSHIFT_PASS} -p OPENSHIFT_USER=${OPENSHIFT_USER} -p DOCKERHUB_ORG=${DOCKERHUB_ORG} -p DOCKERHUB_PASS=${DOCKERHUB_PASS} -p DOCKERHUB_USER=${DOCKERHUB_USER}"
+
+oc delete project ${PROJECT}
+oc projects | grep ${PROJECT}
+while [ $? -eq 0 ]
+do
+  echo "Waiting for ${PROJECT} to be deleted"
+  sleep 5;
+  oc projects | grep ${PROJECT}
+done
+
+
+oc new-project ${PROJECT}
+oc process -f deploy-ansible-service-broker.template.yaml -n ${PROJECT} ${VARS}  | oc create -f -


### PR DESCRIPTION

This adds an OpenShift template which shows how to parameterize options.

The run_template.sh is an example of how to deploy the template with parameters.

Currently this is for information purposes.

Next step will be to update catasb to begin using this file opposed to the "all in one" yaml we have in the project root.

