### PR TITLE
Prepare repo for use with tito

### DIFF
--- a/.tito/packages/.readme
+++ b/.tito/packages/.readme
@@ -1,0 +1,3 @@
+the .tito/packages directory contains metadata files
+named after their packages. Each file has the latest tagged
+version and the project's relative directory.

--- a/.tito/releasers.conf
+++ b/.tito/releasers.conf
@@ -4,3 +4,11 @@ project_name = ansible-service-broker
 #upload_command = scp %(srpm)s my.web.com:public_html/my_srpm/
 #remote_location = http://my.web.com/~msuchy/my_srpm/
 copr_options = --timeout 600
+
+[asb-copr-test]
+releaser = tito.release.CoprReleaser
+project_name = ansible-service-broker
+#upload_command = scp %(srpm)s my.web.com:public_html/my_srpm/
+#remote_location = http://my.web.com/~msuchy/my_srpm/
+copr_options = --timeout 600
+builder.test = 1

--- a/.tito/releasers.conf
+++ b/.tito/releasers.conf
@@ -13,6 +13,6 @@ project_name = ansible-service-broker
 copr_options = --timeout 600
 builder.test = 1
 
-[brew]
+[asb-brew]
 releaser = tito.release.DistGitReleaser
 branches = rhaos-3.6-asb-rhel-7

--- a/.tito/releasers.conf
+++ b/.tito/releasers.conf
@@ -12,3 +12,7 @@ project_name = ansible-service-broker
 #remote_location = http://my.web.com/~msuchy/my_srpm/
 copr_options = --timeout 600
 builder.test = 1
+
+[brew]
+releaser = tito.release.DistGitReleaser
+branches = rhaos-3.6-asb-rhel-7

--- a/.tito/releasers.conf
+++ b/.tito/releasers.conf
@@ -1,0 +1,6 @@
+[asb-copr]
+releaser = tito.release.CoprReleaser
+project_name = ansible-service-broker
+#upload_command = scp %(srpm)s my.web.com:public_html/my_srpm/
+#remote_location = http://my.web.com/~msuchy/my_srpm/
+copr_options = --timeout 600

--- a/.tito/tito.props
+++ b/.tito/tito.props
@@ -1,0 +1,5 @@
+[buildconfig]
+builder = tito.builder.Builder
+tagger = tito.tagger.VersionTagger
+changelog_do_not_remove_cherrypick = 0
+changelog_format = %s (%ae)

--- a/ansible-service-broker.spec
+++ b/ansible-service-broker.spec
@@ -320,4 +320,3 @@ export GOPATH=%{buildroot}/%{gopath}:$(pwd)/Godeps/_workspace:%{gopath}
 %endif
 
 %changelog
-

--- a/docs/building.md
+++ b/docs/building.md
@@ -36,3 +36,9 @@ To build an rpm of the last pushed tag, simply run:
 ```
 tito build --rpm
 ```
+
+## Prerequisites
+
+* tito
+* rhpkg
+* brewkoji

--- a/docs/building.md
+++ b/docs/building.md
@@ -1,0 +1,38 @@
+# Building
+
+```
+dnf install tito
+```
+
+## tagging a release
+
+Tito tag will create a tag for the project using the project name and the
+version-release from the spec file. This creates a nice consistent tagging
+stream.
+
+```
+tito tag
+# follow the prompts.
+# inspect the changelog to ensure it looks acceptable
+# save file
+git push origin
+git push origin NAMEOFTAG
+tito release brew
+```
+
+## building rpm locally
+
+To build an rpm of the currently committed (but not necessarily pushed
+to origin) you can use the `--test` flag.
+
+```
+tito build --test --rpm
+```
+
+## building rpm from last tag
+
+To build an rpm of the last pushed tag, simply run:
+
+```
+tito build --rpm
+```

--- a/extras/ansible-service-broker.spec
+++ b/extras/ansible-service-broker.spec
@@ -38,7 +38,7 @@
 %define modulename ansible-service-broker
 
 Name: %{repo}
-Version: 0
+Version: 0.1.1
 Release: 3%{build_timestamp}%{?dist}
 Summary: Ansible Service Broker
 License: ASL 2.0


### PR DESCRIPTION
Tito will allow us to build to copr, brew and locally in a consistent manner. We can also use the `tito tag` feature to create tags for the repo. Tito will also update the changelog so we can keep track of what went into the RPM. The same build can be submitted to all of the build systems.