### PR TITLE
Local Development Changes:  Simulates broker running InCluster while executing locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
 REGISTRY         ?= docker.io
 PROJECT          ?= ansibleplaybookbundle
 TAG              ?= latest
-BROKER_IMAGE     = $(REGISTRY)/$(PROJECT)/ansible-service-broker
+BROKER_IMAGE     ?= $(REGISTRY)/$(PROJECT)/ansible-service-broker
 BUILD_DIR        = "${GOPATH}/src/github.com/openshift/ansible-service-broker/build"
 PREFIX           ?= /usr/local
+BROKER_CONFIG    ?= $(PWD)/etc/generated_local_development.yaml
 
 vendor:
 	@glide install -v
@@ -17,8 +18,8 @@ install:
 	mkdir -p ${PREFIX}/etc/ansible-service-broker
 	cp etc/example-broker-config.yaml ${PREFIX}/etc/ansible-service-broker/broker-config.yaml
 
-run:
-	${PREFIX}/bin/ansible-service-broker --config ${PREFIX}/etc/ansible-service-broker/broker-config.yaml
+run: 
+	cd scripts && ./run_local.sh ${BROKER_CONFIG}
 
 uninstall:
 	rm  -f ${PREFIX}/bin/ansible-service-broker
@@ -39,6 +40,8 @@ uninstall-mock-registry:
 	rm  -f ${PREFIX}/bin/mock-registry
 	rm -rf ${PREFIX}/etc/mock-registry
 
+prepare-local-env:
+	cd scripts && ./prep_local_devel_env.sh
 
 prepare-build-image: build
 	cp broker build/broker

--- a/docs/local_development.md
+++ b/docs/local_development.md
@@ -1,0 +1,28 @@
+# Recommended Local Development and Debugging Workflow
+
+## Overview
+
+We recommend 2 modes of running the broker for development work.
+
+1. Build the broker executable and run it locally connected to a local oc cluster up from [fusor/catasb 'dev' branch](https://github.com/fusor/catasb/tree/dev)
+2. Build a local image and deploy from image
+
+## Running the broker executable locally
+
+1. Build the Ansible Service Broker executable with the command: ```make build```
+2. Ensure you have a local oc cluster up environment running with [fusor/catasb 'dev' branch](https://github.com/fusor/catasb/tree/dev)
+3. ```cp scripts/my_local_dev_vars.example scripts/my_local_dev_vars```
+4. Edit 'scripts/my_local_dev_vars' 
+5. Prepare your local development environment by running: ```make prepare-local-env```
+    * This will remove the running 'asb' pod and replace the endpoint of the asb route with the locally running broker executable.
+    * You __must__ rerun this whenever you have reset your cluster.
+    * It is safe to run this multiple times
+6. Run the broker executable locally:  ```make run```
+    * Use the cluster as you normally would for testing.
+    * When you want to make a change and rebuild the broker.  CTRL-C, rebuild and re-run
+
+## Build a local image and deploy from image
+
+1. Build the Ansible Service Broker executable with the command: ```make build ```
+3. Build a development image:  ```make build-image BROKER_IMAGE_NAME=asb-dev TAG=local```
+4. Deploy from [templates/deploy-ansible-service-broker.template.yaml](https://github.com/openshift/ansible-service-broker/blob/master/templates/deploy-ansible-service-broker.template.yaml) setting the parameter "-p BROKER_IMAGE=asb-dev:local" to your local image name/tag 

--- a/etc/.gitignore
+++ b/etc/.gitignore
@@ -1,0 +1,2 @@
+generated_local_development.yaml
+

--- a/scripts/.gitignore
+++ b/scripts/.gitignore
@@ -1,0 +1,2 @@
+my_local_dev_vars
+

--- a/scripts/my_local_dev_vars.example
+++ b/scripts/my_local_dev_vars.example
@@ -1,0 +1,20 @@
+#####
+## CHANGE THESE TO REFLECT YOUR ENVIRONMENT
+#####
+
+# Typically the below values are:
+#  For Linux, use OPENSHIFT_SERVER_HOST=172.17.0.1
+#  For macOS, use OPENSHIFT_SERVER_HOST=192.168.37.1
+OPENSHIFT_SERVER_HOST=172.17.0.1
+OPENSHIFT_SERVER_PORT=8443
+
+# BROKER_IP_ADDR must be the IP address of where to reach broker
+#   it should not be 127.0.0.1, needs to be an address the pods will be able to reach
+BROKER_IP_ADDR=${OPENSHIFT_SERVER_HOST}
+DOCKERHUB_USERNAME=""
+DOCKERHUB_PASSWORD=""
+DOCKERHUB_ORG="ansibleplaybookbundle
+
+
+BROKER_CMD="../broker"
+GENERATED_BROKER_CONFIG="../etc/generated_local_development.yaml"

--- a/scripts/prep_local_devel_env.sh
+++ b/scripts/prep_local_devel_env.sh
@@ -1,0 +1,176 @@
+#!/bin/bash
+###
+# This script is intended to allow us to run the broker locally but 
+# fake out the environment so it seems like it is running inside the cluster
+#
+# To run the broker locally we address the below isses:
+# - Service Catalog needs to talk to route and have it reach the local broker 
+#   - Update the asb service & endpoint to point to our local broker 
+# - Create a route for etcd so local broker can talk to etcd
+# - Generate a configuration file for broker to use
+# - Set KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to reach cluster 
+# - Get existing secret for the asb service account and store ca cert/token
+#
+###
+
+MY_VARS="./my_local_dev_vars"
+if [ ! -f $MY_VARS ]; then 
+  echo "Please create $MY_VARS"
+  echo "cp $MY_VARS.example $MY_VARS"
+  echo "then edit as needed"
+  exit 1
+fi 
+
+source ./my_local_dev_vars
+if [ "$?" -ne "0" ]; then
+  echo "Error reading in my_local_dev_var"
+  exit 1
+fi 
+
+
+TEMPLATE_LOCAL_DEV="../templates/deploy-local-dev-changes.yaml"
+ASB_PROJECT="ansible-service-broker"
+BROKER_SVC_ACCT_NAME="asb"
+BROKER_SVC_ACCT="system:serviceaccount:${ASB_PROJECT}:${BROKER_SVC_ACCT_NAME}"
+
+# Faking out https://github.com/kubernetes/client-go/blob/master/rest/config.go#L309
+export KUBERNETES_SERVICE_HOST=${OPENSHIFT_SERVER_HOST}
+export KUBERNETES_SERVICE_PORT=${OPENSHIFT_SERVER_PORT}
+SVC_ACCT_TOKEN_DIR=/var/run/secrets/kubernetes.io/serviceaccount
+SVC_ACCT_CA_CRT=$SVC_ACCT_TOKEN_DIR/ca.crt
+SVC_ACCT_TOKEN_FILE=$SVC_ACCT_TOKEN_DIR/token
+
+# We rely on jq for parsing json data from oc/kubectl
+which jq &> /dev/null
+if [ "$?" -ne 0 ]; then 
+  echo "Please ensure 'jq' is installed and in your path"
+  exit 1
+fi 
+
+# We will fake out the service account directory locally on the machine
+# The directory is under /var/run and likely to be deleted between reboots
+if [ ! -d "$SVC_ACCT_TOKEN_DIR" ]; then 
+  echo "Attempting to create serviceaccount directory: ${SVC_ACCT_TOKEN_DIR}"
+  sudo mkdir -p ${SVC_ACCT_TOKEN_DIR}
+  if [ "$?" -ne "0" ]; then 
+    echo "Please create serviceaccount directory with read/write permissions for your user:  ${SVC_ACCT_TOKEN_DIR}"
+    exit 1
+  fi 
+fi 
+sudo chown ${USER} ${SVC_ACCT_TOKEN_DIR}
+if [ "$?" -ne "0" ]; then 
+  echo "Please chown the serviceaccount directory so your user may read/write:  ${SVC_ACCT_TOKEN_DIR}"
+  exit 1
+fi 
+ 
+
+# Determine the name of the secret which has the 'asb' service account info
+BROKER_SVC_ACCT_SECRET_NAME=`oc get serviceaccount asb -n ansible-service-broker -o json | jq -c '.secrets[] | select(.name | contains("asb-token"))' | jq -c '.name'`
+# Remove quotes from variable
+BROKER_SVC_ACCT_SECRET_NAME=( $(eval echo ${BROKER_SVC_ACCT_SECRET_NAME[@]}) )
+echo "Broker Service Account Token is in secret: ${BROKER_SVC_ACCT_SECRET_NAME}"
+
+###
+# Fetch the service-ca.crt for the service account
+###
+SVC_ACCT_CA_CRT_DATA=`oc get secret ${BROKER_SVC_ACCT_SECRET_NAME} -n ${ASB_PROJECT} -o json | jq -c '.data["service-ca.crt"]'`
+# Remove quotes from variable
+SVC_ACCT_CA_CRT_DATA=( $(eval echo ${SVC_ACCT_CA_CRT_DATA[@]}) )
+# Base64 Decode
+SVC_ACCT_CA_CRT_DATA=`echo ${SVC_ACCT_CA_CRT_DATA} | base64 --decode `
+if [ "$?" -ne 0 ]; then 
+  echo "Unable to determine service-ca.crt for secret '${BROKER_SVC_ACCT_SECRET_NAME}'"
+  exit 1
+fi 
+echo "${SVC_ACCT_CA_CRT_DATA}" &> ${SVC_ACCT_CA_CRT}
+if [ "$?" -ne "0" ]; then 
+  echo "Unable to write the service-ca.crt data for ${BROKER_SVC_ACCT_SECRET_NAME} to: ${SVC_ACCT_CA_CRT}"
+  exit 1 
+fi 
+echo "Service Account: ca.crt"
+echo -e "Wrote \n${SVC_ACCT_CA_CRT_DATA}\n to: ${SVC_ACCT_CA_CRT}\n"
+
+###
+# Fetch the token for the service account
+###
+if [ ! -d $SVC_ACCT_TOKEN_DIR ]; then
+  echo "Please create the directory: ${SVC_ACCT_TOKEN_DIR}"
+  echo "Ensure your user can write to it."
+  exit 1
+fi
+BROKER_SVC_ACCT_TOKEN=`oc get secret ${BROKER_SVC_ACCT_SECRET_NAME} -n ${ASB_PROJECT} -o json | jq -c '.data["token"]'`
+BROKER_SVC_ACCT_TOKEN=( $(eval echo ${BROKER_SVC_ACCT_TOKEN[@]}) )
+BROKER_SVC_ACCT_TOKEN=`echo ${BROKER_SVC_ACCT_TOKEN} | base64 --decode`
+###
+# Note:
+# It is important we do __not__ append the trailing newline in the token file
+# Go's ioutil module will read in the newline as part of the token which breaks it...and causes confusion tracking down
+###
+echo -n "${BROKER_SVC_ACCT_TOKEN}" &> $SVC_ACCT_TOKEN_FILE
+if [ "$?" -ne 0 ]; then 
+  echo "Unable to write token to $SVC_ACCT_TOKEN_FILE"
+  exit 1
+fi
+echo "Service Account: token"
+echo -e "Wrote \n${BROKER_SVC_ACCT_TOKEN}\n to: ${SVC_ACCT_TOKEN_FILE}\n"
+
+# Kill any running broker pods
+oc scale deployments asb --replicas 0 -n ${ASB_PROJECT}
+# Wait for asb pod to be destroyed
+oc get pods -n ${ASB_PROJECT} | grep asb 
+while [ "$?" -ne 1 ]; do 
+  echo "Waiting for asb deployment to scale down"
+  sleep 5
+  oc get pods -n ${ASB_PROJECT} | grep asb 
+done 
+
+oc delete endpoints asb -n ${ASB_PROJECT}
+oc delete service asb  -n ${ASB_PROJECT}
+oc delete route asb-etcd -n ${ASB_PROJECT}
+# Process required changes for local development
+oc process -f ${TEMPLATE_LOCAL_DEV} -n ${ASB_PROJECT} -p BROKER_IP_ADDR=${BROKER_IP_ADDR} | oc create -n ${ASB_PROJECT} -f - 
+
+echo "Sleeping for a few seconds to avoid issues with broker not being able to talk to etcd."
+echo "Appears like there is a delay of when we create the asb-etcd route and when it is available for use"
+sleep 5 
+
+etcd_route=`oc get route asb-etcd -n ${ASB_PROJECT} -o=jsonpath=\'\{.spec.host\}\'`
+echo "etcd route is at: ${etcd_route}"
+
+if [ -z "$DOCKERHUB_USERNAME" ]; then
+  echo "Please set the environment variable DOCKERHUB_USERNAME and re-run"
+  exit 1 
+fi 
+if [ -z "$DOCKERHUB_PASSWORD" ]; then
+  echo "Please set the environment variable DOCKERHUB_PASSWORD and re-run"
+  exit 1 
+fi 
+if [ -z "$DOCKERHUB_ORG" ]; then
+  echo "Please set the environment variable DOCKERHUB_ORG and re-run"
+  exit 1 
+fi 
+
+cat << EOF  > ${GENERATED_BROKER_CONFIG}
+---
+registry:
+  name: dockerhub
+  url: https://registry.hub.docker.com
+  user: ${DOCKERHUB_USERNAME}
+  pass: ${DOCKERHUB_PASSWORD}
+  org: ${DOCKERHUB_ORG}
+dao:
+  etcd_host: ${etcd_route}
+  etcd_port: 80
+log:
+  logfile: /tmp/ansible-service-broker-asb.log
+  stdout: true
+  level: debug
+  color: true
+openshift: {}
+broker:
+  dev_broker: true
+  launch_apb_on_bind: false
+  recovery: true
+  output_request: true
+EOF
+

--- a/scripts/run_local.sh
+++ b/scripts/run_local.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+MY_VARS="./my_local_dev_vars"
+if [ ! -f $MY_VARS ]; then 
+  echo "Please create $MY_VARS"
+  echo "cp $MY_VARS.example $MY_VARS"
+  echo "then edit as needed"
+  exit 1
+fi 
+
+source ./${MY_VARS}
+if [ "$?" -ne "0" ]; then
+  echo "Error reading in ${MY_VARS}"
+  exit 1
+fi 
+
+if [ -z "${BROKER_CMD}" ]; then 
+  echo "Please ensure BROKER_CMD is defined in ${MY_VARS}"
+  exit 1 
+fi 
+
+export KUBERNETES_SERVICE_HOST=${OPENSHIFT_SERVER_HOST}
+export KUBERNETES_SERVICE_PORT=${OPENSHIFT_SERVER_PORT}
+
+BROKER_CONFIG=${GENERATED_BROKER_CONFIG}
+if [ ! -z "$1" ]; then
+  BROKER_CONFIG="$1"
+fi 
+
+if [ -z "${BROKER_CONFIG}" ]; then 
+  echo "Please specify a broker configuration file to run"
+  exit 1
+fi 
+
+echo "Running ${BROKER_CMD} --config ${BROKER_CONFIG}"
+${BROKER_CMD} --config ${BROKER_CONFIG}

--- a/scripts/test_local_server_connection.sh
+++ b/scripts/test_local_server_connection.sh
@@ -1,0 +1,6 @@
+CERT=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+TOKEN=`cat /var/run/secrets/kubernetes.io/serviceaccount/token`
+export KUBERNETES_SERVICE_HOST=192.168.37.1
+export KUBERNETES_SERVICE_PORT=8443
+
+curl --cacert ${CERT} -H "Authorization: Bearer ${TOKEN}" https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}/version

--- a/templates/deploy-local-dev-changes.yaml
+++ b/templates/deploy-local-dev-changes.yaml
@@ -1,0 +1,73 @@
+# Goal of this template is to create or update the required resources so we can
+# run the broker locally yet have it behave as if it's running in the cluster.
+# The required changes are:
+# - Create a route for our etcd so we can communicate to it
+# - Update the asb service/endpoint so it points to our locally running broker
+#   Note the asb route will now use our updated service/endpoint to contact our local broker
+#   so there is no change from Service Catalog perspective
+apiVersion: v1
+kind: Template
+metadata:
+  name: ansible-service-broker-local-development
+objects:
+
+- apiVersion: v1
+  kind: Route
+  metadata:
+    name: asb-etcd
+    labels:
+      app: ansible-service-broker
+      service: etcd
+  spec:
+    to:
+      kind: Service
+      name: etcd
+    port:
+      targetPort: ${ETCD_TARGET_PORT}
+
+- apiVersion: v1
+  kind: Endpoints
+  metadata:
+    labels:
+      app: ansible-service-broker
+      service: asb
+    name: asb
+  subsets:
+  - addresses:
+    - ip: ${BROKER_IP_ADDR}
+    ports:
+    - name: port-${BROKER_PORT}
+      port: ${BROKER_PORT}
+      protocol: TCP
+
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app: ansible-service-broker
+      service: asb
+    name: asb
+  spec:
+    ports:
+    - 
+      name: port-${BROKER_PORT}
+      port: ${BROKER_PORT}
+      protocol: TCP
+      #targetPort: ${BROKER_PORT}
+      nodePort: 0
+  selector: {}
+
+parameters:
+- description: Name of the etcd target port to connect to
+  displayname: ETCD_TARGET_PORT
+  name: ETCD_TARGET_PORT
+  value: etcd-advertise
+
+- description: Brokers port
+  displayname: BROKER_PORT
+  name: BROKER_PORT
+  value: "1338"
+
+- description: Brokers IP Address
+  displayname: BROKER_IP_ADDR
+  name: BROKER_IP_ADDR


### PR DESCRIPTION
Assumes running oc cluster up on localhost.

Allows running broker local on host with:
  - service account credentials
  - etcd route
  - modifies asb route to point to local broker

With this PR we can do the following:

1) Use catasb 'dev' branch to bring up a cluster
2) make build
3) cd scripts && ./run_local.sh

The local broker now replaces the broker the Service Catalog was talking to.

I've had success with this doing provision/bind with mediawiki & rhscl postgres example.


Note the broker will not have access to the service network, for example it couldn't reach the running etcd so we created a route to expose it.  We are not talking to the service network for anything else currently, in future this may be a limitation for us.


Also...I've tested this with building broker on macOS and running locally on Mac talking to cluster.

