### PR TITLE
Automated builds from Dockerhub

### DIFF
--- a/build/automated-build
+++ b/build/automated-build
@@ -33,15 +33,12 @@ RUN yum -y install golang make device-mapper-devel btrfs-progs-devel etcd
 
 ENV GOPATH=/go
 ENV BROKER_PATH=${GOPATH}/src/github.com/openshift
-ENV GLIDE_VERSION=v0.12.3 \
-    GLIDE_HOME=/go/src/github.com/openshift/ansible-service-broker/.glide
-RUN curl -sSL https://github.com/Masterminds/glide/releases/download/$GLIDE_VERSION/glide-$GLIDE_VERSION-linux-amd64.tar.gz | tar -vxz -C /usr/local/bin --strip=1
 
 RUN mkdir -p /go/src/github.com/openshift/ansible-service-broker
 RUN git clone https://github.com/openshift/ansible-service-broker ${BROKER_PATH}/ansible-service-broker
 WORKDIR /go/src/github.com/openshift/ansible-service-broker
 
-RUN go build -ldflags="-s -w" ./cmd/broker
+RUN go build -i -ldflags="-s -w" ./cmd/broker
 RUN mv broker /usr/bin/asbd
 ######################
 # BUILD BROKER SOURCE

--- a/build/automated-build
+++ b/build/automated-build
@@ -1,0 +1,59 @@
+FROM centos:7
+MAINTAINER Ansible Service Broker Community
+
+ENV USER_NAME=ansibleservicebroker \
+    USER_UID=1001 \
+    BASE_DIR=/opt/ansibleservicebroker
+ENV HOME=${BASE_DIR}
+
+RUN mkdir -p ${BASE_DIR} ${BASE_DIR}/etc \
+ && useradd -u ${USER_UID} -r -g 0 -M -d ${BASE_DIR} -b ${BASE_DIR} -s /sbin/nologin -c "ansibleservicebroker user" ${USER_NAME} \
+ && chown -R ${USER_NAME}:0 ${BASE_DIR} \
+ && chmod -R g+rw ${BASE_DIR} /etc/passwd
+
+
+RUN yum -y update \
+ && yum -y install epel-release centos-release-openshift-origin \
+ && yum -y install origin-clients net-tools bind-utils \
+ && yum clean all
+
+RUN mkdir /var/log/ansible-service-broker \
+    && touch /var/log/ansible-service-broker/asb.log \
+    && mkdir /etc/ansible-service-broker
+
+#
+# Dockerhub automatic building expects the source present in the image.
+#
+######################
+# BUILD BROKER SOURCE
+######################
+RUN rpm --import https://mirror.go-repo.io/centos/RPM-GPG-KEY-GO-REPO
+RUN curl -s https://mirror.go-repo.io/centos/go-repo.repo | tee /etc/yum.repos.d/go-repo.repo
+RUN yum -y install golang make device-mapper-devel btrfs-progs-devel etcd
+
+ENV GOPATH=/go
+ENV BROKER_PATH=${GOPATH}/src/github.com/openshift
+ENV GLIDE_VERSION=v0.12.3 \
+    GLIDE_HOME=/go/src/github.com/openshift/ansible-service-broker/.glide
+RUN curl -sSL https://github.com/Masterminds/glide/releases/download/$GLIDE_VERSION/glide-$GLIDE_VERSION-linux-amd64.tar.gz | tar -vxz -C /usr/local/bin --strip=1
+
+RUN mkdir -p /go/src/github.com/openshift/ansible-service-broker
+RUN git clone https://github.com/openshift/ansible-service-broker ${BROKER_PATH}/ansible-service-broker
+WORKDIR /go/src/github.com/openshift/ansible-service-broker
+
+RUN go build -ldflags="-s -w" ./cmd/broker
+RUN mv broker /usr/bin/asbd
+######################
+# BUILD BROKER SOURCE
+######################
+
+COPY entrypoint.sh /usr/bin/
+
+RUN chown -R ${USER_NAME}:0 /var/log/ansible-service-broker \
+ && chown -R ${USER_NAME}:0 /etc/ansible-service-broker \
+ && chmod -R g+rw /var/log/ansible-service-broker /etc/ansible-service-broker
+
+USER ${USER_UID}
+RUN sed "s@${USER_NAME}:x:${USER_UID}:@${USER_NAME}:x:\${USER_ID}:@g" /etc/passwd > ${BASE_DIR}/etc/passwd.template
+
+ENTRYPOINT ["entrypoint.sh"]


### PR DESCRIPTION
The docker registry has ability to automatically build containers.
But, the container expects the latest source. We'll use automated-build
to represent the automated build Dockerfile.

Tested this change out here: https://hub.docker.com/r/rthallisey/ansible-service-broker-test-builds/builds/
