### PR TITLE
Match template registry name

### DIFF
--- a/scripts/prep_local_devel_env.sh
+++ b/scripts/prep_local_devel_env.sh
@@ -200,7 +200,9 @@ cat << EOF  > ${GENERATED_BROKER_CONFIG}
 ---
 registry:
   - type: dockerhub
-    name: dockerhub
+# NOTE: Careful with registry.name; it *must* match the name that was used when
+# catasb was originally brought up
+    name: dh
     url: https://registry.hub.docker.com
     user: ${DOCKERHUB_USERNAME}
     pass: ${DOCKERHUB_PASSWORD}


### PR DESCRIPTION
* Need to make sure we're using the same registry name as was used when
catasb was original brought up so that matching IDs are generated.

"dockerhub" vs "dh" will produce different IDs when hashed, manifesting
as 400s on provision requests (/spec lookups will miss)

Changes proposed in this pull request
 - Update registry name to match shortened name in main deployment template

**Which issue this PR fixes (This will close that issue when PR gets merged)**
fixes #352 