### PR TITLE
technical debt: make scripts run from anywhere

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,10 +20,10 @@ build: broker
 	@echo > /dev/null
 
 run: broker | $(KUBERNETES_FILES)
-	@cd scripts && ./run_local.sh ${BROKER_CONFIG}
+	@./scripts/run_local.sh ${BROKER_CONFIG}
 
 $(KUBERNETES_FILES):
-	@cd scripts && ./prep_local_devel_env.sh
+	@./scripts/prep_local_devel_env.sh
 
 prepare-local-env: $(KUBERNETES_FILES)
 	@echo > /dev/null
@@ -51,8 +51,11 @@ clean:
 	@rm -f broker
 	@rm -f build/broker
 
+really-clean: clean
+	@rm -f $(KUBERNETES_FILES)
+
 deploy:
-	@${GOPATH}/src/github.com/openshift/ansible-service-broker/scripts/deploy.sh ${BROKER_IMAGE}:${TAG} ${REGISTRY} ${ORG}
+	@./scripts/deploy.sh ${BROKER_IMAGE}:${TAG} ${REGISTRY} ${ORG}
 
 test:
 	go test ./pkg/...

--- a/scripts/my_local_dev_vars.example
+++ b/scripts/my_local_dev_vars.example
@@ -20,6 +20,3 @@ CA_FILE=""
 
 # Always, IfNotPresent, Never
 IMAGE_PULL_POLICY="Always"
-
-BROKER_CMD="../broker"
-GENERATED_BROKER_CONFIG="../etc/generated_local_development.yaml"

--- a/scripts/prep_local_devel_env.sh
+++ b/scripts/prep_local_devel_env.sh
@@ -12,8 +12,15 @@
 # - Get existing secret for the asb service account and store ca cert/token
 #
 ###
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+PROJECT_ROOT=${SCRIPT_DIR}/..
+TEMPLATE_DIR="${PROJECT_ROOT}/templates"
 
-MY_VARS="./my_local_dev_vars"
+# sane defaults, can be overridden in my_vars
+GENERATED_BROKER_CONFIG=${PROJECT_ROOT}/etc/generated_local_development.yaml
+
+# process myvars
+MY_VARS="${SCRIPT_DIR}/my_local_dev_vars"
 if [ ! -f $MY_VARS ]; then
   echo "Please create $MY_VARS"
   echo "cp $MY_VARS.example $MY_VARS"
@@ -21,14 +28,13 @@ if [ ! -f $MY_VARS ]; then
   exit 1
 fi
 
-source ./my_local_dev_vars
+source ${MY_VARS}
 if [ "$?" -ne "0" ]; then
   echo "Error reading in my_local_dev_var"
   exit 1
 fi
 
-
-TEMPLATE_LOCAL_DEV="../templates/deploy-local-dev-changes.yaml"
+TEMPLATE_LOCAL_DEV="${TEMPLATE_DIR}/deploy-local-dev-changes.yaml"
 ASB_PROJECT="ansible-service-broker"
 BROKER_SVC_ACCT_NAME="asb"
 BROKER_SVC_ACCT="system:serviceaccount:${ASB_PROJECT}:${BROKER_SVC_ACCT_NAME}"

--- a/scripts/run_local.sh
+++ b/scripts/run_local.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
-MY_VARS="./my_local_dev_vars"
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+PROJECT_ROOT=${SCRIPT_DIR}/..
+
+# sane defaults, can be overridden in my_vars
+BROKER_CMD=${PROJECT_ROOT}/broker
+GENERATED_BROKER_CONFIG=${PROJECT_ROOT}/etc/generated_local_development.yaml
+
+MY_VARS="${SCRIPT_DIR}/my_local_dev_vars"
 if [ ! -f $MY_VARS ]; then
   echo "Please create $MY_VARS"
   echo "cp $MY_VARS.example $MY_VARS"
@@ -7,7 +14,7 @@ if [ ! -f $MY_VARS ]; then
   exit 1
 fi
 
-source ./${MY_VARS}
+source ${MY_VARS}
 if [ "$?" -ne "0" ]; then
   echo "Error reading in ${MY_VARS}"
   exit 1


### PR DESCRIPTION
The prep_local_devel_env.sh and run_local.sh scripts would only run from inside scripts directory. You can now run them from the project root: `./scripts/run_local.sh`.