### PR TITLE
fusor test will now print out details on the actual file

### DIFF
--- a/pkg/fusortest/util.go
+++ b/pkg/fusortest/util.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -107,7 +109,8 @@ func fail(t *testing.T, a interface{}, b interface{}, message string) {
 	if len(message) == 0 {
 		message = fmt.Sprintf("%v != %v", a, b)
 	}
-	t.Fatal(message)
+	_, file, line, _ := runtime.Caller(3)
+	t.Fatal(fmt.Sprintf("\n%v had error on line %v\nMessage: %v", file[strings.LastIndex(file, "/")+1:], line, message))
 }
 
 // AssertEqual - Assert that inputs are equivalent.


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
Will determine the actual file that caused the issues and print that out during the test run.
Allows user's to more easily see the tests that were broken. and example out put is
```
--- FAIL: TestRegistryLoadSpecsNoError (0.00s)
        util.go:113:
                registry_test.go had error on line 165
                Message: 1 != 2
```

Changes proposed in this pull request
 - get the actual caller of the fusor test method
   - 3 callers up, 0 -> call to Callers, 1 -> call to unexported ```fail``` 2 -> call to  unexported ```assert```, 3 -> call to the public ```AssertXXXX``` method.

**Does this PR depend on another PR (Use this to track when PRs should be merged)**
depends-on <PR>
No
**Which issue this PR fixes (This will close that issue when PR gets merged)**
fixes #320 