### PR TITLE
Improve CI logging

### DIFF
--- a/scripts/broker-ci/error.sh
+++ b/scripts/broker-ci/error.sh
@@ -22,9 +22,6 @@ function convert-to-red {
     if ${PROVISION_ERROR}; then
 	PROVISION_ERROR="${color_red}true${color_norm}"
     fi
-    if ${PROVISION_ERROR}; then
-	PROVISION_ERROR="${color_red}true${color_norm}"
-    fi
     if ${POD_PRESET_ERROR}; then
 	POD_PRESET_ERROR="${color_red}true${color_norm}"
     fi
@@ -35,7 +32,6 @@ function convert-to-red {
 
 function error-variables {
     set +x
-    convert-to-red
 
     print-with-yellow "##### ERROR VARIABLE LIST #####"
     print-with-yellow "RESOURCE_ERROR: ${RESOURCE_ERROR}"
@@ -48,38 +44,44 @@ function error-variables {
 
 function error-check {
     set +x
+
     if ${RESOURCE_ERROR}; then
 	print-with-red "RESOURCE ERROR reported from ${1}"
-	error-variables
+	redirect-output
 	pod-logs
 	broker-logs
-	exit 1
     elif ${BIND_ERROR}; then
 	print-with-red "BIND ERROR reported from ${1}"
-	error-variables
+	redirect-output
 	podpreset-logs
 	secret-logs
 	broker-logs
 	catalog-logs
-	exit 1
     elif ${PROVISION_ERROR}; then
 	print-with-red "PROVISION ERROR reported from ${1}"
-	error-variables
+	redirect-output
 	pod-logs
 	broker-logs
-	exit 1
     elif ${POD_PRESET_ERROR}; then
 	print-with-red "POD PRESET ERROR reported from ${1}"
-	error-variables
+	redirect-output
 	pod-logs
 	secret-logs
 	podpreset-logs
-	exit 1
     elif ${VERIFY_CI_ERROR}; then
 	print-with-red "VERIFY CI ERROR reported from ${1}"
+	redirect-output
 	error-variables
 	print-all-logs
+    fi
+
+    if ${VERIFY_CI_ERROR} || ${POD_PRESET_ERROR} || ${PROVISION_ERROR} ||
+	${BIND_ERROR} || ${RESOURCE_ERROR}; then
+	restore-output
+	convert-to-red
+	error-variables
 	exit 1
     fi
+
     set -x
 }

--- a/scripts/broker-ci/local-ci.sh
+++ b/scripts/broker-ci/local-ci.sh
@@ -75,3 +75,5 @@ provision
 bind
 pickup-pod-presets
 verify-ci-run
+convert-to-red
+error-variables

--- a/scripts/broker-ci/logs.sh
+++ b/scripts/broker-ci/logs.sh
@@ -2,7 +2,7 @@
 
 function redirect-output {
     if ${LOCAL_CI}; then
-	# If local CI don't output logs. Let the user do it.
+	# If local CI don't output logs. Let the developer check them.
 	exec 3>&1 4>&2 >/dev/null
     fi
 }
@@ -10,13 +10,12 @@ function redirect-output {
 function restore-output {
     if ${LOCAL_CI}; then
 	# Restore stdout and stderr
-	exec 1>&3 2>&4
+	exec 1>&3 2>&4 3>&- 4>&-
     fi
 }
 
 function log-header {
     set +x
-    redirect-output
     header=$1
     print-with-red "##### START ${header} ######"
 }
@@ -24,7 +23,6 @@ function log-header {
 function log-footer {
     footer=$1
     print-with-red "##### END ${footer} ######"
-    restore-output
 }
 
 function wait-logs {


### PR DESCRIPTION
Print the error summary last.

Changes proposed in this pull request
 - Improves CI logging
 - Fixes an error with duplicate PROVISION_ERROR checks
 - Print CI run output last
 - Close file descriptors after we're done with them
