### PR TITLE
Configurable, external broker auth support

### DIFF
--- a/etc/example-config.yaml
+++ b/etc/example-config.yaml
@@ -14,9 +14,9 @@ log:
   level: debug
   color: true
 openshift:
-  target: localhost:8443
-  user: OPENSHIFT_USER
-  pass: OPENSHIFT_PASS
+  host: ""
+  ca_file: ""
+  bearer_token_file: ""
   image_pull_policy: IfNotPresent
 broker:
   dev_broker: true

--- a/pkg/apb/executor.go
+++ b/pkg/apb/executor.go
@@ -14,27 +14,6 @@ import (
 	"k8s.io/kubernetes/pkg/api/v1"
 )
 
-////////////////////////////////////////////////////////////
-// TODO (Erik): Need to refactor to get rid of 80% of the usages
-// of this. It's all over the place and doesn't need to be.
-// Think it's going to turn into the natural place for the
-// configurable svcaccount cert/token location and openshift target
-//
-// I'm planning on submitting a PR to fix this. Yell at me if
-// that hasn't been done. :)
-////////////////////////////////////////////////////////////
-
-// ClusterConfig - DEPRECATED Configuration struct for clusters
-type ClusterConfig struct {
-	InCluster  bool
-	Target     string
-	User       string
-	Password   string `yaml:"pass"`
-	PullPolicy string `yaml:"image_pull_policy"`
-}
-
-////////////////////////////////////////////////////////////
-
 // ExecuteApb - Runs an APB Action with a provided set of inputs
 func ExecuteApb(
 	action string,

--- a/pkg/apb/hack.go
+++ b/pkg/apb/hack.go
@@ -6,14 +6,6 @@ import (
 	"syscall"
 )
 
-// HardcodedClusterConfig - Default cluster config.
-var HardcodedClusterConfig = ClusterConfig{
-	//Target:   "cap.example.com:8443",
-	Target:   "10.1.2.2:8443",
-	User:     "admin",
-	Password: "admin",
-}
-
 // RunCommand - runs a command with the args.
 // HACK: really need a better way to do docker run
 func RunCommand(cmd string, args ...string) ([]byte, error) {

--- a/pkg/apb/types.go
+++ b/pkg/apb/types.go
@@ -80,6 +80,14 @@ type JobState struct {
 	Podname string `json:"podname"`
 }
 
+// ClusterConfig - Configuration for the cluster.
+type ClusterConfig struct {
+	Host            string `yaml:"host"`
+	CAFile          string `yaml:"ca_file"`
+	BearerTokenFile string `yaml:"bearer_token_file"`
+	PullPolicy      string `yaml:"image_pull_policy"`
+}
+
 const (
 	// StateInProgress - In progress job state
 	StateInProgress State = "in progress"

--- a/pkg/app/config.go
+++ b/pkg/app/config.go
@@ -48,9 +48,6 @@ func CreateConfig(configFile string) (Config, error) {
 		return Config{}, err
 	}
 
-	// If no target is provided assume we are inside a cluster
-	config.Openshift.InCluster = config.Openshift.Target == ""
-
 	return config, nil
 }
 

--- a/pkg/broker/broker_test.go
+++ b/pkg/broker/broker_test.go
@@ -1,18 +1,31 @@
 package broker
 
 import (
+	"os"
 	"testing"
 
+	logging "github.com/op/go-logging"
 	"github.com/openshift/ansible-service-broker/pkg/apb"
 	ft "github.com/openshift/ansible-service-broker/pkg/fusortest"
 	"github.com/pborman/uuid"
 )
 
+var log = logging.MustGetLogger("handler")
+
+func init() {
+	colorFormatter := logging.MustStringFormatter(
+		"%{color}[%{time}] [%{level}] %{message}%{color:reset}",
+	)
+	backend := logging.NewLogBackend(os.Stdout, "", 1)
+	backendFormatter := logging.NewBackendFormatter(backend, colorFormatter)
+	logging.SetBackend(backend, backendFormatter)
+}
+
 func TestUpdate(t *testing.T) {
 	brokerConfig := new(Config)
 	brokerConfig.DevBroker = true
 	brokerConfig.LaunchApbOnBind = false
-	broker, _ := NewAnsibleBroker(nil, nil, apb.ClusterConfig{}, nil, WorkEngine{}, *brokerConfig)
+	broker, _ := NewAnsibleBroker(nil, log, apb.ClusterConfig{}, nil, WorkEngine{}, *brokerConfig)
 	resp, err := broker.Update(uuid.NewUUID(), nil)
 	if resp != nil {
 		t.Fail()

--- a/scripts/my_local_dev_vars.example
+++ b/scripts/my_local_dev_vars.example
@@ -15,6 +15,9 @@ DOCKERHUB_USERNAME=""
 DOCKERHUB_PASSWORD=""
 DOCKERHUB_ORG="ansibleplaybookbundle"
 
+BEARER_TOKEN_FILE=""
+CA_FILE=""
+
 # Always, IfNotPresent, Never
 IMAGE_PULL_POLICY="Always"
 

--- a/scripts/prep_local_devel_env.sh
+++ b/scripts/prep_local_devel_env.sh
@@ -167,6 +167,9 @@ log:
   level: debug
   color: true
 openshift:
+  host: ${OPENSHIFT_SERVER_HOST}
+  bearer_token_file: ${BEARER_TOKEN_FILE}
+  ca_file: ${CA_FILE}
   image_pull_policy: ${IMAGE_PULL_POLICY}
 broker:
   dev_broker: true

--- a/scripts/prep_local_devel_env.sh
+++ b/scripts/prep_local_devel_env.sh
@@ -168,8 +168,8 @@ log:
   color: true
 openshift:
   host: ${OPENSHIFT_SERVER_HOST}
-  bearer_token_file: ${BEARER_TOKEN_FILE}
-  ca_file: ${CA_FILE}
+  bearer_token_file:${BEARER_TOKEN_FILE}
+  ca_file:${CA_FILE}
   image_pull_policy: ${IMAGE_PULL_POLICY}
 broker:
   dev_broker: true

--- a/templates/deploy-ansible-service-broker.template.yaml
+++ b/templates/deploy-ansible-service-broker.template.yaml
@@ -198,6 +198,9 @@ objects:
         level: debug
         color: true
       openshift:
+        host: ${CLUSTER_AUTH_HOST}
+        ca_file: ${CA_FILE}
+        bearer_token_file: ${BEARER_TOKEN_FILE}
         image_pull_policy: ${IMAGE_PULL_POLICY}
       broker:
         dev_broker: ${DEV_BROKER}
@@ -290,3 +293,25 @@ parameters:
   displayname: APB ImagePullPolicy
   name: IMAGE_PULL_POLICY
   value: "IfNotPresent"
+
+############################################################
+# NOTE: Default behavior for these are going to use the kubernetes
+# InClusterConfig. These are typically overridden for running
+# the broker outside of a cluster. Under normal circumstances,
+# you probably want to leave these blank.
+############################################################
+- description: Service Account CAFile Path
+  displayname: Service Account CAFile Path
+  name: CA_FILE
+  value: ""
+
+- description: Service Account Bearer Token File
+  displayname: Service Account Bearer Token File
+  name: BEARER_TOKEN_FILE
+  value: ""
+
+- description: Cluster Authentication Host
+  displayname: Cluster Authentication Host
+  name: CLUSTER_AUTH_HOST
+  value: ""
+############################################################


### PR DESCRIPTION
Allows for configuration to tell the broker where to find the cluster host, CAFile, and BearerTokenFile. Good example for how to retrieve these manually can be found in the `prep_local_devel_env.sh`.

## Test
1) Run catasb local once, creates prereqs for `prep_local_devel_env.sh`.
2) Run `prep_local_devel_env.sh`, should export CAFile and token files to `/var/run/secrets/kubernetes.io/serviceaccount`.
3) Edit generated configuration file in $YOUR_CHECKOUT/etc/generated_local_development.yaml. Make sure host is your openshift host (https://172.17.0.1:8443 for me) and ca_file/bearer_token_file both point to exported files from the prep script.
4) Run `./broker -c ./etc/generated_local_development.yaml`
5) **Confirm in broker logs successful, secure login**
6) Shut down broker. Set ca_file field to "". This should trigger an insecure local login.
7) Run `./broker -c ./etc/generated_local_development.yaml`
8) **Confirm in broker logs successful, insecure login**
9) Shut down broker, set host, ca_file, and bearer_token_file to empty strings "". Should trigger an InCluster login.
10) Run `./broker -c ./etc/generated_local_development.yaml`
11) **Confirm failed login. Broker should not be able to InCluster auth outside of the cluster**
12) Rebuild broker image from source, configure catasb to deploy new custom image.
13) **reset catasb, confirm your new image was actually deployed and pod logs read successful login. This is InCluster auth correctly using k8s values**