### PR TITLE
Sandboxed APB Implementation

### DIFF
--- a/build/config.yaml
+++ b/build/config.yaml
@@ -17,3 +17,6 @@ openshift:
   target: {{OPENSHIFT_TARGET}}
   user: {{OPENSHIFT_USER}}
   pass: {{OPENSHIFT_PASS}}
+broker:
+  devbroker: false
+  launchapbonbind: false

--- a/etc/ex.dockerimg.config.yaml
+++ b/etc/ex.dockerimg.config.yaml
@@ -17,3 +17,6 @@ openshift:
   target: {{OPENSHIFT_TARGET}}
   user: {{OPENSHIFT_USER}}
   pass: {{OPENSHIFT_PASS}}
+broker:
+  devbroker: true
+  launchapbonbind: false

--- a/etc/ex.mock.config.yaml
+++ b/etc/ex.mock.config.yaml
@@ -17,3 +17,6 @@ openshift:
   target: {{OPENSHIFT_TARGET}}
   user: {{OPENSHIFT_USER}}
   pass: {{OPENSHIFT_PASS}}
+broker:
+  devbroker: true
+  launchapbonbind: false

--- a/etc/ex.prod.config.yaml
+++ b/etc/ex.prod.config.yaml
@@ -17,3 +17,6 @@ openshift:
   target: ocp.prod.example.com:8443
   user: OPENSHIFT_USER
   pass: OPENSHIFT_PASS
+broker:
+  devbroker: false
+  launchapbonbind: false

--- a/pkg/apb/client.go
+++ b/pkg/apb/client.go
@@ -8,11 +8,13 @@ import (
 
 	docker "github.com/fsouza/go-dockerclient"
 	logging "github.com/op/go-logging"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	restclient "k8s.io/client-go/rest"
 
 	"github.com/pborman/uuid"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/homedir"
+	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
 )
 
@@ -113,44 +115,15 @@ func (c *Client) RunImage(
 	spec *Spec,
 	context *Context,
 	p *Parameters,
-) ([]byte, error) {
+) (string, error) {
 	// HACK: We're expecting to run containers via go APIs rather than cli cmds
 	// TODO: Expecting parameters to be passed here in the future as well
 
 	extraVars, err := createExtraVars(context, p)
+
 	if err != nil {
-		return nil, err
+		return "", err
 	}
-
-	////////////////////////////////////////////////////////////////////////////////
-	// This needs a lot of cleanup. Broker was originally written to run
-	// inside a machine that also had a running dockerd available on /var/run/docker.sock
-	// If the broker is running inside of a container on ocp or k8s, this docker runtime
-	// is not available to the broker's environment in the same way. This requires
-	// the broker to run the apb metacontainer remotely...somehow.
-	// * options for docker are ugly:
-	// -> Nested docker? (bad)
-	// -> Remote docker (not a ton of options?) TCP socket?
-	// * We know we've got an available ocp cluster _somewhere_. Use oc run instead of
-	// docker? Requires an auth'd oc client available to the broker, but that can
-	// be baked into the broker's container runtime. This is done as a temporary soln.
-	//
-	// TODO: Need to figure out the right way to accomplish running metacontainers
-	// in remote runtimes longterm.
-	////////////////////////////////////////////////////////////////////////////////
-	//oc run ansible-service-broker-apb --env "OPENSHIFT_TARGET=10.1.2.2:8443"
-	//--env "OPENSHIFT_USER=admin" --env "OPENSHIFT_PASS=derp"
-	//--image=apb/ansible-service-broker-ansibleapp --restart=Never --
-	//provision -e "dockerhub_user=eriknelson" -e "dockerhub_pass=derp"
-	//-e "openshift_target=10.1.2.2:8443" -e "openshift_user=admin" -e "openshift_pass=derp"
-
-	// NOTE: Older approach when docker is easily available to the broker to run
-	// metacontainers, i.e., just running on
-	//return RunCommand("docker", "run",
-	//"-e", fmt.Sprintf("OPENSHIFT_TARGET=%s", clusterConfig.Target),
-	//"-e", fmt.Sprintf("OPENSHIFT_USER=%s", clusterConfig.User),
-	//"-e", fmt.Sprintf("OPENSHIFT_PASS=%s", clusterConfig.Password),
-	//spec.Name, action, "--extra-vars", string(params))
 
 	if !clusterConfig.InCluster {
 		err = c.refreshLoginToken(clusterConfig)
@@ -158,12 +131,11 @@ func (c *Client) RunImage(
 		if err != nil {
 			c.log.Error("Error occurred while refreshing login token! Aborting apb run.")
 			c.log.Error(err.Error())
-			return nil, err
+			return "", err
 		}
 		c.log.Notice("Login token successfully refreshed.")
 	}
 
-	c.log.Debug("Running OC run...")
 	c.log.Debug("clusterConfig:")
 	if !clusterConfig.InCluster {
 		c.log.Debug("target: [ %s ]", clusterConfig.Target)
@@ -175,20 +147,89 @@ func (c *Client) RunImage(
 	c.log.Debug("action:[ %s ]", action)
 	c.log.Debug("extra-vars:[ %s ]", extraVars)
 
-	if clusterConfig.InCluster {
-		return RunCommand("oc", "run", fmt.Sprintf("aa-%s", uuid.New()),
-			fmt.Sprintf("--image-pull-policy=Always"),
-			fmt.Sprintf("--image=%s", spec.Image), "--restart=Never",
-			"--", action, "--extra-vars", extraVars)
-	} else {
-		return RunCommand("oc", "run", fmt.Sprintf("aa-%s", uuid.New()),
-			"--env", fmt.Sprintf("OPENSHIFT_TARGET=%s", clusterConfig.Target),
-			"--env", fmt.Sprintf("OPENSHIFT_USER=%s", clusterConfig.User),
-			"--env", fmt.Sprintf("OPENSHIFT_PASS=%s", clusterConfig.Password),
-			fmt.Sprintf("--image-pull-policy=Always"),
-			fmt.Sprintf("--image=%s", spec.Image), "--restart=Never",
-			"--", action, "--extra-vars", extraVars)
+	// TODO(rhallisey): Cleanup the local vs incluster code paths so there
+	// is almost no variation between the two.
+	//
+	// If we're using a locally running broker we want to use the default
+	// namespace.
+	ns := context.Namespace
+	apbId := fmt.Sprintf("apb-%s", uuid.New())
+
+	sam := NewServiceAccountManager(c.log)
+	serviceAccountName, err := sam.CreateApbSandbox(ns, apbId)
+
+	if err != nil {
+		c.log.Error(err.Error())
+		return apbId, err
 	}
+
+	//TODO(rhallisey): The Kubernetes API objects should be in JSON structs
+	// so it's easier to manipulate them. This is for a rebase so we don't
+	// block the service account work.  I'll come back after and clean this
+	// up.
+	var pod *v1.Pod
+	if clusterConfig.InCluster {
+		pod = &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: apbId,
+			},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Name:  "apb",
+						Image: spec.Image,
+						Args: []string{
+							action,
+							"--extra-vars",
+							extraVars,
+						},
+						ImagePullPolicy: v1.PullAlways,
+					},
+				},
+				RestartPolicy:      v1.RestartPolicyNever,
+				ServiceAccountName: serviceAccountName,
+			},
+		}
+	} else {
+		// Set the namespace to default for the local broker.
+		ns = "default"
+
+		pod = &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: fmt.Sprintf("apb-%s", uuid.New()),
+			},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Name:  "apb",
+						Image: spec.Image,
+						Args: []string{
+							action,
+							"--extra-vars",
+							extraVars,
+						},
+						Env: []v1.EnvVar{{
+							Name:  "OPENSHIFT_TARGET",
+							Value: clusterConfig.Target,
+						}, {
+							Name:  "OPENSHIFT_USER",
+							Value: clusterConfig.User,
+						}, {
+							Name:  "OPENSHIFT_PASS",
+							Value: clusterConfig.Password,
+						}},
+						ImagePullPolicy: v1.PullAlways,
+					},
+				},
+				RestartPolicy: v1.RestartPolicyNever,
+			},
+		}
+	}
+
+	c.log.Notice(fmt.Sprintf("Creating pod %q in the %s namespace", pod.Name, ns))
+	_, err = c.ClusterClient.CoreV1().Pods(ns).Create(pod)
+
+	return apbId, err
 }
 
 func (c *Client) PullImage(imageName string) error {

--- a/pkg/apb/deprovision.go
+++ b/pkg/apb/deprovision.go
@@ -6,7 +6,7 @@ import (
 	"github.com/op/go-logging"
 )
 
-func Deprovision(instance *ServiceInstance, log *logging.Logger) error {
+func Deprovision(instance *ServiceInstance, log *logging.Logger) (string, error) {
 	specJSON, _ := DumpJSON(instance)
 
 	log.Notice("============================================================")
@@ -21,22 +21,22 @@ func Deprovision(instance *ServiceInstance, log *logging.Logger) error {
 	var err error
 
 	if client, err = NewClient(log); err != nil {
-		return err
+		return "", err
 	}
 
 	if err = client.PullImage(instance.Spec.Name); err != nil {
-		return err
+		return "", err
 	}
 
 	// Might need to change up this interface to feed in instance ids
-	output, err := client.RunImage(
+	podName, err := client.RunImage(
 		"deprovision", HardcodedClusterConfig, instance.Spec, instance.Context, instance.Parameters)
 
 	if err != nil {
 		log.Error("Problem running image")
-		return err
+		return podName, err
 	}
 
-	log.Info(string(output))
-	return nil
+	log.Info(string(podName))
+	return podName, nil
 }

--- a/pkg/apb/hack.go
+++ b/pkg/apb/hack.go
@@ -1,6 +1,10 @@
 package apb
 
-import "os/exec"
+import (
+	"bytes"
+	"os/exec"
+	"syscall"
+)
 
 var HardcodedClusterConfig = ClusterConfig{
 	//Target:   "cap.example.com:8443",
@@ -13,4 +17,32 @@ var HardcodedClusterConfig = ClusterConfig{
 func RunCommand(cmd string, args ...string) ([]byte, error) {
 	output, err := exec.Command(cmd, args...).CombinedOutput()
 	return output, err
+}
+
+func RunCommandWithExitCode(name string, args ...string) (stdout string, stderr string, exitCode int) {
+	var outbuf, errbuf bytes.Buffer
+	defaultFailedCode := 1
+	cmd := exec.Command(name, args...)
+	cmd.Stdout = &outbuf
+	cmd.Stderr = &errbuf
+
+	err := cmd.Run()
+	stdout = outbuf.String()
+	stderr = errbuf.String()
+
+	if err != nil {
+		if exitError, ok := err.(*exec.ExitError); ok {
+			ws := exitError.Sys().(syscall.WaitStatus)
+			exitCode = ws.ExitStatus()
+		} else {
+			exitCode = defaultFailedCode
+			if stderr == "" {
+				stderr = err.Error()
+			}
+		}
+	} else {
+		ws := cmd.ProcessState.Sys().(syscall.WaitStatus)
+		exitCode = ws.ExitStatus()
+	}
+	return
 }

--- a/pkg/apb/svc_acct.go
+++ b/pkg/apb/svc_acct.go
@@ -1,0 +1,197 @@
+package apb
+
+import (
+	logging "github.com/op/go-logging"
+	yaml "gopkg.in/yaml.v2"
+	"os"
+	"path/filepath"
+)
+
+type ServiceAccountManager struct {
+	log *logging.Logger
+}
+
+func NewServiceAccountManager(log *logging.Logger) ServiceAccountManager {
+	return ServiceAccountManager{
+		log: log,
+	}
+}
+
+// Sets up ServiceAccount based apb sandbox
+// Returns service account name to be used as a handle for destroying
+// the sandbox at the conclusion of running the apb
+func (s *ServiceAccountManager) CreateApbSandbox(
+	namespace string,
+	apbId string,
+) (string, error) {
+	svcAccountName := apbId
+	roleBindingName := apbId
+	apbRole := "cluster-admin"
+
+	svcAcctM := map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "ServiceAccount",
+		"metadata": map[string]string{
+			"name":      apbId,
+			"namespace": namespace,
+		},
+	}
+
+	roleBindingM := map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "RoleBinding",
+		"metadata": map[string]string{
+			"name":      roleBindingName,
+			"namespace": namespace,
+		},
+		"subjects": []map[string]string{
+			map[string]string{
+				"kind":      "ServiceAccount",
+				"name":      svcAccountName,
+				"namespace": namespace,
+			},
+		},
+		"roleRef": map[string]string{
+			"name": apbRole,
+		},
+	}
+
+	s.createResourceDir()
+	rFilePath, err := s.writeResourceFile(apbId, &svcAcctM, &roleBindingM)
+	if err != nil {
+		return "", err
+	}
+
+	// Create resources in cluster
+	s.createResources(rFilePath, namespace)
+
+	s.log.Info("Successfully created apb sandbox: [ %s ]", apbId)
+
+	return apbId, nil
+}
+
+func (s *ServiceAccountManager) createResources(rFilePath string, namespace string) error {
+	s.log.Debug("Creating resources from file at path: %s", rFilePath)
+	output, err := RunCommand("oc", "create", "-f", rFilePath, "--namespace="+namespace)
+	// TODO: Parse output somehow to validate things got created?
+	if err != nil {
+		s.log.Error("Something went wrong trying to create resources in cluster")
+		s.log.Error("Returned error:")
+		s.log.Error(err.Error())
+		s.log.Error("oc create -f output:")
+		s.log.Error(string(output))
+		return err
+	}
+	s.log.Debug("Successfully created resources, oc create -f output:")
+	s.log.Debug("\n" + string(output))
+	return nil
+}
+
+func (s *ServiceAccountManager) writeResourceFile(
+	apbId string,
+	svcAcctM *map[string]interface{},
+	roleBindingM *map[string]interface{},
+) (string, error) {
+	// Create file if doesn't already exist
+	filePath := s.createFile(apbId)
+
+	file, err := os.OpenFile(filePath, os.O_RDWR, 0644)
+	defer file.Close()
+
+	if err != nil {
+		s.log.Error("Something went wrong writing resources to file!")
+		s.log.Error(err.Error())
+		return "", err
+	}
+
+	file.WriteString("---\n")
+	svcAcctY, err := yaml.Marshal(svcAcctM)
+	if err != nil {
+		s.log.Error("Something went wrong marshalling svc acct to yaml")
+		s.log.Error(err.Error())
+		return "", err
+	}
+	file.WriteString(string(svcAcctY))
+
+	file.WriteString("---\n")
+	roleBindingY, err := yaml.Marshal(roleBindingM)
+	if err != nil {
+		s.log.Error("Something went wrong marshalling role binding to yaml")
+		s.log.Error(err.Error())
+		return "", err
+	}
+	file.WriteString(string(roleBindingY))
+
+	s.log.Info("Successfully wrote resources to %s", filePath)
+	return filePath, nil
+}
+
+func (s *ServiceAccountManager) createResourceDir() {
+	dir := resourceDir()
+	s.log.Debug("Creating resource file dir: %s", dir)
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		os.Mkdir(dir, os.ModePerm)
+	}
+}
+
+func (s *ServiceAccountManager) createFile(apbId string) string {
+	rFilePath := filepath.Join(resourceDir(), apbId+".yaml")
+	s.log.Debug("Creating resource file %s", rFilePath)
+	var _, err = os.Stat(rFilePath)
+
+	if os.IsNotExist(err) {
+		var file, err = os.Create(rFilePath)
+		if err != nil {
+			s.log.Error("Something went wrong touching resource file!")
+			s.log.Error(err.Error())
+		}
+		defer file.Close()
+	}
+	return rFilePath
+}
+
+func (s *ServiceAccountManager) DestroyApbSandbox(
+	handle string,
+	namespace string,
+) error {
+	if handle == "" {
+		s.log.Info("Requested destruction of APB sandbox with empty handle, skipping.")
+		return nil
+	}
+
+	s.log.Debug("Deleting serviceaccount %s, namespace %s", handle, namespace)
+	output, err := RunCommand(
+		"oc", "delete", "serviceaccount", handle, "--namespace="+namespace,
+	)
+	if err != nil {
+		s.log.Error("Something went wrong trying to destroy the serviceaccount!")
+		s.log.Error(err.Error())
+		s.log.Error("oc delete output:")
+		s.log.Error(string(output))
+		return err
+	}
+	s.log.Debug("Successfully deleted serviceaccount %s, namespace %s", handle, namespace)
+	s.log.Debug("oc delete output:")
+	s.log.Debug(string(output))
+
+	s.log.Debug("Deleting rolebinding %s, namespace ", handle, namespace)
+	output, err = RunCommand(
+		"oc", "delete", "rolebinding", handle, "--namespace="+namespace,
+	)
+	if err != nil {
+		s.log.Error("Something went wrong trying to destroy the rolebinding!")
+		s.log.Error(err.Error())
+		s.log.Error("oc delete output:")
+		s.log.Error(string(output))
+		return err
+	}
+	s.log.Debug("Successfully deleted rolebinding %s, namespace ", handle, namespace)
+	s.log.Debug("oc delete output:")
+	s.log.Debug(string(output))
+
+	return nil
+}
+
+func resourceDir() string {
+	return filepath.FromSlash("/tmp/asb-resource-files")
+}

--- a/pkg/apb/types.go
+++ b/pkg/apb/types.go
@@ -73,6 +73,10 @@ const (
 	StateInProgress State = "in progress"
 	StateSucceeded  State = "succeeded"
 	StateFailed     State = "failed"
+
+	// NOTE: Applied to APB ServiceAccount via RoleBinding, not ClusterRoleBinding
+	// cluster-admin scoped to the project the apb is operating in
+	ApbRole = "cluster-admin"
 )
 
 func specLogDump(spec *Spec, log *logging.Logger) {


### PR DESCRIPTION
Sandboxes apb with dynamically created ServiceAccounts and RoleBindings.

I'm not very happy with the way DestroyApbSandbox works here. We need to revisit it since authors working in the broker.go should should *not* have to worry about leaking the sandboxes; they should always be cleaned up on the conclusion of the pods. I'd personally like to see this get implemented as an event handler that executes on some kind of a pod terminate trigger, but I'm unable to get that in by tomorrow. I plan on following this up with an issue to revisit post TP1.