### PR TITLE
removing unnecessary function that just add's indirection.

### DIFF
--- a/pkg/apb/dockerhub_registry.go
+++ b/pkg/apb/dockerhub_registry.go
@@ -13,6 +13,7 @@ import (
 	"github.com/containers/image/transports"
 	"github.com/containers/image/types"
 	logging "github.com/op/go-logging"
+	yaml "gopkg.in/yaml.v2"
 )
 
 // DockerHubRegistry - Docker Hub registry
@@ -74,7 +75,7 @@ func (r *DockerHubRegistry) createSpecs(rawBundleData []*ImageData) ([]*Spec, er
 			return nil, _err
 		}
 
-		if _err = LoadYAML(string(decodedSpecYaml), _spec); _err != nil {
+		if _err = yaml.Unmarshal(decodedSpecYaml, _spec); _err != nil {
 			r.log.Error("Something went wrong loading decoded spec yaml - %v - %v", string(decodedSpecYaml), _err)
 			return nil, _err
 		}

--- a/pkg/apb/rhcc_registry.go
+++ b/pkg/apb/rhcc_registry.go
@@ -3,10 +3,13 @@ package apb
 import (
 	b64 "encoding/base64"
 	"encoding/json"
-	logging "github.com/op/go-logging"
 	"io/ioutil"
 	"net/http"
 	"strings"
+
+	yaml "gopkg.in/yaml.v2"
+
+	logging "github.com/op/go-logging"
 )
 
 // RHCCRegistry - Red Hat Container Catalog Registry
@@ -132,7 +135,7 @@ func (r RHCCRegistry) imageToSpec(image *Image) (*Spec, error) {
 		return nil, err
 	}
 
-	if err = LoadYAML(string(decodedSpecYaml), _spec); err != nil {
+	if err = yaml.Unmarshal(decodedSpecYaml, _spec); err != nil {
 		r.log.Error("Something went wrong loading decoded spec yaml, %s", err)
 		return nil, err
 	}

--- a/pkg/apb/types.go
+++ b/pkg/apb/types.go
@@ -5,7 +5,6 @@ import (
 
 	logging "github.com/op/go-logging"
 	"github.com/pborman/uuid"
-	yaml "gopkg.in/yaml.v2"
 )
 
 type Parameters map[string]interface{}
@@ -162,16 +161,6 @@ func DumpJSON(obj interface{}) (string, error) {
 	}
 
 	return string(payload), nil
-}
-
-func LoadYAML(payload string, obj interface{}) error {
-	var err error
-
-	if err = yaml.Unmarshal([]byte(payload), obj); err != nil {
-		return err
-	}
-
-	return nil
 }
 
 type RecoverStatus struct {

--- a/pkg/apb/types_test.go
+++ b/pkg/apb/types_test.go
@@ -152,7 +152,7 @@ cwo=`
 	}
 
 	spec := &Spec{}
-	if err = LoadYAML(string(decodedyaml), spec); err != nil {
+	if err = yaml.Unmarshal(decodedyaml, spec); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/apb/types_test.go
+++ b/pkg/apb/types_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	ft "github.com/openshift/ansible-service-broker/pkg/fusortest"
+	yaml "gopkg.in/yaml.v2"
 )
 
 // array can't be const

--- a/pkg/broker/util_test.go
+++ b/pkg/broker/util_test.go
@@ -95,7 +95,7 @@ cwo=`
 	}
 
 	spec := &apb.Spec{}
-	if err = apb.LoadYAML(string(decodedyaml), spec); err != nil {
+	if err = yaml.Unmarshal(decodedyaml, spec); err != nil {
 		t.Fatal(err)
 	}
 	required := []string{"mediawiki_site_lang"}

--- a/pkg/broker/util_test.go
+++ b/pkg/broker/util_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openshift/ansible-service-broker/pkg/apb"
 	ft "github.com/openshift/ansible-service-broker/pkg/fusortest"
 	"github.com/pborman/uuid"
+	yaml "gopkg.in/yaml.v2"
 )
 
 func TestEnumIsCopied(t *testing.T) {


### PR DESCRIPTION
Really want to open a discussion on this one. 

I think that it does not make sense to wrap package calls like this unless you are doing more logic for every time you call that method. 

If we do want to continue, then we should update the function 
```
func LoadYAML(yaml []byte, obj interface{}) {
        return yaml.Unmarshal(yaml, obj)
}
```