### PR TITLE
Remove bogus selinux requires in rpm spec

### DIFF
--- a/ansible-service-broker.spec
+++ b/ansible-service-broker.spec
@@ -73,7 +73,6 @@ containers scripts for ansible-service-broker
 Summary: selinux policy module for %{name}
 BuildRequires: checkpolicy, selinux-policy-devel, hardlink, policycoreutils
 BuildRequires: /usr/bin/pod2man
-Requires: selinux-policy >= %{selinux_policy_ver}
 Requires(post): /usr/sbin/semodule, /sbin/restorecon, /usr/sbin/setsebool, /usr/sbin/selinuxenabled, /usr/sbin/semanage
 Requires(post): policycoreutils-python
 Requires(post): selinux-policy-targeted


### PR DESCRIPTION
This does not evaluate properly, besides which selinux-policy is a dependency of selinux-policy-targeted, which is already a requires.