### PR TITLE
get both tls.key AND tls.crt not two tls.keys

### DIFF
--- a/scripts/prep_local_devel_env.sh
+++ b/scripts/prep_local_devel_env.sh
@@ -113,7 +113,7 @@ echo -e "Wrote \n${BROKER_SVC_ACCT_TOKEN}\n to: ${SVC_ACCT_TOKEN_FILE}\n"
 ###
 # Fetch the tls.crt for the asb deployment
 ###
-TLS_CRT_DATA=`oc get secret asb-tls -o jsonpath='{ .data.tls\.key }'`
+TLS_CRT_DATA=`oc get secret asb-tls -o jsonpath='{ .data.tls\.crt }'`
 # Remove quotes from variable
 TLS_CRT_DATA=( $(eval echo ${TLS_CRT_DATA[@]}) )
 # Base64 Decode


### PR DESCRIPTION
I had an oversight when I reviewed PR 305. The change from using jq to jsonpath also introduced this bug where we stopped looking at the tls.crt which is actually quite important