### PR TITLE
Update Dockerfile names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ prepare-local-env: $(KUBERNETES_FILES) ## Prepare the local environment for runn
 
 build-image: ## Build a docker image with the broker binary
 	cp broker build/broker
-	docker build -f ${BUILD_DIR}/Dockerfile-canary -t ${BROKER_IMAGE}:${TAG} ${BUILD_DIR}
+	docker build -f ${BUILD_DIR}/Dockerfile-localdev -t ${BROKER_IMAGE}:${TAG} ${BUILD_DIR}
 	@echo
 	@echo "Remember you need to push your image before calling make deploy"
 	@echo "    docker push ${BROKER_IMAGE}:${TAG}"

--- a/build/Dockerfile-canary
+++ b/build/Dockerfile-canary
@@ -21,8 +21,30 @@ RUN mkdir /var/log/ansible-service-broker \
     && touch /var/log/ansible-service-broker/asb.log \
     && mkdir /etc/ansible-service-broker
 
+#
+# Dockerhub automatic building expects the source present in the image.
+#
+######################
+# BUILD BROKER SOURCE
+######################
+RUN rpm --import https://mirror.go-repo.io/centos/RPM-GPG-KEY-GO-REPO
+RUN curl -s https://mirror.go-repo.io/centos/go-repo.repo | tee /etc/yum.repos.d/go-repo.repo
+RUN yum -y install golang make device-mapper-devel btrfs-progs-devel etcd
+
+ENV GOPATH=/go
+ENV BROKER_PATH=${GOPATH}/src/github.com/openshift
+
+RUN mkdir -p /go/src/github.com/openshift/ansible-service-broker
+RUN git clone https://github.com/openshift/ansible-service-broker ${BROKER_PATH}/ansible-service-broker
+WORKDIR /go/src/github.com/openshift/ansible-service-broker
+
+RUN go build -i -ldflags="-s -w" ./cmd/broker
+RUN mv broker /usr/bin/asbd
+######################
+# BUILD BROKER SOURCE
+######################
+
 COPY entrypoint.sh /usr/bin/
-COPY broker /usr/bin/asbd
 
 RUN chown -R ${USER_NAME}:0 /var/log/ansible-service-broker \
  && chown -R ${USER_NAME}:0 /etc/ansible-service-broker \

--- a/build/Dockerfile-localdev
+++ b/build/Dockerfile-localdev
@@ -21,30 +21,8 @@ RUN mkdir /var/log/ansible-service-broker \
     && touch /var/log/ansible-service-broker/asb.log \
     && mkdir /etc/ansible-service-broker
 
-#
-# Dockerhub automatic building expects the source present in the image.
-#
-######################
-# BUILD BROKER SOURCE
-######################
-RUN rpm --import https://mirror.go-repo.io/centos/RPM-GPG-KEY-GO-REPO
-RUN curl -s https://mirror.go-repo.io/centos/go-repo.repo | tee /etc/yum.repos.d/go-repo.repo
-RUN yum -y install golang make device-mapper-devel btrfs-progs-devel etcd
-
-ENV GOPATH=/go
-ENV BROKER_PATH=${GOPATH}/src/github.com/openshift
-
-RUN mkdir -p /go/src/github.com/openshift/ansible-service-broker
-RUN git clone https://github.com/openshift/ansible-service-broker ${BROKER_PATH}/ansible-service-broker
-WORKDIR /go/src/github.com/openshift/ansible-service-broker
-
-RUN go build -i -ldflags="-s -w" ./cmd/broker
-RUN mv broker /usr/bin/asbd
-######################
-# BUILD BROKER SOURCE
-######################
-
 COPY entrypoint.sh /usr/bin/
+COPY broker /usr/bin/asbd
 
 RUN chown -R ${USER_NAME}:0 /var/log/ansible-service-broker \
  && chown -R ${USER_NAME}:0 /etc/ansible-service-broker \

--- a/build/README.md
+++ b/build/README.md
@@ -4,3 +4,5 @@ There are three dockerfiles here being used to generate containers for three dif
 - **Latest**: Stable images released less frequently and expected to work with the latest apb containers. These are built using RPM's from the @ansible-service-broker/ansible-service-broker-latest copr repo. The packages in this repo are built using tito when we're fairly confident we'll produce a stable build.
 - **Nightly**: Automated image builds using automated RPM builds. This tag is intended to ensure RPM builds work on an ongoing basis. These are built using RPM's from the @ansible-service-broker/ansible-service-broker-nightly copr repo.
 - As time goes on and releases are made we may also create tags for specified versions, for example, v1.0, v1.1, etc. In most cases expect that these were retagged from latest.
+
+Dockerfile-localdev is similar to Dockerfile-canary except it will take a local build of the broker and add it to the container, rather than building it within the container, in order to save some time. Dockerfile-localdev is what the Makefile in the parent directory will use to generate a container build.


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
automated-build is what is currently being used to build Canary images. As such I'm renaming it to conform with the scheme I brought up @ Wednesdays meeting. To do this I need to call the Dockerfile being used by the Makefile something else. I chose -localdev for lack of any better idea.

Changes proposed in this pull request
 - Move Dockerfile-canary to Dockerfile-localdev
 - Move automated-build to Dockerfile-canary
 - Fix Makefile to track this change

**Does this PR depend on another PR (Use this to track when PRs should be merged)**
depends-on <PR>
No

**Which issue this PR fixes (This will close that issue when PR gets merged)**
fixes <issue_number>
N/A