### PR TITLE
remove trailing slash

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -17,7 +17,7 @@ RUN mkdir -p ${BASE_DIR} ${BASE_DIR}/etc /var/run/asb-auth \
  && userdel ansibleservicebroker \
  && useradd -u ${USER_UID} -r -g 0 -M -d ${BASE_DIR} -b ${BASE_DIR} -s /sbin/nologin -c "ansibleservicebroker user" ${USER_NAME} \
  && chown -R ${USER_NAME}:0 ${BASE_DIR} /var/log/ansible-service-broker /etc/ansible-service-broker /var/run/asb-auth \
- && chmod -R g+rw ${BASE_DIR} /etc/passwd /etc/ansible-service-broker /var/log/ansible-service-broker /var/run/asb-auth \
+ && chmod -R g+rw ${BASE_DIR} /etc/passwd /etc/ansible-service-broker /var/log/ansible-service-broker /var/run/asb-auth
 
 
 USER ${USER_UID}


### PR DESCRIPTION
Fix the trailing slash error during auto builds of RPM containers. This problem was introduced by the auth PR.
