### PR TITLE
Only Extract the Credentials once

### DIFF
--- a/pkg/broker/provision_job.go
+++ b/pkg/broker/provision_job.go
@@ -62,19 +62,6 @@ func (p *ProvisionJob) Run(token string, msgBuffer chan<- WorkMsg) {
 	msgBuffer <- ProvisionMsg{InstanceUUID: p.serviceInstance.ID.String(),
 		JobToken: token, SpecID: p.serviceInstance.Spec.ID, PodName: podName, Msg: "", Error: ""}
 
-	// need to get the pod name for the job state
-	extCreds, extErr := apb.ExtractCredentials(podName, p.serviceInstance.Context.Namespace, p.log)
-	if extErr != nil {
-		p.log.Error("broker::Provision extError occurred.")
-		p.log.Error("%s", extErr.Error())
-		// send extError message
-		// can't have an extError type in a struct you want marshalled
-		// https://github.com/golang/go/issues/5161
-		msgBuffer <- ProvisionMsg{InstanceUUID: p.serviceInstance.ID.String(),
-			JobToken: token, SpecID: p.serviceInstance.Spec.ID, PodName: podName, Msg: "", Error: extErr.Error()}
-		return
-	}
-
 	p.log.Info("Destroying APB sandbox...")
 	sm.DestroyApbSandbox(podName, p.serviceInstance.Context.Namespace)
 


### PR DESCRIPTION
When we provision an APB, we create it and extract
the credentials from it. We don't want to make an explicit
call to extract credentials after a provision because the
expectation is that we already have the credentials.