### PR TITLE
Add a PR and Issues template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,10 @@
+**This form is for bug reports and feature requests. Major features will go through a [spec process](https://github.com/openshift/ansible-service-broker/blob/master/CONTRIBUTING.md).**
+
+> # Feature:
+> # Bug:
+
+**What happened**:
+
+**What you expected to happen**:
+
+**How to reproduce it**:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+**Describe what this PR does and why we need it**:
+
+Changes proposed in this pull request
+ -
+ -
+ -
+
+**Does this PR depend on another PR (Use this to track when PRs should be merged)**
+depends-on <PR>
+
+**Which issue this PR fixes (This will close that issue when PR gets merged)**
+fixes <issue_number>


### PR DESCRIPTION
The PR and Issues template will help guide a developer when
create a new PR or issue. This will help organize the git repo
so the community can review PRs and fix bugs  faster.