### PR TITLE
Handle err when generating Dockerhub token

### DIFF
--- a/pkg/registries/adapters/dockerhub_adapter.go
+++ b/pkg/registries/adapters/dockerhub_adapter.go
@@ -49,7 +49,7 @@ func (r DockerHubAdapter) GetImageNames() ([]string, error) {
 
 	token, err := r.getDockerHubToken()
 	if err != nil {
-		r.Log.Error("unable to generate docker hub token")
+		r.Log.Errorf("unable to generate docker hub token - %v", err)
 		return nil, err
 	}
 
@@ -82,7 +82,7 @@ func (r DockerHubAdapter) GetImageNames() ([]string, error) {
 	}
 	// check to see if the context had an error
 	if ctx.Err() != nil {
-		r.Log.Error("encountered an error while loading images, we may not have all the apb in the catalog - %v", ctx.Err())
+		r.Log.Errorf("encountered an error while loading images, we may not have all the apb in the catalog - %v", ctx.Err())
 		return apbData, ctx.Err()
 	}
 

--- a/pkg/registries/adapters/dockerhub_adapter.go
+++ b/pkg/registries/adapters/dockerhub_adapter.go
@@ -48,6 +48,10 @@ func (r DockerHubAdapter) GetImageNames() ([]string, error) {
 	r.Log.Debug("Loading image list for org: [ %s ]", r.Config.Org)
 
 	token, err := r.getDockerHubToken()
+	if err != nil {
+		r.Log.Error("unable to generate docker hub token")
+		return nil, err
+	}
 
 	channel := make(chan string)
 	ctx, cancelFunc := context.WithCancel(context.Background())

--- a/pkg/registries/adapters/dockerhub_adapter_test.go
+++ b/pkg/registries/adapters/dockerhub_adapter_test.go
@@ -7,5 +7,6 @@ import (
 )
 
 func TestDockerhubName(t *testing.T) {
-	ft.AssertEqual(t, dockerhubName, "docker.io", "dockerhub name does not match docker.io")
+	dha := DockerHubAdapter{}
+	ft.AssertEqual(t, dha.RegistryName(), "docker.io", "dockerhub name does not match docker.io")
 }

--- a/pkg/registries/adapters/dockerhub_adapter_test.go
+++ b/pkg/registries/adapters/dockerhub_adapter_test.go
@@ -1,0 +1,11 @@
+package adapters
+
+import (
+	"testing"
+
+	ft "github.com/openshift/ansible-service-broker/pkg/fusortest"
+)
+
+func TestDockerhubName(t *testing.T) {
+	ft.AssertEqual(t, dockerhubName, "docker.io", "dockerhub name does not match docker.io")
+}

--- a/scripts/run_latest_build.sh
+++ b/scripts/run_latest_build.sh
@@ -58,8 +58,8 @@ oc cluster up --image=openshift/origin --version=v3.6.0-rc.0 --service-catalog=t
 # 'ansibleplaybookbundle' organization, this can be overridden with the
 # parameter DOCKERHUB_ORG being passed into the template.
 #
-DOCKERHUB_USER=""
-DOCKERHUB_PASS=""
+DOCKERHUB_USER="changeme"
+DOCKERHUB_PASS="changeme"
 DOCKERHUB_ORG="ansibleplaybookbundle"
 
 curl -s https://raw.githubusercontent.com/openshift/ansible-service-broker/master/templates/deploy-ansible-service-broker.template.yaml > deploy-ansible-service-broker.template.yaml
@@ -71,9 +71,9 @@ oc login -u system:admin
 oc new-project ansible-service-broker
 oc process -f ./deploy-ansible-service-broker.template.yaml \
     -n ansible-service-broker \
-    -p DOCKERHUB_USER=$DOCKERHUB_USER \
-    -p DOCKERHUB_PASS=$DOCKERHUB_PASS \
-    -p DOCKERHUB_ORG=$DOCKERHUB_ORG | oc create -f -
+    -p DOCKERHUB_USER="$DOCKERHUB_USER" \
+    -p DOCKERHUB_PASS="$DOCKERHUB_PASS" \
+    -p DOCKERHUB_ORG="$DOCKERHUB_ORG" | oc create -f -
 
 if [ "$?" -ne 0 ]; then
 	echo "Error processing template and creating deployment"
@@ -89,6 +89,10 @@ cat <<EOF > ansible-service-broker.broker
       name: ansible-service-broker
     spec:
       url: https://${ASB_ROUTE}
+      authInfo:
+        basicAuthSecret:
+          namespace: ansible-service-broker
+          name: asb-auth-secret
 EOF
 
 oc create -f ./ansible-service-broker.broker

--- a/scripts/run_latest_build.sh
+++ b/scripts/run_latest_build.sh
@@ -58,10 +58,9 @@ oc cluster up --image=openshift/origin --version=v3.6.0-rc.0 --service-catalog=t
 # 'ansibleplaybookbundle' organization, this can be overridden with the
 # parameter DOCKERHUB_ORG being passed into the template.
 #
-
-DOCKERHUB_USER="changeme"
-DOCKERHUB_PASS="changeme"
-
+DOCKERHUB_USER=""
+DOCKERHUB_PASS=""
+DOCKERHUB_ORG="ansibleplaybookbundle"
 
 curl -s https://raw.githubusercontent.com/openshift/ansible-service-broker/master/templates/deploy-ansible-service-broker.template.yaml > deploy-ansible-service-broker.template.yaml
 
@@ -70,7 +69,12 @@ curl -s https://raw.githubusercontent.com/openshift/ansible-service-broker/maste
 #
 oc login -u system:admin
 oc new-project ansible-service-broker
-oc process -f ./deploy-ansible-service-broker.template.yaml -n ansible-service-broker -p DOCKERHUB_USER="" -p DOCKERHUB_PASS="" -p DOCKERHUB_ORG="ansibleplaybookbundle" | oc create -f -
+oc process -f ./deploy-ansible-service-broker.template.yaml \
+    -n ansible-service-broker \
+    -p DOCKERHUB_USER=$DOCKERHUB_USER \
+    -p DOCKERHUB_PASS=$DOCKERHUB_PASS \
+    -p DOCKERHUB_ORG=$DOCKERHUB_ORG | oc create -f -
+
 if [ "$?" -ne 0 ]; then
 	echo "Error processing template and creating deployment"
 	exit


### PR DESCRIPTION
The main purpose of this PR is to go through the process and be
introduced to it.

**Describe what this PR does and why we need it**:

Changes proposed in this pull request
- Dockerhub adapter now handles err on failure to generate token
- scripts/run_latest_build.sh now uses the docker user, pass, and
  organization information
- A test for the dockerhub_adapter now exists, albeit a trivial one