### PR TITLE
Move the client calls to the runtime pkg

### DIFF
--- a/pkg/apb/ext_creds.go
+++ b/pkg/apb/ext_creds.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/openshift/ansible-service-broker/pkg/runtime"
+
 	logging "github.com/op/go-logging"
 )
 
@@ -38,7 +40,7 @@ func monitorOutput(namespace string, podname string, log *logging.Logger) ([]byt
 		failedToExec := errors.New("exit status 1")
 		credsNotAvailable := errors.New("exit status 2")
 
-		output, err := RunCommand("oc", "exec", podname, gatherCredentialsCMD, "--namespace="+namespace)
+		output, err := runtime.RunCommand("oc", "exec", podname, gatherCredentialsCMD, "--namespace="+namespace)
 		podCompleted := strings.Contains(string(output), "current phase is Succeeded") ||
 			strings.Contains(string(output), "cannot exec into a container in a completed pod")
 

--- a/pkg/apb/ext_creds.go
+++ b/pkg/apb/ext_creds.go
@@ -40,7 +40,7 @@ func monitorOutput(namespace string, podname string, log *logging.Logger) ([]byt
 		failedToExec := errors.New("exit status 1")
 		credsNotAvailable := errors.New("exit status 2")
 
-		output, err := runtime.RunCommand("oc", "exec", podname, gatherCredentialsCMD, "--namespace="+namespace)
+		output, err := runtime.RunCommand("kubectl", "exec", podname, gatherCredentialsCMD, "--namespace="+namespace)
 		podCompleted := strings.Contains(string(output), "current phase is Succeeded") ||
 			strings.Contains(string(output), "cannot exec into a container in a completed pod")
 

--- a/pkg/apb/provision.go
+++ b/pkg/apb/provision.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/openshift/ansible-service-broker/pkg/runtime"
+
 	logging "github.com/op/go-logging"
 )
 
@@ -68,6 +70,6 @@ func Provision(
 }
 
 func projectExists(project string) bool {
-	_, _, code := RunCommandWithExitCode("oc", "get", "project", project)
+	_, _, code := runtime.RunCommandWithExitCode("oc", "get", "project", project)
 	return code == 0
 }

--- a/pkg/apb/provision.go
+++ b/pkg/apb/provision.go
@@ -70,6 +70,6 @@ func Provision(
 }
 
 func projectExists(project string) bool {
-	_, _, code := runtime.RunCommandWithExitCode("oc", "get", "project", project)
+	_, _, code := runtime.RunCommandWithExitCode("kubectl", "get", "project", project)
 	return code == 0
 }

--- a/pkg/apb/svc_acct.go
+++ b/pkg/apb/svc_acct.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/openshift/ansible-service-broker/pkg/runtime"
+
 	logging "github.com/op/go-logging"
 	yaml "gopkg.in/yaml.v2"
 )
@@ -72,7 +74,7 @@ func (s *ServiceAccountManager) CreateApbSandbox(namespace string, apbID string,
 
 func (s *ServiceAccountManager) createResources(rFilePath string, namespace string) error {
 	s.log.Debug("Creating resources from file at path: %s", rFilePath)
-	output, err := RunCommand("oc", "create", "-f", rFilePath, "--namespace="+namespace)
+	output, err := runtime.RunCommand("oc", "create", "-f", rFilePath, "--namespace="+namespace)
 	// TODO: Parse output somehow to validate things got created?
 	if err != nil {
 		s.log.Error("Something went wrong trying to create resources in cluster")
@@ -165,7 +167,7 @@ func (s *ServiceAccountManager) DestroyApbSandbox(handle string, namespace strin
 	}
 
 	s.log.Debug("Deleting serviceaccount %s, namespace %s", handle, namespace)
-	output, err := RunCommand(
+	output, err := runtime.RunCommand(
 		"oc", "delete", "serviceaccount", handle, "--namespace="+namespace,
 	)
 	if err != nil {
@@ -180,7 +182,7 @@ func (s *ServiceAccountManager) DestroyApbSandbox(handle string, namespace strin
 	s.log.Debug(string(output))
 
 	s.log.Debug("Deleting rolebinding %s, namespace %s", handle, namespace)
-	output, err = RunCommand(
+	output, err = runtime.RunCommand(
 		"oc", "delete", "rolebinding", handle, "--namespace="+namespace,
 	)
 	if err != nil {

--- a/pkg/apb/watch_pod.go
+++ b/pkg/apb/watch_pod.go
@@ -23,7 +23,7 @@ func watchPod(podName string, namespace string, log *logging.Logger) (string, er
 	for r := 1; r <= apbWatchRetries; r++ {
 		log.Info("Watch pod [ %s ] tick %d", podName, r)
 		output, err := runtime.RunCommand(
-			"oc", "get", "pod", "--no-headers=true", "--namespace="+namespace, podName)
+			"kubectl", "get", "pod", "--no-headers=true", "--namespace="+namespace, podName)
 
 		outStr := string(output)
 

--- a/pkg/apb/watch_pod.go
+++ b/pkg/apb/watch_pod.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/openshift/ansible-service-broker/pkg/runtime"
+
 	logging "github.com/op/go-logging"
 )
 
@@ -20,7 +22,7 @@ func watchPod(podName string, namespace string, log *logging.Logger) (string, er
 
 	for r := 1; r <= apbWatchRetries; r++ {
 		log.Info("Watch pod [ %s ] tick %d", podName, r)
-		output, err := RunCommand(
+		output, err := runtime.RunCommand(
 			"oc", "get", "pod", "--no-headers=true", "--namespace="+namespace, podName)
 
 		outStr := string(output)

--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openshift/ansible-service-broker/pkg/auth"
 	"github.com/openshift/ansible-service-broker/pkg/dao"
 	"github.com/openshift/ansible-service-broker/pkg/registries"
+	"github.com/openshift/ansible-service-broker/pkg/runtime"
 	"github.com/pborman/uuid"
 	k8srestclient "k8s.io/client-go/rest"
 )
@@ -912,7 +913,7 @@ func ocLogin(log *logging.Logger, args ...string) error {
 
 	fullArgs := append([]string{"login"}, args...)
 
-	output, err := apb.RunCommand("oc", fullArgs...)
+	output, err := runtime.RunCommand("oc", fullArgs...)
 	log.Debug("Login output:")
 	log.Debug(string(output))
 

--- a/pkg/runtime/hack.go
+++ b/pkg/runtime/hack.go
@@ -1,4 +1,4 @@
-package apb
+package runtime
 
 import (
 	"bytes"


### PR DESCRIPTION
Create the runtime pkg and start converting a few things to using ```kubectl```.
Remaining Commands:
 - ```oc login```
 - creating svc accounts
 - creating rolebindings

Changes proposed in this pull request
 - Move RunCommand to the runtime pkg 
 - Use ```kubectl``` for a few commands
 
