### PR TITLE
Add an insecure option to the openshift template

### DIFF
--- a/build/entrypoint.sh
+++ b/build/entrypoint.sh
@@ -10,11 +10,14 @@ if [[ -z "$BROKER_CONFIG" ]] ; then
   exit 1
 fi
 
-
 if [ ! -f "$BROKER_CONFIG" ] ; then
   echo "No config file mounted to $BROKER_CONFIG"
   exit 1
 fi
 echo "Using config file mounted to $BROKER_CONFIG"
 
-asbd -c $BROKER_CONFIG
+if ${INSECURE}; then
+    FLAGS+=" --insecure"
+fi
+
+asbd -c $BROKER_CONFIG $FLAGS

--- a/templates/deploy-ansible-service-broker.template.yaml
+++ b/templates/deploy-ansible-service-broker.template.yaml
@@ -104,7 +104,7 @@ objects:
           env:
           - name: BROKER_CONFIG
             value: ${BROKER_CONFIG}
-          - name: INSCURE
+          - name: INSECURE
             value: ${INSECURE}
           resources: {}
           terminationMessagePath: /tmp/termination-log

--- a/templates/deploy-ansible-service-broker.template.yaml
+++ b/templates/deploy-ansible-service-broker.template.yaml
@@ -53,7 +53,7 @@ objects:
     port:
       targetPort: port-1338
     tls:
-      termination: Reencrypt
+      termination: ${TERMINATION}
 
 - apiVersion: v1
   kind: PersistentVolumeClaim
@@ -104,6 +104,8 @@ objects:
           env:
           - name: BROKER_CONFIG
             value: ${BROKER_CONFIG}
+          - name: INSCURE
+            value: ${INSECURE}
           resources: {}
           terminationMessagePath: /tmp/termination-log
 
@@ -214,6 +216,18 @@ parameters:
   displayname: Ansible Service Broker Configuration File
   name: BROKER_CONFIG
   value: /etc/ansible-service-broker/config.yaml
+
+# SSL enabled: INSECURE="false", TERMINATION=Reencrypt
+# Insecure enabled: INSECURE="true", TERMINATION=edge
+- description: Run in insecure mode
+  displayname: Ansible Service Broker Insecure
+  name: INSECURE
+  value: "false"
+
+- description: Secure the route with TLS
+  displayname: Ansible Service Broker Termination
+  name: TERMINATION
+  value: Reencrypt
 
 - description: Dockerhub user password
   displayname: Dockerhub user password


### PR DESCRIPTION
Running the broker in insecure mode from the template should
only require changing a few settings.

Changes proposed in this pull request
 - Option to run the broker as insecure from the openshift template

fixes https://github.com/openshift/ansible-service-broker/issues/333
