### PR TITLE
Only print out error messages only once

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -39,10 +39,7 @@ func CreateApp() App {
 
 	// Writing directly to stderr because log has not been bootstrapped
 	if app.args, err = CreateArgs(); err != nil {
-		os.Stderr.WriteString("ERROR: Failed to validate input\n")
-		os.Stderr.WriteString(err.Error() + "\n")
-		ArgsUsage()
-		os.Exit(127)
+		os.Exit(1)
 	}
 
 	if app.args.Version {
@@ -58,7 +55,7 @@ func CreateApp() App {
 	// pkg.
 	if app.config, err = CreateConfig(app.args.ConfigFile); err != nil {
 		os.Stderr.WriteString("ERROR: Failed to read config file\n")
-		os.Stderr.WriteString(err.Error())
+		os.Stderr.WriteString(err.Error() + "\n")
 		os.Exit(1)
 	}
 

--- a/pkg/app/args.go
+++ b/pkg/app/args.go
@@ -1,8 +1,6 @@
 package app
 
 import (
-	"fmt"
-
 	flags "github.com/jessevdk/go-flags"
 )
 
@@ -21,10 +19,4 @@ func CreateArgs() (Args, error) {
 		return args, err
 	}
 	return args, nil
-}
-
-// ArgsUsage - Will  print the usuage of the arguments.
-func ArgsUsage() {
-	// TODO
-	fmt.Println("USAGE: To be implemented...")
 }


### PR DESCRIPTION
We are printing error messages and the help menu
twice. Also, clean up some unused options

Cherry-pick  #264 from release-0.9