### PR TITLE
Increase bind timeout to 30minutes

### DIFF
--- a/pkg/apb/types.go
+++ b/pkg/apb/types.go
@@ -88,9 +88,9 @@ const (
 	ApbRole = "cluster-admin"
 
 	// Bind credential gathering constants
-	// 5 seconds x 60 retries = 5 minute timout
+	// 5 seconds x 7200 retries = 2 hour timeout
 	credentialExtInterval = 5
-	credentialExtRetries  = 60
+	credentialExtRetries  = 7200
 	gatherCredentialsCMD  = "broker-bind-creds"
 )
 


### PR DESCRIPTION
Longer running apps need a longer timeout. This timeout isn't just
for bind. It's the timeout of an apb so it needs to be higher.