### PR TITLE
Add local etcd support for local env

### DIFF
--- a/scripts/my_local_dev_vars.example
+++ b/scripts/my_local_dev_vars.example
@@ -19,6 +19,7 @@ BEARER_TOKEN_FILE=""
 BROKER_INSECURE="true"
 CA_FILE=""
 REFRESH_INTERVAL="600s"
+#LOCAL_ETCD="false" # Use localhost:2379 for etcd
 
 # Disable basic auth. it is enabled by default
 #ENABLE_BASIC_AUTH="false"

--- a/scripts/prep_local_devel_env.sh
+++ b/scripts/prep_local_devel_env.sh
@@ -180,8 +180,16 @@ echo "Sleeping for a few seconds to avoid issues with broker not being able to t
 echo "Appears like there is a delay of when we create the asb-etcd route and when it is available for use"
 sleep 5
 
-etcd_route=`oc get route asb-etcd -n ${ASB_PROJECT} -o=jsonpath=\'\{.spec.host\}\'`
-echo "etcd route is at: ${etcd_route}"
+if [ "$LOCAL_ETCD" == "true" ]; then
+  ETCD_ROUTE="localhost"
+  ETCD_PORT=2379
+else
+  ETCD_ROUTE=`oc get route asb-etcd -n ${ASB_PROJECT} -o=jsonpath=\'\{.spec.host\}\'`
+  ETCD_PORT=80
+fi
+
+echo "etcd route is at: ${ETCD_ROUTE}"
+echo "etcd port is: ${ETCD_PORT}"
 
 if [ -z "$DOCKERHUB_USERNAME" ]; then
   echo "Please set the environment variable DOCKERHUB_USERNAME and re-run"
@@ -206,8 +214,8 @@ registry:
     pass: ${DOCKERHUB_PASSWORD}
     org: ${DOCKERHUB_ORG}
 dao:
-  etcd_host: ${etcd_route}
-  etcd_port: 80
+  etcd_host: ${ETCD_ROUTE}
+  etcd_port: ${ETCD_PORT}
 log:
   logfile: /tmp/ansible-service-broker-asb.log
   stdout: true


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
Most broker developers don't use the in cluster etcd instance and instead prefer an instance running locally so etcdctl and other tools can be used to interact with raw etcd. This PR introduces a proper configuration param so we can stop hacking up the generated config.

Changes proposed in this pull request
 - Set LOCAL_ETCD="true" in `my_local_dev_vars` to have `prep_local` script configure for a local etcd instance running on the developer's host.