### PR TITLE
Make the ImagePullPolicy Configurable

### DIFF
--- a/etc/example-config.yaml
+++ b/etc/example-config.yaml
@@ -17,6 +17,7 @@ openshift:
   target: localhost:8443
   user: OPENSHIFT_USER
   pass: OPENSHIFT_PASS
+  image_pull_policy: IfNotPresent
 broker:
   dev_broker: true
   launch_apb_on_bind: false

--- a/scripts/my_local_dev_vars.example
+++ b/scripts/my_local_dev_vars.example
@@ -15,6 +15,8 @@ DOCKERHUB_USERNAME=""
 DOCKERHUB_PASSWORD=""
 DOCKERHUB_ORG="ansibleplaybookbundle"
 
+# Always, IfNotPresent, Never
+IMAGE_PULL_POLICY="Always"
 
 BROKER_CMD="../broker"
 GENERATED_BROKER_CONFIG="../etc/generated_local_development.yaml"

--- a/scripts/prep_local_devel_env.sh
+++ b/scripts/prep_local_devel_env.sh
@@ -166,7 +166,8 @@ log:
   stdout: true
   level: debug
   color: true
-openshift: {}
+openshift:
+  image_pull_policy: ${IMAGE_PULL_POLICY}
 broker:
   dev_broker: true
   launch_apb_on_bind: false


### PR DESCRIPTION
The pull policy of an APB should be set by the broker.
To configure it, set image_pull_policy in the config file.

The image_pull_policy setting will be verified that it's
a correct setting. The option is not case sensetive and will
error if an incorrect setting is used.

Fixes https://github.com/openshift/ansible-service-broker/issues/235