### PR TITLE
1469401 - Print out error messages only once

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -33,10 +33,7 @@ func CreateApp() App {
 
 	// Writing directly to stderr because log has not been bootstrapped
 	if app.args, err = CreateArgs(); err != nil {
-		os.Stderr.WriteString("ERROR: Failed to validate input\n")
-		os.Stderr.WriteString(err.Error() + "\n")
-		ArgsUsage()
-		os.Exit(127)
+		os.Exit(1)
 	}
 
 	if app.args.Version {
@@ -50,7 +47,7 @@ func CreateApp() App {
 
 	if app.config, err = CreateConfig(app.args.ConfigFile); err != nil {
 		os.Stderr.WriteString("ERROR: Failed to read config file\n")
-		os.Stderr.WriteString(err.Error())
+		os.Stderr.WriteString(err.Error() + "\n")
 		os.Exit(1)
 	}
 

--- a/pkg/app/args.go
+++ b/pkg/app/args.go
@@ -1,9 +1,6 @@
 package app
 
 import (
-	"errors"
-	"fmt"
-
 	flags "github.com/jessevdk/go-flags"
 )
 
@@ -20,24 +17,5 @@ func CreateArgs() (Args, error) {
 		return args, err
 	}
 
-	err = validateArgs(&args)
-	if err != nil {
-		return args, err
-	}
-
 	return args, nil
-}
-
-func validateArgs(args *Args) error {
-	var err error
-	if args.ConfigFile == "" {
-		err = errors.New("must provide a config file location with -c, or --config")
-	}
-
-	return err
-}
-
-func ArgsUsage() {
-	// TODO
-	fmt.Println("USAGE: To be implemented...")
 }


### PR DESCRIPTION
We are printing error messages and the help menu
twice. Also, clean up some unused options.

Closes-bz1469401