### PR TITLE
377 - The service name returned by asb is invalid

### DIFF
--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -245,6 +245,9 @@ func addNameAndIDForSpec(specs []*apb.Spec, registryName string) {
 		spec.FQName = strings.Replace(fmt.Sprintf("%v-%v", registryName, imageName),
 			"/", "-", -1)
 		spec.FQName = fmt.Sprintf("%.51v", spec.FQName)
+		if strings.HasSuffix(spec.FQName, "-") {
+			spec.FQName = spec.FQName[:len(spec.FQName)-1]
+		}
 
 		// ID Will be a md5 hash of the fully qualified spec name.
 		hasher := md5.New()

--- a/pkg/broker/broker_test.go
+++ b/pkg/broker/broker_test.go
@@ -32,3 +32,12 @@ func TestUpdate(t *testing.T) {
 	}
 	ft.AssertEqual(t, err, notImplemented, "Update must have been implemented")
 }
+
+func TestAddNameAndIDForSpecStripsTailingDash(t *testing.T) {
+	spec1 := apb.Spec{Image: "1234567890123456789012345678901234567890-"}
+	spec2 := apb.Spec{Image: "org/hello-world-apb"}
+	spcs := []*apb.Spec{&spec1, &spec2}
+	addNameAndIDForSpec(spcs, "h")
+	ft.AssertEqual(t, "h-1234567890123456789012345678901234567890", spcs[0].FQName)
+	ft.AssertEqual(t, "h-org-hello-world-apb", spcs[1].FQName)
+}


### PR DESCRIPTION
Will see if the FQname was cut off at a "-" character

fixes #377 