### PR TITLE
Breakup all the Broker Clients into a clients pkg

### DIFF
--- a/pkg/apb/client.go
+++ b/pkg/apb/client.go
@@ -54,23 +54,15 @@ type Client struct {
 }
 
 func NewClient(log *logging.Logger) (*Client, error) {
-	dockerClient, err := clients.Docker(log)
-	if err != nil {
-		log.Error("Could not load docker client")
-		return nil, err
-	}
-
-	k8s, err := clients.Kubernetes(log)
-	if err != nil {
-		return nil, err
-	}
-
-	rest := k8s.CoreV1().RESTClient()
+	//TODO: This object gets created each provision, bind, deprovision,
+	// and unbind.  Instead, those functions should be using the global
+	// clients were needed and this class needs to be reworked.
+	k8s := clients.Clients.KubernetesClient
 
 	client := &Client{
-		dockerClient:  dockerClient,
+		dockerClient:  clients.Clients.DockerClient,
 		ClusterClient: k8s,
-		RESTClient:    rest,
+		RESTClient:    k8s.CoreV1().RESTClient(),
 		log:           log,
 	}
 
@@ -146,14 +138,14 @@ func (c *Client) RunImage(
 	}
 
 	c.log.Notice(fmt.Sprintf("Creating pod %q in the %s namespace", pod.Name, ns))
-	_, err = c.ClusterClient.CoreV1().Pods(ns).Create(pod)
+	_, err = clients.Clients.KubernetesClient.CoreV1().Pods(ns).Create(pod)
 
 	return apbId, err
 }
 
 func (c *Client) PullImage(imageName string) error {
 	// Under what circumstances does this error out?
-	c.dockerClient.PullImage(docker.PullImageOptions{
+	clients.Clients.DockerClient.PullImage(docker.PullImageOptions{
 		Repository:   imageName,
 		OutputStream: os.Stdout,
 	}, docker.AuthConfiguration{})

--- a/pkg/apb/client.go
+++ b/pkg/apb/client.go
@@ -39,8 +39,6 @@ First cut might have to pass kubecfg from broker. FIRST SPRINT broker passes use
 admin/admin
 */
 
-var DockerSocket = "unix:///var/run/docker.sock"
-
 type ClusterConfig struct {
 	InCluster bool
 	Target    string
@@ -56,7 +54,7 @@ type Client struct {
 }
 
 func NewClient(log *logging.Logger) (*Client, error) {
-	dockerClient, err := docker.NewClient(DockerSocket)
+	dockerClient, err := clients.Docker(log)
 	if err != nil {
 		log.Error("Could not load docker client")
 		return nil, err

--- a/pkg/apb/client.go
+++ b/pkg/apb/client.go
@@ -11,9 +11,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	restclient "k8s.io/client-go/rest"
 
+	"github.com/openshift/ansible-service-broker/pkg/clients"
 	"github.com/pborman/uuid"
-	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/client-go/util/homedir"
 	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
 )
@@ -56,19 +55,6 @@ type Client struct {
 	log           *logging.Logger
 }
 
-func createClientConfigFromFile(configPath string) (*restclient.Config, error) {
-	clientConfig, err := clientcmd.LoadFromFile(configPath)
-	if err != nil {
-		return nil, err
-	}
-
-	config, err := clientcmd.NewDefaultClientConfig(*clientConfig, &clientcmd.ConfigOverrides{}).ClientConfig()
-	if err != nil {
-		return nil, err
-	}
-	return config, nil
-}
-
 func NewClient(log *logging.Logger) (*Client, error) {
 	dockerClient, err := docker.NewClient(DockerSocket)
 	if err != nil {
@@ -76,32 +62,16 @@ func NewClient(log *logging.Logger) (*Client, error) {
 		return nil, err
 	}
 
-	// NOTE: Both the external and internal client object are using the same
-	// clientset library. Internal clientset normally uses a different
-	// library
-	clientConfig, err := restclient.InClusterConfig()
+	k8s, err := clients.Kubernetes(log)
 	if err != nil {
-		log.Warning("Failed to create a InternalClientSet: %v.", err)
-
-		log.Debug("Checking for a local Cluster Config")
-		clientConfig, err = createClientConfigFromFile(homedir.HomeDir() + "/.kube/config")
-		if err != nil {
-			log.Error("Failed to create LocalClientSet")
-			return nil, err
-		}
-	}
-
-	clientset, err := clientset.NewForConfig(clientConfig)
-	if err != nil {
-		log.Error("Failed to create LocalClientSet")
 		return nil, err
 	}
 
-	rest := clientset.CoreV1().RESTClient()
+	rest := k8s.CoreV1().RESTClient()
 
 	client := &Client{
 		dockerClient:  dockerClient,
-		ClusterClient: clientset,
+		ClusterClient: k8s,
 		RESTClient:    rest,
 		log:           log,
 	}

--- a/pkg/app/config.go
+++ b/pkg/app/config.go
@@ -8,12 +8,12 @@ import (
 
 	"github.com/openshift/ansible-service-broker/pkg/apb"
 	"github.com/openshift/ansible-service-broker/pkg/broker"
-	"github.com/openshift/ansible-service-broker/pkg/dao"
+	"github.com/openshift/ansible-service-broker/pkg/clients"
 )
 
 type Config struct {
 	Registry   apb.RegistryConfig
-	Dao        dao.Config
+	Dao        clients.EtcdConfig
 	Log        LogConfig
 	Openshift  apb.ClusterConfig
 	ConfigFile string

--- a/pkg/clients/clients.go
+++ b/pkg/clients/clients.go
@@ -1,0 +1,16 @@
+package clients
+
+import (
+	d "github.com/fsouza/go-dockerclient"
+
+	"github.com/coreos/etcd/client"
+	"k8s.io/client-go/rest"
+	"k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
+)
+
+var Clients struct {
+	EtcdClient       client.Client
+	KubernetesClient *clientset.Clientset
+	DockerClient     *d.Client
+	RESTClient       rest.Interface
+}

--- a/pkg/clients/docker.go
+++ b/pkg/clients/docker.go
@@ -5,11 +5,13 @@ import (
 	logging "github.com/op/go-logging"
 )
 
-func Docker(log *logging.Logger) (*docker.Client, error) {
+func NewDocker(log *logging.Logger) error {
 	dockerClient, err := docker.NewClient(DockerSocket)
 	if err != nil {
 		log.Error("Could not load docker client")
-		return nil, err
+		return err
 	}
-	return dockerClient, nil
+
+	Clients.DockerClient = dockerClient
+	return nil
 }

--- a/pkg/clients/docker.go
+++ b/pkg/clients/docker.go
@@ -1,0 +1,15 @@
+package clients
+
+import (
+	docker "github.com/fsouza/go-dockerclient"
+	logging "github.com/op/go-logging"
+)
+
+func Docker(log *logging.Logger) (*docker.Client, error) {
+	dockerClient, err := docker.NewClient(DockerSocket)
+	if err != nil {
+		log.Error("Could not load docker client")
+		return nil, err
+	}
+	return dockerClient, nil
+}

--- a/pkg/clients/etcd.go
+++ b/pkg/clients/etcd.go
@@ -14,7 +14,7 @@ type EtcdConfig struct {
 	EtcdPort string `yaml:"etcd_port"`
 }
 
-func Etcd(config EtcdConfig, log *logging.Logger) (client.Client, error) {
+func NewEtcd(config EtcdConfig, log *logging.Logger) error {
 	// TODO: Config validation
 	endpoints := []string{etcdEndpoint(config.EtcdHost, config.EtcdPort)}
 
@@ -29,10 +29,11 @@ func Etcd(config EtcdConfig, log *logging.Logger) (client.Client, error) {
 		HeaderTimeoutPerRequest: time.Second,
 	})
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	return etcdClient, nil
+	Clients.EtcdClient = etcdClient
+	return nil
 }
 
 func etcdEndpoint(host string, port string) string {

--- a/pkg/clients/etcd.go
+++ b/pkg/clients/etcd.go
@@ -1,0 +1,40 @@
+package clients
+
+import (
+	"fmt"
+	"time"
+
+	logging "github.com/op/go-logging"
+
+	"github.com/coreos/etcd/client"
+)
+
+type EtcdConfig struct {
+	EtcdHost string `yaml:"etcd_host"`
+	EtcdPort string `yaml:"etcd_port"`
+}
+
+func Etcd(config EtcdConfig, log *logging.Logger) (client.Client, error) {
+	// TODO: Config validation
+	endpoints := []string{etcdEndpoint(config.EtcdHost, config.EtcdPort)}
+
+	log.Info("== ETCD CX ==")
+	log.Infof("EtcdHost: %s", config.EtcdHost)
+	log.Infof("EtcdPort: %s", config.EtcdPort)
+	log.Infof("Endpoints: %v", endpoints)
+
+	etcdClient, err := client.New(client.Config{
+		Endpoints:               endpoints,
+		Transport:               client.DefaultTransport,
+		HeaderTimeoutPerRequest: time.Second,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return etcdClient, nil
+}
+
+func etcdEndpoint(host string, port string) string {
+	return fmt.Sprintf("http://%s:%s", host, port)
+}

--- a/pkg/clients/kubernetes.go
+++ b/pkg/clients/kubernetes.go
@@ -22,7 +22,7 @@ func createClientConfigFromFile(configPath string) (*restclient.Config, error) {
 	return config, nil
 }
 
-func Kubernetes(log *logging.Logger) (*clientset.Clientset, error) {
+func NewKubernetes(log *logging.Logger) error {
 	// NOTE: Both the external and internal client object are using the same
 	// clientset library. Internal clientset normally uses a different
 	// library
@@ -34,15 +34,19 @@ func Kubernetes(log *logging.Logger) (*clientset.Clientset, error) {
 		clientConfig, err = createClientConfigFromFile(homedir.HomeDir() + "/.kube/config")
 		if err != nil {
 			log.Error("Failed to create LocalClientSet")
-			return nil, err
+			return err
 		}
 	}
 
 	clientset, err := clientset.NewForConfig(clientConfig)
 	if err != nil {
 		log.Error("Failed to create LocalClientSet")
-		return nil, err
+		return err
 	}
 
-	return clientset, nil
+	rest := clientset.CoreV1().RESTClient()
+
+	Clients.RESTClient = rest
+	Clients.KubernetesClient = clientset
+	return nil
 }

--- a/pkg/clients/kubernetes.go
+++ b/pkg/clients/kubernetes.go
@@ -1,0 +1,48 @@
+package clients
+
+import (
+	logging "github.com/op/go-logging"
+	restclient "k8s.io/client-go/rest"
+
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/homedir"
+	"k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
+)
+
+func createClientConfigFromFile(configPath string) (*restclient.Config, error) {
+	clientConfig, err := clientcmd.LoadFromFile(configPath)
+	if err != nil {
+		return nil, err
+	}
+
+	config, err := clientcmd.NewDefaultClientConfig(*clientConfig, &clientcmd.ConfigOverrides{}).ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+	return config, nil
+}
+
+func Kubernetes(log *logging.Logger) (*clientset.Clientset, error) {
+	// NOTE: Both the external and internal client object are using the same
+	// clientset library. Internal clientset normally uses a different
+	// library
+	clientConfig, err := restclient.InClusterConfig()
+	if err != nil {
+		log.Warning("Failed to create a InternalClientSet: %v.", err)
+
+		log.Debug("Checking for a local Cluster Config")
+		clientConfig, err = createClientConfigFromFile(homedir.HomeDir() + "/.kube/config")
+		if err != nil {
+			log.Error("Failed to create LocalClientSet")
+			return nil, err
+		}
+	}
+
+	clientset, err := clientset.NewForConfig(clientConfig)
+	if err != nil {
+		log.Error("Failed to create LocalClientSet")
+		return nil, err
+	}
+
+	return clientset, nil
+}

--- a/pkg/clients/types.go
+++ b/pkg/clients/types.go
@@ -1,0 +1,5 @@
+package clients
+
+const (
+	DockerSocket = "unix:///var/run/docker.sock"
+)

--- a/pkg/dao/dao.go
+++ b/pkg/dao/dao.go
@@ -24,21 +24,15 @@ type Dao struct {
 }
 
 // NewDao - Create a new Dao object
-func NewDao(config clients.EtcdConfig, log *logging.Logger) (*Dao, error) {
-	var err error
+func NewDao(config clients.EtcdConfig, log *logging.Logger) *Dao {
 	dao := Dao{
 		config: config,
 		log:    log,
 	}
 
-	dao.client, err = clients.Etcd(config, log)
-	if err != nil {
-		return nil, err
-	}
-
+	dao.client = clients.Clients.EtcdClient
 	dao.kapi = client.NewKeysAPI(dao.client)
-
-	return &dao, nil
+	return &dao
 }
 
 // SetRaw - Allows the setting of the value json string to the key in the kvp API.

--- a/pkg/dao/dao.go
+++ b/pkg/dao/dao.go
@@ -7,52 +7,31 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strings"
-	"time"
 
 	"github.com/coreos/etcd/client"
 	"github.com/coreos/etcd/version"
 	logging "github.com/op/go-logging"
 	"github.com/openshift/ansible-service-broker/pkg/apb"
+	"github.com/openshift/ansible-service-broker/pkg/clients"
 	"github.com/pborman/uuid"
 )
 
-// Config - confg holds etcd host and port.
-type Config struct {
-	EtcdHost string `yaml:"etcd_host"`
-	EtcdPort string `yaml:"etcd_port"`
-}
-
-// Dao - retreive, create, and update  objects from etcd
 type Dao struct {
-	config    Config
-	log       *logging.Logger
-	endpoints []string
-	client    client.Client
-	kapi      client.KeysAPI // Used to interact with kvp API over HTTP
+	config clients.EtcdConfig
+	log    *logging.Logger
+	client client.Client
+	kapi   client.KeysAPI // Used to interact with kvp API over HTTP
 }
 
 // NewDao - Create a new Dao object
-func NewDao(config Config, log *logging.Logger) (*Dao, error) {
+func NewDao(config clients.EtcdConfig, log *logging.Logger) (*Dao, error) {
 	var err error
 	dao := Dao{
 		config: config,
 		log:    log,
 	}
 
-	// TODO: Config validation
-
-	dao.endpoints = []string{etcdEndpoint(config.EtcdHost, config.EtcdPort)}
-
-	log.Info("== ETCD CX ==")
-	log.Info(fmt.Sprintf("EtcdHost: %s", config.EtcdHost))
-	log.Info(fmt.Sprintf("EtcdPort: %s", config.EtcdPort))
-	log.Info(fmt.Sprintf("Endpoints: %v", dao.endpoints))
-
-	dao.client, err = client.New(client.Config{
-		Endpoints:               dao.endpoints,
-		Transport:               client.DefaultTransport,
-		HeaderTimeoutPerRequest: time.Second,
-	})
+	dao.client, err = clients.Etcd(config, log)
 	if err != nil {
 		return nil, err
 	}
@@ -62,17 +41,13 @@ func NewDao(config Config, log *logging.Logger) (*Dao, error) {
 	return &dao, nil
 }
 
-func etcdEndpoint(host string, port string) string {
-	return fmt.Sprintf("http://%s:%s", host, port)
-}
-
 // SetRaw - Allows the setting of the value json string to the key in the kvp API.
 func (d *Dao) SetRaw(key string, val string) error {
 	_, err := d.kapi.Set(context.Background(), key, val /*opts*/, nil)
 	return err
 }
 
-func (d *Dao) GetEtcdVersion(config Config) (string, string, error) {
+func (d *Dao) GetEtcdVersion(config clients.EtcdConfig) (string, string, error) {
 	// The next etcd release (1.4) will have client.GetVersion()
 	// We'll use this to test our etcd connection for now
 	resp, err := http.Get("http://" + config.EtcdHost + ":" + config.EtcdPort + "/version")


### PR DESCRIPTION
Refactor the broker clients into their own package.

Right now, we have clients scattered around in different packages. This is causing the clients to be initialized on each action (bind, unbind, etc...) as well as other places because the clients aren't available for use.

Let's initialize the clients one time and distribute those clients to the places that need it.  This patch set creates a global struct 'Clients' that gets initialized by app.go before the broker object is created.  Any function that runs after the broker object creation, will have access to all the clients.

Fixes: #213 