### PR TITLE
Break apart the Kubernetes Client

### DIFF
--- a/pkg/apb/client.go
+++ b/pkg/apb/client.go
@@ -11,9 +11,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	restclient "k8s.io/client-go/rest"
 
+	"github.com/openshift/ansible-service-broker/pkg/clients"
 	"github.com/pborman/uuid"
-	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/client-go/util/homedir"
 	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
 )
@@ -56,19 +55,6 @@ type Client struct {
 	log           *logging.Logger
 }
 
-func createClientConfigFromFile(configPath string) (*restclient.Config, error) {
-	clientConfig, err := clientcmd.LoadFromFile(configPath)
-	if err != nil {
-		return nil, err
-	}
-
-	config, err := clientcmd.NewDefaultClientConfig(*clientConfig, &clientcmd.ConfigOverrides{}).ClientConfig()
-	if err != nil {
-		return nil, err
-	}
-	return config, nil
-}
-
 func NewClient(log *logging.Logger) (*Client, error) {
 	dockerClient, err := docker.NewClient(DockerSocket)
 	if err != nil {
@@ -76,32 +62,16 @@ func NewClient(log *logging.Logger) (*Client, error) {
 		return nil, err
 	}
 
-	// NOTE: Both the external and internal client object are using the same
-	// clientset library. Internal clientset normally uses a different
-	// library
-	clientConfig, err := restclient.InClusterConfig()
+	k8s, err := clients.Kubernetes(log)
 	if err != nil {
-		log.Warning("Failed to create a InternalClientSet: %v.", err)
-
-		log.Debug("Checking for a local Cluster Config")
-		clientConfig, err = createClientConfigFromFile(homedir.HomeDir() + "/.kube/config")
-		if err != nil {
-			log.Error("Failed to create LocalClientSet")
-			return nil, err
-		}
-	}
-
-	clientset, err := clientset.NewForConfig(clientConfig)
-	if err != nil {
-		log.Error("Failed to create LocalClientSet")
 		return nil, err
 	}
 
-	rest := clientset.CoreV1().RESTClient()
+	rest := k8s.CoreV1().RESTClient()
 
 	client := &Client{
 		dockerClient:  dockerClient,
-		ClusterClient: clientset,
+		ClusterClient: k8s,
 		RESTClient:    rest,
 		log:           log,
 	}

--- a/pkg/clients/kubernetes.go
+++ b/pkg/clients/kubernetes.go
@@ -1,0 +1,48 @@
+package clients
+
+import (
+	logging "github.com/op/go-logging"
+	restclient "k8s.io/client-go/rest"
+
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/homedir"
+	"k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
+)
+
+func createClientConfigFromFile(configPath string) (*restclient.Config, error) {
+	clientConfig, err := clientcmd.LoadFromFile(configPath)
+	if err != nil {
+		return nil, err
+	}
+
+	config, err := clientcmd.NewDefaultClientConfig(*clientConfig, &clientcmd.ConfigOverrides{}).ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+	return config, nil
+}
+
+func Kubernetes(log *logging.Logger) (*clientset.Clientset, error) {
+	// NOTE: Both the external and internal client object are using the same
+	// clientset library. Internal clientset normally uses a different
+	// library
+	clientConfig, err := restclient.InClusterConfig()
+	if err != nil {
+		log.Warning("Failed to create a InternalClientSet: %v.", err)
+
+		log.Debug("Checking for a local Cluster Config")
+		clientConfig, err = createClientConfigFromFile(homedir.HomeDir() + "/.kube/config")
+		if err != nil {
+			log.Error("Failed to create LocalClientSet")
+			return nil, err
+		}
+	}
+
+	clientset, err := clientset.NewForConfig(clientConfig)
+	if err != nil {
+		log.Error("Failed to create LocalClientSet")
+		return nil, err
+	}
+
+	return clientset, nil
+}


### PR DESCRIPTION
Make a separate directory for clients so they are not part of the APB code.  This will make the clients
easy to initialize, a single place to create the object, and adds the ability to easily create new ones.

Partially-fixes: https://github.com/openshift/ansible-service-broker/issues/213