### PR TITLE
With a newer Etcd, we can use the GetVersion function

### DIFF
--- a/pkg/clients/clients.go
+++ b/pkg/clients/clients.go
@@ -7,7 +7,7 @@ import (
 )
 
 var instances struct {
-	Etcd       *etcd.Client
+	Etcd       etcd.Client
 	Kubernetes *k8s.Clientset
 }
 

--- a/pkg/clients/etcd.go
+++ b/pkg/clients/etcd.go
@@ -51,7 +51,7 @@ func GetEtcdVersion(ec EtcdConfig) (string, string, error) {
 }
 
 // Etcd - Create a new etcd client if needed, returns reference
-func Etcd(config EtcdConfig, log *logging.Logger) (*etcd.Client, error) {
+func Etcd(config EtcdConfig, log *logging.Logger) (etcd.Client, error) {
 	errMsg := "Something went wrong intializing etcd client!"
 	once.Etcd.Do(func() {
 		client, err := newEtcd(config, log)
@@ -73,7 +73,7 @@ func Etcd(config EtcdConfig, log *logging.Logger) (*etcd.Client, error) {
 	return instances.Etcd, nil
 }
 
-func newEtcd(config EtcdConfig, log *logging.Logger) (*etcd.Client, error) {
+func newEtcd(config EtcdConfig, log *logging.Logger) (etcd.Client, error) {
 	// TODO: Config validation
 	endpoints := []string{etcdEndpoint(config.EtcdHost, config.EtcdPort)}
 
@@ -91,7 +91,7 @@ func newEtcd(config EtcdConfig, log *logging.Logger) (*etcd.Client, error) {
 		return nil, err
 	}
 
-	return &etcdClient, err
+	return etcdClient, err
 }
 
 func etcdEndpoint(host string, port string) string {

--- a/pkg/dao/dao.go
+++ b/pkg/dao/dao.go
@@ -27,7 +27,7 @@ func (c Config) GetEtcdConfig() clients.EtcdConfig {
 type Dao struct {
 	config Config
 	log    *logging.Logger
-	client *client.Client
+	client client.Client
 	kapi   client.KeysAPI // Used to interact with kvp API over HTTP
 }
 
@@ -43,7 +43,7 @@ func NewDao(config Config, log *logging.Logger) (*Dao, error) {
 		return nil, err
 	}
 	dao.client = etcdClient
-	dao.kapi = client.NewKeysAPI(*dao.client)
+	dao.kapi = client.NewKeysAPI(dao.client)
 	return &dao, nil
 }
 


### PR DESCRIPTION
The GetEtcdVersion function was a temporary workaround to contact Etcd until we moved to a newer etcd. The change we needed merged in v3.1.1.