### PR TITLE
Improve the broker bind output by using error returned from RunCommand

### DIFF
--- a/pkg/apb/bind_test.go
+++ b/pkg/apb/bind_test.go
@@ -21,7 +21,7 @@ changed: [localhost]
 
 TASK [debug] *******************************************************************
 ok: [localhost] => {
-    "msg": "<BIND_CREDENTIALS>eyJkYiI6ICJmdXNvcl9ndWVzdGJvb2tfZGIiLCAidXNlciI6ICJkdWRlcl90d28iLCAicGFzcyI6ICJkb2c4dHdvIn0=</BIND_CREDENTIALS>"
+    "msg": "eyJkYiI6ICJmdXNvcl9ndWVzdGJvb2tfZGIiLCAidXNlciI6ICJkdWRlcl90d28iLCAicGFzcyI6ICJkb2c4dHdvIn0="
 }
 
 PLAY RECAP *********************************************************************

--- a/pkg/apb/ext_creds.go
+++ b/pkg/apb/ext_creds.go
@@ -38,8 +38,8 @@ func monitorOutput(namespace string, podname string, log *logging.Logger) ([]byt
 	for r := 1; r <= credentialExtRetries; r++ {
 		// err will be the return code from the exec command
 		// Use the error code to deterine the state
-		FailedToExec := errors.New("exit status 1")
-		CredsNotAvailable := errors.New("exit status 2")
+		failedToExec := errors.New("exit status 1")
+		credsNotAvailable := errors.New("exit status 2")
 
 		output, err := RunCommand("oc", "exec", podname, gatherCredentialsCMD, "--namespace="+namespace)
 		podCompleted := strings.Contains(string(output), "current phase is Succeeded") ||
@@ -48,13 +48,13 @@ func monitorOutput(namespace string, podname string, log *logging.Logger) ([]byt
 		if err == nil {
 			log.Notice("[%s] Bind credentials found", podname)
 			return output, nil
-		} else if podCompleted && err.Error() == FailedToExec.Error() {
+		} else if podCompleted && err.Error() == failedToExec.Error() {
 			log.Notice("[%s] APB completed", podname)
 			return nil, nil
-		} else if err.Error() == FailedToExec.Error() {
+		} else if err.Error() == failedToExec.Error() {
 			log.Info(string(output))
 			log.Warning("[%s] Retry attempt %d: Failed to exec into the container", podname, r)
-		} else if err.Error() == CredsNotAvailable.Error() {
+		} else if err.Error() == credsNotAvailable.Error() {
 			log.Info(string(output))
 			log.Warning("[%s] Retry attempt %d: Bind credentials not availble yet", podname, r)
 		} else {

--- a/pkg/apb/ext_creds.go
+++ b/pkg/apb/ext_creds.go
@@ -36,29 +36,30 @@ func monitorOutput(namespace string, podname string, log *logging.Logger) ([]byt
 	// instead of only getting the credentials
 
 	for r := 1; r <= credentialExtRetries; r++ {
-		output, err := RunCommand("oc", "exec", podname, gatherCredentialsCMD, "--namespace="+namespace)
-		if err != nil {
-			// Since we combine stderr and stdout in RunCommand, log
-			// output of RunCommand as Info
-			log.Info(err.Error())
-		}
+		// err will be the return code from the exec command
+		// Use the error code to deterine the state
+		FailedToExec := errors.New("exit status 1")
+		CredsNotAvailable := errors.New("exit status 2")
 
-		stillWaiting := strings.Contains(string(output), "ContainerCreating") ||
-			strings.Contains(string(output), "NotFound") ||
-			strings.Contains(string(output), "container not found")
+		output, err := RunCommand("oc", "exec", podname, gatherCredentialsCMD, "--namespace="+namespace)
 		podCompleted := strings.Contains(string(output), "current phase is Succeeded") ||
 			strings.Contains(string(output), "cannot exec into a container in a completed pod")
 
-		// TODO: Replace the string parsing by passing around the pod
-		// object and checking its status
-		if stillWaiting {
-			log.Info("[%s] Retry attempt %d: Waiting for container to start", podname, r)
-		} else if podCompleted {
-			log.Notice("[%s] APB completed", podname)
-			return nil, nil
-		} else if strings.Contains(string(output), "BIND_CREDENTIALS") {
+		if err == nil {
 			log.Notice("[%s] Bind credentials found", podname)
 			return output, nil
+		} else if podCompleted && err.Error() == FailedToExec.Error() {
+			log.Notice("[%s] APB completed", podname)
+			return nil, nil
+		} else if err.Error() == FailedToExec.Error() {
+			log.Info(string(output))
+			log.Warning("[%s] Retry attempt %d: Failed to exec into the container", podname, r)
+		} else if err.Error() == CredsNotAvailable.Error() {
+			log.Info(string(output))
+			log.Warning("[%s] Retry attempt %d: Bind credentials not availble yet", podname, r)
+		} else {
+			log.Info(string(output))
+			log.Warning("[%s] Retry attempt %d: Failed to exec into the container", podname, r)
 		}
 
 		log.Warning("[%s] Retry attempt %d: exec into %s failed", podname, r, podname)
@@ -83,42 +84,14 @@ func buildExtractedCredentials(output []byte) (*ExtractedCredentials, error) {
 }
 
 func decodeOutput(output []byte) (map[string]string, error) {
-	// Possible return states
-	// 1) nil, nil -> No credentials found, no errors occurred. Valid.
-	// 2) creds, nil -> Credentials found, no errors occurred. Valid.
-	// 3) nil, err -> Credentials found, no errors occurred. Error state.
 	str := string(output)
 
-	startIdx := strings.Index(str, "<BIND_CREDENTIALS>")
-	startOffset := startIdx + len("<BIND_CREDENTIALS>")
-	endIdx := strings.Index(str, "</BIND_CREDENTIALS>")
-
-	if startIdx < 0 || endIdx < 0 {
-		startIdx = strings.Index(str, "<BIND_ERROR>")
-		startOffset := startIdx + len("<BIND_ERROR>")
-		endIdx := strings.Index(str, "</BIND_ERROR>")
-		if startIdx > -1 && endIdx > -1 {
-			// Case 3, error reported
-			return nil, errors.New(str[startOffset:endIdx])
-		}
-
-		if strings.Contains(str, "image can't be pulled") {
-			return nil, errors.New("image can't be pulled")
-		} else if strings.Contains(str, "FAILED! =>") {
-			return nil, errors.New("provision failed, INSERT MESSAGE HERE")
-		} else {
-			// Case 1, no creds found, no errors occurred
-			return nil, nil
-		}
-	}
-
-	decodedjson, err := base64.StdEncoding.DecodeString(str[startOffset:endIdx])
+	decodedjson, err := base64.StdEncoding.DecodeString(str)
 	if err != nil {
 		return nil, err
 	}
 
 	decoded := make(map[string]string)
 	json.Unmarshal(decodedjson, &decoded)
-	// Case 2, creds successfully found and decoded
 	return decoded, nil
 }

--- a/pkg/apb/ext_creds_test.go
+++ b/pkg/apb/ext_creds_test.go
@@ -7,124 +7,9 @@ import (
 	ft "github.com/openshift/ansible-service-broker/pkg/fusortest"
 )
 
-func TestDecodeOutput(t *testing.T) {
-	output := []byte(`
-Login failed (401 Unauthorized)
-
-PLAY [all] *********************************************************************
-
-TASK [setup] *******************************************************************
-ok: [localhost]
-
-TASK [Bind] ********************************************************************
-changed: [localhost]
-
-TASK [debug] *******************************************************************
-ok: [localhost] => {
-    "msg": "<BIND_CREDENTIALS>eyJkYiI6ICJmdXNvcl9ndWVzdGJvb2tfZGIiLCAidXNlciI6ICJkdWRlcl90d28iLCAicGFzcyI6ICJkb2c4dHdvIn0=</BIND_CREDENTIALS>"
-}
-
-PLAY RECAP *********************************************************************
-localhost                  : ok=3    changed=1    unreachable=0    failed=0
-`)
-	result, err := decodeOutput(output)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	ft.AssertNotNil(t, result, "result")
-	ft.AssertEqual(t, result["db"], "fusor_guestbook_db", "db is not fusor_guestbook_db")
-	ft.AssertEqual(t, result["user"], "duder_two", "user is not duder_two")
-	ft.AssertEqual(t, result["pass"], "dog8two", "password is not dog8two")
-}
-
-func TestImageCantbePulled(t *testing.T) {
-	output := []byte(`
-Error from server (BadRequest): container "aa-425ef090-5f6f-4a0a-87ed-b072881d944d" in pod "aa-425ef090-5f6f-4a0a-87ed
--b072881d944d" is waiting to start: image can't be pulled
-`)
-	result, err := decodeOutput(output)
-	if err == nil {
-		t.Fatal("decode should've returned an error")
-	}
-
-	if result != nil {
-		t.Fatal("result should've been nil")
-	}
-
-	assertError(t, err, "image can't be pulled")
-}
-
-func TestFailedMessageDecodeOutput(t *testing.T) {
-	output := []byte(`
-PLAY [Deploy rds-apb to openshift] *********************************************
-TASK [setup] *******************************************************************
-ok: [localhost]
-TASK [rds-apb-openshift : set_fact] ********************************************
-ok: [localhost]
-TASK [rds-apb-openshift : rds] *************************************************
-fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "msg": "Region not specified. Unable to determine re
-gion from EC2_REGION."}
-        to retry, use: --limit @/opt/ansibleapp/actions/provision.retry
-PLAY RECAP *********************************************************************
-localhost                  : ok=2    changed=0    unreachable=0    failed=1
-`)
-	result, err := decodeOutput(output)
-	if err == nil {
-		t.Fatal("decode should've returned an error")
-	}
-
-	if result != nil {
-		t.Fatal("result should've been nil")
-	}
-	assertError(t, err, "provision failed, INSERT MESSAGE HERE")
-	// need to better parse the FAILED json returned.
-}
-
-func TestBuildExtractedCredentialsError(t *testing.T) {
-	output := []byte(`
-Login failed (401 Unauthorized)
-
-PLAY [all] *********************************************************************
-
-TASK [setup] *******************************************************************
-ok: [localhost]
-
-TASK [Bind] ********************************************************************
-changed: [localhost]
-
-TASK [debug] *******************************************************************
-ok: [localhost] => {
-    "msg": "<BIND_CREDENTIALS>eyJkYiI6ICJmdXNvcl9ndWVzdGJvb2tfZGIiLCAidXNlciI6ICJkdWRlcl90d28iLCAicGFzcyI6ICJkb2c4dHdvIn0="
-}
-
-PLAY RECAP *********************************************************************
-localhost                  : ok=3    changed=1    unreachable=0    failed=0
-`)
-	bd, _ := buildExtractedCredentials(output)
-	ft.AssertNotNil(t, bd, "credential is nil")
-}
-
 func TestBuildExtractedCredentials(t *testing.T) {
-	output := []byte(`
-Login failed (401 Unauthorized)
+	output := []byte("eyJkYiI6ICJmdXNvcl9ndWVzdGJvb2tfZGIiLCAidXNlciI6ICJkdWRlcl90d28iLCAicGFzcyI6ICJkb2c4dHdvIn0=")
 
-PLAY [all] *********************************************************************
-
-TASK [setup] *******************************************************************
-ok: [localhost]
-
-TASK [Bind] ********************************************************************
-changed: [localhost]
-
-TASK [debug] *******************************************************************
-ok: [localhost] => {
-    "msg": "<BIND_CREDENTIALS>eyJkYiI6ICJmdXNvcl9ndWVzdGJvb2tfZGIiLCAidXNlciI6ICJkdWRlcl90d28iLCAicGFzcyI6ICJkb2c4dHdvIn0=</BIND_CREDENTIALS>"
-}
-
-PLAY RECAP *********************************************************************
-localhost                  : ok=3    changed=1    unreachable=0    failed=0
-`)
 	bd, _ := buildExtractedCredentials(output)
 	ft.AssertNotNil(t, bd, "credential is nil")
 	ft.AssertEqual(t, bd.Credentials["db"], "fusor_guestbook_db", "db is not fusor_guestbook_db")
@@ -132,70 +17,11 @@ localhost                  : ok=3    changed=1    unreachable=0    failed=0
 	ft.AssertEqual(t, bd.Credentials["pass"], "dog8two", "password is not dog8two")
 }
 
-func TestErrorDecodeOutput(t *testing.T) {
-	output := []byte(`
-	error: dial tcp [::1]:8443: getsockopt: connection refused
-
-PLAY [all] *********************************************************************
-
-TASK [setup] *******************************************************************
-ok: [localhost]
-
-TASK [Bind] ********************************************************************
-fatal: [localhost]: FAILED! => {"changed": true, "cmd": "./bind", "delta": "0:00:00.115091", "end": "2017-03-13 14:55:28.434412", "failed": true, "rc": 1, "start": "2017-03-13 14:55:28.319321", "stderr": "", "stdout": "<BIND_ERROR>Malformed parameter input</BIND_ERROR>", "stdout_lines": ["<BIND_ERROR>Malformed parameter input</BIND_ERROR>"], "warnings": []}
-        to retry, use: --limit @/opt/apb/actions/bind.retry
-
-PLAY RECAP *********************************************************************
-localhost                  : ok=1    changed=0    unreachable=0    failed=1
-`)
-	_, err := decodeOutput(output)
-	assertError(t, err, "Malformed parameter input")
-}
-
 func TestExitGracefully(t *testing.T) {
-	output := []byte(`
-	error: dial tcp [::1]:8443: getsockopt: connection refused
+	output := []byte("eyJkYiI6ICJmdXNvcl9ndWVzdGJvb2tfZGIiLCAidXNlciI6ICJkdWRlcl90d28iLCAicGFzcyI6ICJkb2c4dHdvIn0=")
 
-PLAY [all] *********************************************************************
-`)
 	_, err := decodeOutput(output)
 	ft.AssertEqual(t, err, nil)
-}
-
-func TestHandleOpenErrorBracket(t *testing.T) {
-	t.Skip("REVISIT when monitoring output is redone")
-	output := []byte(`
-TASK [Bind] ******************<BIND_ERROR>**************************************
-`)
-	_, err := decodeOutput(output)
-	assertError(t, err, "Unable to parse output")
-}
-
-func TestHandleOpenCredentialsBracket(t *testing.T) {
-	t.Skip("REVISIT when monitoring output is redone")
-	output := []byte(`
-TASK [Bind] ******************<BIND_CREDENTIALS>**************************************
-`)
-	_, err := decodeOutput(output)
-	assertError(t, err, "Unable to parse output")
-}
-
-func TestHandleCloseCredsBrackets(t *testing.T) {
-	t.Skip("REVISIT when monitoring output is redone")
-	output := []byte(`
-TASK [Bind] ******************</BIND_CREDENTIALS>**************************************
-`)
-	_, err := decodeOutput(output)
-	assertError(t, err, "Unable to parse output")
-}
-
-func TestHandleCloseErrorBrackets(t *testing.T) {
-	t.Skip("REVISIT when monitoring output is redone")
-	output := []byte(`
-TASK [Bind] ******************</BIND_ERROR>**************************************
-`)
-	_, err := decodeOutput(output)
-	assertError(t, err, "Unable to parse output")
 }
 
 // didn't think this was generic enough to go in ft.

--- a/pkg/apb/types.go
+++ b/pkg/apb/types.go
@@ -53,7 +53,6 @@ type Context struct {
 // ExtractedCredentials - Credentials that are extracted from the pods
 type ExtractedCredentials struct {
 	Credentials map[string]interface{} `json:"credentials,omitempty"`
-	// might be more one day
 }
 
 // State - Job State


### PR DESCRIPTION
We can predict the error code returned from RunCommand and use
it to gather bind credentials.

depends-on: https://github.com/fusor/apb-examples/issues/34