### PR TITLE
Work Topics and Deprovision Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ etc/mock.config.yaml
 #Compiled binaries
 broker
 build/broker
+!pkg/broker
 
 # python artifacts
 .python-version

--- a/pkg/apb/deprovision.go
+++ b/pkg/apb/deprovision.go
@@ -42,8 +42,7 @@ func Deprovision(
 
 	podOutput, err := watchPod(podName, instance.Context.Namespace, log)
 	if err != nil {
-		log.Error("Error returned from watching pod")
-		log.Errorf("error: %s", err.Error())
+		log.Errorf("Error returned from watching pod\nerror: %s", err.Error())
 		log.Errorf("output: %s", podOutput)
 	}
 

--- a/pkg/apb/deprovision.go
+++ b/pkg/apb/deprovision.go
@@ -6,7 +6,9 @@ import (
 )
 
 // Deprovision - runs the abp with the deprovision action.
-func Deprovision(instance *ServiceInstance, clusterConfig ClusterConfig, log *logging.Logger) (string, error) {
+func Deprovision(
+	instance *ServiceInstance, clusterConfig ClusterConfig, log *logging.Logger,
+) (string, error) {
 	log.Notice("============================================================")
 	log.Notice("                      DEPROVISIONING                        ")
 	log.Notice("============================================================")
@@ -33,12 +35,17 @@ func Deprovision(instance *ServiceInstance, clusterConfig ClusterConfig, log *lo
 		"deprovision", clusterConfig, instance.Spec,
 		instance.Context, instance.Parameters, log,
 	)
-
 	if err != nil {
 		log.Error("Problem executing apb %s", err)
 		return podName, err
 	}
 
-	log.Info(string(podName))
+	podOutput, err := watchPod(podName, instance.Context.Namespace, log)
+	if err != nil {
+		log.Error("Error returned from watching pod")
+		log.Errorf("error: %s", err.Error())
+		log.Errorf("output: %s", podOutput)
+	}
+
 	return podName, err
 }

--- a/pkg/apb/ext_creds.go
+++ b/pkg/apb/ext_creds.go
@@ -11,9 +11,6 @@ import (
 	logging "github.com/op/go-logging"
 )
 
-var timeoutFreq = 6    // Seconds
-var totalTimeout = 900 // 15min
-
 // ExtractCredentials - Extract credentials from pod in a certain namespace.
 func ExtractCredentials(
 	podname string, namespace string, log *logging.Logger,
@@ -35,7 +32,7 @@ func monitorOutput(namespace string, podname string, log *logging.Logger) ([]byt
 	// It would also be nice to gather the script output that exec runs
 	// instead of only getting the credentials
 
-	for r := 1; r <= credentialExtRetries; r++ {
+	for r := 1; r <= apbWatchRetries; r++ {
 		// err will be the return code from the exec command
 		// Use the error code to deterine the state
 		failedToExec := errors.New("exit status 1")
@@ -63,9 +60,10 @@ func monitorOutput(namespace string, podname string, log *logging.Logger) ([]byt
 		}
 
 		log.Warning("[%s] Retry attempt %d: exec into %s failed", podname, r, podname)
-		time.Sleep(time.Duration(credentialExtInterval) * time.Second)
+		time.Sleep(time.Duration(apbWatchInterval) * time.Second)
 	}
-	timeout := fmt.Sprintf("[%s] ExecTimeout: Failed to gather bind credentials after %d retries", podname, credentialExtRetries)
+
+	timeout := fmt.Sprintf("[%s] ExecTimeout: Failed to gather bind credentials after %d retries", podname, apbWatchRetries)
 	return nil, errors.New(timeout)
 }
 

--- a/pkg/apb/types.go
+++ b/pkg/apb/types.go
@@ -91,11 +91,10 @@ const (
 	// cluster-admin scoped to the project the apb is operating in
 	ApbRole = "cluster-admin"
 
-	// Bind credential gathering constants
-	// 5 seconds x 7200 retries = 2 hour timeout
-	credentialExtInterval = 5
-	credentialExtRetries  = 7200
-	gatherCredentialsCMD  = "broker-bind-creds"
+	// 5s x 7200 retries, 2 hours
+	apbWatchInterval     = 5
+	apbWatchRetries      = 7200
+	gatherCredentialsCMD = "broker-bind-creds"
 )
 
 // SpecLogDump - log spec for debug

--- a/pkg/apb/watch_pod.go
+++ b/pkg/apb/watch_pod.go
@@ -1,0 +1,52 @@
+package apb
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	logging "github.com/op/go-logging"
+)
+
+const (
+	podStatusRunning   = "Running"
+	podStatusCompleted = "Completed"
+	podStatusError     = "Error"
+)
+
+func watchPod(podName string, namespace string, log *logging.Logger) (string, error) {
+	log.Debugf(
+		"Watching pod [ %s ] in namespace [ %s ] for completion", podName, namespace)
+
+	for r := 1; r <= apbWatchRetries; r++ {
+		log.Info("Watch pod [ %s ] tick %d", podName, r)
+		output, err := RunCommand(
+			"oc", "get", "pod", "--no-headers=true", "--namespace="+namespace, podName)
+
+		outStr := string(output)
+
+		isPodRunning := strings.Contains(outStr, podStatusRunning)
+		didPodComplete := strings.Contains(outStr, podStatusCompleted)
+		didPodError := strings.Contains(outStr, podStatusError)
+
+		if err != nil {
+			log.Infof("Got error from watch pod cmd: %s\n error: %s\n output: %s",
+				podName, string(err.Error()), outStr)
+		} else if didPodError {
+			return outStr, fmt.Errorf("Pod %s is reporting error", podName)
+		} else if didPodComplete {
+			return outStr, nil
+		} else if isPodRunning {
+			log.Info("Pod %s still running, continuing to watch", podName)
+		} else {
+			log.Info("Pod completion not found, continuing to watch")
+			log.Infof("%s", outStr)
+		}
+
+		time.Sleep(time.Duration(apbWatchInterval) * time.Second)
+	}
+
+	err := fmt.Errorf(
+		"Timed out while watching pod %s for completion", podName)
+	return "", err
+}

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -116,10 +116,10 @@ func CreateApp() App {
 
 	app.log.Debug("Initializing WorkEngine")
 	app.engine = broker.NewWorkEngine(MsgBufferSize)
-	app.engine.AttachSubscriberToTopic(
+	app.engine.AttachSubscriber(
 		broker.NewProvisionWorkSubscriber(app.dao, app.log.Logger),
 		broker.ProvisionTopic)
-	app.engine.AttachSubscriberToTopic(
+	app.engine.AttachSubscriber(
 		broker.NewDeprovisionWorkSubscriber(app.dao, app.log.Logger),
 		broker.DeprovisionTopic)
 	app.log.Debugf("Active work engine topics: %+v", app.engine.GetActiveTopics())

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -116,12 +116,20 @@ func CreateApp() App {
 
 	app.log.Debug("Initializing WorkEngine")
 	app.engine = broker.NewWorkEngine(MsgBufferSize)
-	app.engine.AttachSubscriber(
+	err = app.engine.AttachSubscriber(
 		broker.NewProvisionWorkSubscriber(app.dao, app.log.Logger),
 		broker.ProvisionTopic)
-	app.engine.AttachSubscriber(
+	if err != nil {
+		app.log.Errorf("Failed to attach subscriber to WorkEngine: %s", err.Error())
+		os.Exit(1)
+	}
+	err = app.engine.AttachSubscriber(
 		broker.NewDeprovisionWorkSubscriber(app.dao, app.log.Logger),
 		broker.DeprovisionTopic)
+	if err != nil {
+		app.log.Errorf("Failed to attach subscriber to WorkEngine: %s", err.Error())
+		os.Exit(1)
+	}
 	app.log.Debugf("Active work engine topics: %+v", app.engine.GetActiveTopics())
 
 	app.log.Debug("Creating AnsibleBroker")

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -116,8 +116,13 @@ func CreateApp() App {
 
 	app.log.Debug("Initializing WorkEngine")
 	app.engine = broker.NewWorkEngine(MsgBufferSize)
-	app.log.Debug("Initializing Provision WorkSubscriber")
-	app.engine.AttachSubscriber(broker.NewProvisionWorkSubscriber(app.dao, app.log.Logger))
+	app.engine.AttachSubscriberToTopic(
+		broker.NewProvisionWorkSubscriber(app.dao, app.log.Logger),
+		broker.ProvisionTopic)
+	app.engine.AttachSubscriberToTopic(
+		broker.NewDeprovisionWorkSubscriber(app.dao, app.log.Logger),
+		broker.DeprovisionTopic)
+	app.log.Debugf("Active work engine topics: %+v", app.engine.GetActiveTopics())
 
 	app.log.Debug("Creating AnsibleBroker")
 	if app.broker, err = broker.NewAnsibleBroker(

--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -315,7 +315,7 @@ func (a AnsibleBroker) Recover() (string, error) {
 
 			// Need to use the same token as before, since that's what the
 			// catalog will try to ping.
-			a.engine.StartNewJobOnTopic(rs.State.Token, pjob, ProvisionTopic)
+			a.engine.StartNewJob(rs.State.Token, pjob, ProvisionTopic)
 
 			// HACK: there might be a delay between the first time the state in etcd
 			// is set and the job was already started. But I need the token.
@@ -523,7 +523,7 @@ func (a AnsibleBroker) Provision(instanceUUID uuid.UUID, req *ProvisionRequest, 
 		// asyncronously provision and return the token for the lastoperation
 		pjob := NewProvisionJob(serviceInstance, a.clusterConfig, a.log)
 
-		token = a.engine.StartNewJobOnTopic("", pjob, ProvisionTopic)
+		token = a.engine.StartNewJob("", pjob, ProvisionTopic)
 
 		// HACK: there might be a delay between the first time the state in etcd
 		// is set and the job was already started. But I need the token.
@@ -596,7 +596,7 @@ func (a AnsibleBroker) Deprovision(
 		// asynchronously provision and return the token for the lastoperation
 		dpjob := NewDeprovisionJob(instance, a.clusterConfig, a.dao, a.log)
 
-		token = a.engine.StartNewJobOnTopic("", dpjob, DeprovisionTopic)
+		token = a.engine.StartNewJob("", dpjob, DeprovisionTopic)
 
 		// HACK: there might be a delay between the first time the state in etcd
 		// is set and the job was already started. But I need the token.

--- a/pkg/broker/deprovision_subscriber.go
+++ b/pkg/broker/deprovision_subscriber.go
@@ -1,0 +1,99 @@
+package broker
+
+import (
+	"encoding/json"
+
+	logging "github.com/op/go-logging"
+	"github.com/openshift/ansible-service-broker/pkg/apb"
+	"github.com/openshift/ansible-service-broker/pkg/dao"
+)
+
+// DeprovisionWorkSubscriber - Lissten for provision messages
+type DeprovisionWorkSubscriber struct {
+	dao       *dao.Dao
+	log       *logging.Logger
+	msgBuffer <-chan WorkMsg
+}
+
+// NewDeprovisionWorkSubscriber - Create a new work subscriber.
+func NewDeprovisionWorkSubscriber(dao *dao.Dao, log *logging.Logger) *DeprovisionWorkSubscriber {
+	return &DeprovisionWorkSubscriber{dao: dao, log: log}
+}
+
+// Subscribe - will start the work subscriber listenning on the message buffer for deprovision messages.
+func (d *DeprovisionWorkSubscriber) Subscribe(msgBuffer <-chan WorkMsg) {
+	d.msgBuffer = msgBuffer
+	var dmsg *DeprovisionMsg
+
+	go func() {
+		d.log.Info("Listening for deprovision messages")
+		for {
+			msg := <-msgBuffer
+
+			d.log.Debug("Processed deprovision message from buffer")
+			json.Unmarshal([]byte(msg.Render()), &dmsg)
+
+			if dmsg.Error != "" {
+				// Job failed, mark failure
+				setFailedDeprovisionJob(d.dao, dmsg)
+				return
+			}
+
+			instance, err := d.dao.GetServiceInstance(dmsg.InstanceUUID)
+			if err != nil {
+				d.log.Errorf(
+					"Error occurred getting service instance [ %s ] after deprovision job:",
+					dmsg.InstanceUUID,
+				)
+				d.log.Errorf("%s", err.Error())
+				setFailedDeprovisionJob(d.dao, dmsg)
+				return
+			}
+
+			// Job is not reporting error, cleanup after deprovision
+			err = cleanupDeprovision(dmsg.PodName, instance, d.dao, d.log)
+			if err != nil {
+				d.log.Error("Failed cleaning up deprovision after job, error: %s", err.Error())
+				// Cleanup is reporting something has gone wrong. Deprovision overall
+				// has not completed. Mark the job as failed.
+				setFailedDeprovisionJob(d.dao, dmsg)
+				return
+			}
+
+			// No errors reported, deprovision action successfully performed and
+			// broker has successfully cleaned up. Mark depro success
+			d.dao.SetState(dmsg.InstanceUUID, apb.JobState{Token: dmsg.JobToken,
+				State: apb.StateSucceeded, Podname: dmsg.PodName})
+		}
+	}()
+}
+
+func setFailedDeprovisionJob(dao *dao.Dao, dmsg *DeprovisionMsg) {
+	dao.SetState(dmsg.InstanceUUID, apb.JobState{
+		Token:   dmsg.JobToken,
+		State:   apb.StateFailed,
+		Podname: dmsg.PodName,
+	})
+}
+
+func cleanupDeprovision(
+	podName string, instance *apb.ServiceInstance, dao *dao.Dao, log *logging.Logger,
+) error {
+	var err error
+	id := instance.ID.String()
+	sm := apb.NewServiceAccountManager(log)
+	log.Info("Destroying APB sandbox...")
+	sm.DestroyApbSandbox(podName, instance.Context.Namespace)
+
+	if err = dao.DeleteExtractedCredentials(id); err != nil {
+		log.Error("failed to delete extracted credentials - %#v", err)
+		return err
+	}
+
+	if err = dao.DeleteServiceInstance(id); err != nil {
+		log.Error("failed to delete service instance - %#v", err)
+		return err
+	}
+
+	return nil
+}

--- a/pkg/broker/provision_subscriber.go
+++ b/pkg/broker/provision_subscriber.go
@@ -31,21 +31,25 @@ func (p *ProvisionWorkSubscriber) Subscribe(msgBuffer <-chan WorkMsg) {
 		for {
 			msg := <-msgBuffer
 
-			p.log.Debug("Processed message from buffer")
+			p.log.Debug("Processed provision message from buffer")
 			// HACK: this seems like a hack, there's probably a better way to
 			// get the data sent through instead of a string
 			json.Unmarshal([]byte(msg.Render()), &pmsg)
 
 			if pmsg.Error != "" {
-				p.dao.SetState(pmsg.InstanceUUID, apb.JobState{Token: pmsg.JobToken, State: apb.StateFailed, Podname: pmsg.PodName})
+				p.log.Errorf("Provision job reporting error: %s", pmsg.Error)
+				p.dao.SetState(pmsg.InstanceUUID, apb.JobState{Token: pmsg.JobToken,
+					State: apb.StateFailed, Podname: pmsg.PodName})
 			} else if pmsg.Msg == "" {
 				// HACK: OMG this is horrible. We should probably pass in a
 				// state. Since we'll also be using this to get more granular
 				// updates one day.
-				p.dao.SetState(pmsg.InstanceUUID, apb.JobState{Token: pmsg.JobToken, State: apb.StateInProgress, Podname: pmsg.PodName})
+				p.dao.SetState(pmsg.InstanceUUID, apb.JobState{Token: pmsg.JobToken,
+					State: apb.StateInProgress, Podname: pmsg.PodName})
 			} else {
 				json.Unmarshal([]byte(pmsg.Msg), &extCreds)
-				p.dao.SetState(pmsg.InstanceUUID, apb.JobState{Token: pmsg.JobToken, State: apb.StateSucceeded, Podname: pmsg.PodName})
+				p.dao.SetState(pmsg.InstanceUUID, apb.JobState{Token: pmsg.JobToken,
+					State: apb.StateSucceeded, Podname: pmsg.PodName})
 				p.dao.SetExtractedCredentials(pmsg.InstanceUUID, extCreds)
 			}
 		}

--- a/pkg/broker/types.go
+++ b/pkg/broker/types.go
@@ -15,6 +15,12 @@ const (
 	planParameterKey = "_apb_plan_id"
 )
 
+// Work Engine messaging consts
+const (
+	ProvisionTopic   WorkTopic = "provision_topic"
+	DeprovisionTopic WorkTopic = "deprovision_topic"
+)
+
 // Service - Service object to be returned.
 // based on https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#service-objects
 type Service struct {

--- a/pkg/broker/types.go
+++ b/pkg/broker/types.go
@@ -15,11 +15,25 @@ const (
 	planParameterKey = "_apb_plan_id"
 )
 
+// WorkTopic - Topic jobs can publish messages to, and subscribers can listen to
+type WorkTopic string
+
 // Work Engine messaging consts
 const (
 	ProvisionTopic   WorkTopic = "provision_topic"
 	DeprovisionTopic WorkTopic = "deprovision_topic"
 )
+
+var workTopicSet = map[WorkTopic]bool{
+	ProvisionTopic:   true,
+	DeprovisionTopic: true,
+}
+
+// IsValidWorkTopic - Check if WorkTopic is part of acceptable set
+func IsValidWorkTopic(topic WorkTopic) bool {
+	_, ok := workTopicSet[topic]
+	return ok
+}
 
 // Service - Service object to be returned.
 // based on https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#service-objects

--- a/pkg/broker/work_engine.go
+++ b/pkg/broker/work_engine.go
@@ -7,20 +7,26 @@ type Work interface {
 	Run(token string, msgBuffer chan<- WorkMsg)
 }
 
+// WorkTopic - Topic jobs can publish messages to, and subscribers can listen to
+type WorkTopic string
+
 // WorkEngine - a new engine for doing work.
 type WorkEngine struct {
-	msgBuffer chan WorkMsg
+	topics map[WorkTopic]chan WorkMsg
 }
 
 // NewWorkEngine - creates a new work engine
 func NewWorkEngine(bufferSize int) *WorkEngine {
-	return &WorkEngine{
-		msgBuffer: make(chan WorkMsg, bufferSize),
-	}
+	return &WorkEngine{topics: make(map[WorkTopic]chan WorkMsg)}
 }
 
-// StartNewJob - Starts a job in an new goroutine. returns token, or generated token if an empty token is passed in.
-func (engine *WorkEngine) StartNewJob(token string, work Work) string {
+//msgBuffer: make(chan WorkMsg, bufferSize),
+
+// StartNewJobOnTopic - Starts a job in an new goroutine, reporting to a specific topic.
+// returns token, or generated token if an empty token is passed in.
+func (engine *WorkEngine) StartNewJobOnTopic(
+	token string, work Work, topic WorkTopic,
+) string {
 	var jobToken string
 
 	if token == "" {
@@ -28,11 +34,32 @@ func (engine *WorkEngine) StartNewJob(token string, work Work) string {
 	} else {
 		jobToken = token
 	}
-	go work.Run(jobToken, engine.msgBuffer)
+
+	msgBuffer, topicExists := engine.topics[topic]
+	if !topicExists {
+		msgBuffer = make(chan WorkMsg)
+		engine.topics[topic] = msgBuffer
+	}
+
+	go work.Run(jobToken, msgBuffer)
 	return jobToken
 }
 
-// AttachSubscriber - Attach a subscriber to the engine. Will send the WorkMsg to the subscribers through the message buffer.
-func (engine *WorkEngine) AttachSubscriber(subscriber WorkSubscriber) {
-	subscriber.Subscribe(engine.msgBuffer)
+// AttachSubscriberToTopic - Attach a subscriber a specific messaging topic.
+// Will send the WorkMsg to the subscribers through the message buffer.
+func (engine *WorkEngine) AttachSubscriberToTopic(
+	subscriber WorkSubscriber, topic WorkTopic,
+) {
+	msgBuffer, topicExists := engine.topics[topic]
+	if !topicExists {
+		msgBuffer = make(chan WorkMsg)
+		engine.topics[topic] = msgBuffer
+	}
+
+	subscriber.Subscribe(msgBuffer)
+}
+
+// GetActiveTopics - Get list of topics
+func (engine *WorkEngine) GetActiveTopics() map[WorkTopic]chan WorkMsg {
+	return engine.topics
 }

--- a/pkg/broker/work_engine.go
+++ b/pkg/broker/work_engine.go
@@ -20,11 +20,9 @@ func NewWorkEngine(bufferSize int) *WorkEngine {
 	return &WorkEngine{topics: make(map[WorkTopic]chan WorkMsg)}
 }
 
-//msgBuffer: make(chan WorkMsg, bufferSize),
-
-// StartNewJobOnTopic - Starts a job in an new goroutine, reporting to a specific topic.
+// StartNewJob - Starts a job in an new goroutine, reporting to a specific topic.
 // returns token, or generated token if an empty token is passed in.
-func (engine *WorkEngine) StartNewJobOnTopic(
+func (engine *WorkEngine) StartNewJob(
 	token string, work Work, topic WorkTopic,
 ) string {
 	var jobToken string
@@ -45,9 +43,9 @@ func (engine *WorkEngine) StartNewJobOnTopic(
 	return jobToken
 }
 
-// AttachSubscriberToTopic - Attach a subscriber a specific messaging topic.
+// AttachSubscriber - Attach a subscriber a specific messaging topic.
 // Will send the WorkMsg to the subscribers through the message buffer.
-func (engine *WorkEngine) AttachSubscriberToTopic(
+func (engine *WorkEngine) AttachSubscriber(
 	subscriber WorkSubscriber, topic WorkTopic,
 ) {
 	msgBuffer, topicExists := engine.topics[topic]


### PR DESCRIPTION
* Added topics to work engine
* Added deprovision subscriber, make sure the ProvisionSubscriber stops
processing deprovision messages as previously written
* Added pod watcher for actions that don't require cred extraction
but still need to watch for completion and handle
* Various refactoring to leverage new stuff

**Which issue this PR fixes (This will close that issue when PR gets merged)**
fixes #341
