### PR TITLE
Allow specifying a tag for apbs

### DIFF
--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -240,8 +240,11 @@ func (a AnsibleBroker) Bootstrap() (*BootstrapResponse, error) {
 func addNameAndIDForSpec(specs []*apb.Spec, registryName string) {
 	for _, spec := range specs {
 		//need to make / a hyphen to allow for global uniqueness but still match spec.
-		spec.FQName = strings.Replace(fmt.Sprintf("%v-%v", registryName, spec.Image),
+
+		imageName := strings.Replace(spec.Image, ":", "-", -1)
+		spec.FQName = strings.Replace(fmt.Sprintf("%v-%v", registryName, imageName),
 			"/", "-", -1)
+		spec.FQName = fmt.Sprintf("%.51v", spec.FQName)
 
 		// ID Will be a md5 hash of the fully qualified spec name.
 		hasher := md5.New()

--- a/pkg/registries/adapters/adapter.go
+++ b/pkg/registries/adapters/adapter.go
@@ -3,6 +3,7 @@ package adapters
 import (
 	b64 "encoding/base64"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/url"
 
@@ -34,13 +35,13 @@ type Configuration struct {
 	Pass   string
 	Org    string
 	Images []string
+	Tag    string
 }
 
 // Retrieve the spec from a registry manifest request
-func imageToSpec(log *logging.Logger, req *http.Request) (*apb.Spec, error) {
+func imageToSpec(log *logging.Logger, req *http.Request, apbtag string) (*apb.Spec, error) {
 	log.Debug("Registry::imageToSpec")
 	spec := &apb.Spec{}
-
 	req.Header.Add("Accept", "application/json")
 
 	resp, err := http.DefaultClient.Do(req)
@@ -101,6 +102,8 @@ func imageToSpec(log *logging.Logger, req *http.Request) (*apb.Spec, error) {
 		log.Errorf("Something went wrong loading decoded spec yaml, %s", err)
 		return nil, err
 	}
+
+	spec.Image = fmt.Sprintf("%s:%s", spec.Image, apbtag)
 
 	log.Debugf("adapter::imageToSpec -> Got plans %+v", spec.Plans)
 	log.Debugf("Successfully converted Image %s into Spec", spec.Image)

--- a/pkg/registries/adapters/dockerhub_adapter.go
+++ b/pkg/registries/adapters/dockerhub_adapter.go
@@ -15,7 +15,7 @@ import (
 const dockerhubName = "docker.io"
 const dockerHubLoginURL = "https://hub.docker.com/v2/users/login/"
 const dockerHubRepoImages = "https://hub.docker.com/v2/repositories/%v/?page_size=100"
-const dockerHubManifestURL = "https://registry.hub.docker.com/v2/%v/manifests/latest"
+const dockerHubManifestURL = "https://registry.hub.docker.com/v2/%v/manifests/%v"
 
 // DockerHubAdapter - Docker Hub Adapter
 type DockerHubAdapter struct {
@@ -205,7 +205,10 @@ func (r DockerHubAdapter) getNextImages(ctx context.Context,
 }
 
 func (r DockerHubAdapter) loadSpec(imageName string) (*apb.Spec, error) {
-	req, err := http.NewRequest("GET", fmt.Sprintf(dockerHubManifestURL, imageName), nil)
+	if r.Config.Tag == "" {
+		r.Config.Tag = "latest"
+	}
+	req, err := http.NewRequest("GET", fmt.Sprintf(dockerHubManifestURL, imageName, r.Config.Tag), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -214,7 +217,7 @@ func (r DockerHubAdapter) loadSpec(imageName string) (*apb.Spec, error) {
 		return nil, err
 	}
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %v", token))
-	return imageToSpec(r.Log, req)
+	return imageToSpec(r.Log, req, r.Config.Tag)
 }
 
 func getBearerToken(imageName string) (string, error) {

--- a/pkg/registries/adapters/openshift_adapter.go
+++ b/pkg/registries/adapters/openshift_adapter.go
@@ -12,7 +12,7 @@ import (
 
 const openShiftName = "registry.connect.redhat.com"
 const openShiftAuthURL = "https://sso.redhat.com/auth/realms/rhc4tp/protocol/docker-v2/auth?service=docker-registry"
-const openShiftManifestURL = "https://registry.connect.redhat.com/v2/%v/manifests/latest"
+const openShiftManifestURL = "https://registry.connect.redhat.com/v2/%v/manifests/%v"
 
 // OpenShiftAdapter - Docker Hub Adapter
 type OpenShiftAdapter struct {
@@ -93,7 +93,10 @@ func (r OpenShiftAdapter) getOpenShiftAuthToken() (string, error) {
 
 func (r OpenShiftAdapter) loadSpec(imageName string) (*apb.Spec, error) {
 	r.Log.Debug("OpenShiftAdapter::LoadSpec")
-	req, err := http.NewRequest("GET", fmt.Sprintf(openShiftManifestURL, imageName), nil)
+	if r.Config.Tag == "" {
+		r.Config.Tag = "latest"
+	}
+	req, err := http.NewRequest("GET", fmt.Sprintf(openShiftManifestURL, imageName, r.Config.Tag), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -102,5 +105,5 @@ func (r OpenShiftAdapter) loadSpec(imageName string) (*apb.Spec, error) {
 		return nil, err
 	}
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %v", token))
-	return imageToSpec(r.Log, req)
+	return imageToSpec(r.Log, req, r.Config.Tag)
 }

--- a/pkg/registries/adapters/rhcc_adapter.go
+++ b/pkg/registries/adapters/rhcc_adapter.go
@@ -54,13 +54,16 @@ func (r RHCCAdapter) GetImageNames() ([]string, error) {
 // FetchSpecs - retrieve the spec from the image names
 func (r RHCCAdapter) FetchSpecs(imageNames []string) ([]*apb.Spec, error) {
 	specs := []*apb.Spec{}
+	if r.Config.Tag == "" {
+		r.Config.Tag = "latest"
+	}
 	for _, imageName := range imageNames {
 		req, err := http.NewRequest("GET",
-			fmt.Sprintf("%v/v2/%v/manifests/latest", r.Config.URL.String(), imageName), nil)
+			fmt.Sprintf("%v/v2/%v/manifests/%v", r.Config.URL.String(), imageName, r.Config.Tag), nil)
 		if err != nil {
 			return specs, err
 		}
-		spec, err := imageToSpec(r.Log, req)
+		spec, err := imageToSpec(r.Log, req, r.Config.Tag)
 		if err != nil {
 			return specs, err
 		}

--- a/pkg/registries/registry.go
+++ b/pkg/registries/registry.go
@@ -21,6 +21,7 @@ type Config struct {
 	User   string
 	Pass   string
 	Org    string
+	Tag    string
 	Type   string
 	Name   string
 	Images []string
@@ -148,7 +149,8 @@ func NewRegistry(config Config, log *logging.Logger) (Registry, error) {
 		User:   config.User,
 		Pass:   config.Pass,
 		Org:    config.Org,
-		Images: config.Images}
+		Images: config.Images,
+		Tag:    config.Tag}
 
 	switch strings.ToLower(config.Type) {
 	case "rhcc":

--- a/scripts/broker-ci/mediawiki123.yaml
+++ b/scripts/broker-ci/mediawiki123.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mediawiki
   namespace: default
 spec:
-  serviceClassName: dh-ansibleplaybookbundle-mediawiki123-apb
+  serviceClassName: dh-ansibleplaybookbundle-mediawiki123-apb-latest
   planName: default
   parameters:
     mediawiki_db_schema: "mediawiki"

--- a/scripts/broker-ci/postgresql.yaml
+++ b/scripts/broker-ci/postgresql.yaml
@@ -4,7 +4,7 @@ metadata:
   name: postgresql
   namespace: default
 spec:
-  serviceClassName: dh-ansibleplaybookbundle-rhscl-postgresql-apb
+  serviceClassName: dh-ansibleplaybookbundle-rhscl-postgresql-apb-lates
   planName: prod
   parameters:
     postgresql_database: "admin"

--- a/templates/deploy-ansible-service-broker.template.yaml
+++ b/templates/deploy-ansible-service-broker.template.yaml
@@ -170,6 +170,7 @@ objects:
           user: "${DOCKERHUB_USER}"
           pass: "${DOCKERHUB_PASS}"
           org: "${DOCKERHUB_ORG}"
+          tag: "${TAG}"
       dao:
         etcd_host: 0.0.0.0
         etcd_port: 2379
@@ -243,6 +244,11 @@ parameters:
   displayname: Dockerhub organization
   name: DOCKERHUB_ORG
   value: ansibleplaybookbundle
+
+- description: APB Image Tag
+  displayname: APB Image Tag
+  name: TAG
+  value: latest
 
 - description: OpenShift User Password
   displayname: OpenShift User Password


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
Specify alternate tags for APB's. In order to more easily test canary/nightly apb images.

Changes proposed in this pull request
 - Add a 'tag' config option for registries in the config.yaml. The template will default it to latest.

**Does this PR depend on another PR (Use this to track when PRs should be merged)**
depends-on <PR>
There's a half way done PR for catasb that will make it easier to override the tag.

**Which issue this PR fixes (This will close that issue when PR gets merged)**
fixes <issue_number>
N/A