### PR TITLE
Fix rebase mistake

### DIFF
--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -92,7 +92,7 @@ elif [[ "$action" == "ci" ]]; then
   echo "            Broker CI            "
   echo "================================="
   ./scripts/broker-ci/setup.sh
-  if [ $? -ne 0 ]; then
+  if [ $? -eq 0 ]; then
       make ci LOCAL_CI=false
   fi
 fi


### PR DESCRIPTION
I wanted to duplicate ```if ! ${ERROR};``` logic where we only run
```make ci``` if the setup worked.. Instead, ```make ci```
only runs when the setup errors.

Changes proposed in this pull request
 - Fixes a false positive introduced from #348 