### PR TITLE
Added UI form information to metadata fields for parsing by OpenShift

### DIFF
--- a/pkg/apb/types.go
+++ b/pkg/apb/types.go
@@ -15,15 +15,17 @@ type SpecManifest map[string]*Spec
 
 // ParameterDescriptor - a parameter to be used by the service catalog to get data.
 type ParameterDescriptor struct {
-	Name        string      `json:"name"`
-	Title       string      `json:"title"`
-	Type        string      `json:"type"`
-	Description string      `json:"description,omitempty"`
-	Default     interface{} `json:"default,omitempty"`
-	Maxlength   int         `json:"maxlength,omitempty"`
-	Pattern     string      `json:"pattern,omitempty"`
-	Enum        []string    `json:"enum,omitempty"`
-	Required    bool        `json:"required"`
+	Name         string      `json:"name"`
+	Title        string      `json:"title"`
+	Type         string      `json:"type"`
+	Description  string      `json:"description,omitempty"`
+	Default      interface{} `json:"default,omitempty"`
+	Maxlength    int         `json:"maxlength,omitempty"`
+	Pattern      string      `json:"pattern,omitempty"`
+	Enum         []string    `json:"enum,omitempty"`
+	Required     bool        `json:"required"`
+	DisplayType  string      `json:"display_type,omitempty" yaml:"display_type,omitempty"`
+	DisplayGroup string      `json:"display_group,omitempty" yaml:"display_group,omitempty"`
 }
 
 // Plan - Plan object describing an APB deployment plan and associated parameters

--- a/pkg/broker/util_test.go
+++ b/pkg/broker/util_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/base64"
 	"testing"
 
+	"strings"
+
 	schema "github.com/lestrrat/go-jsschema"
 	"github.com/openshift/ansible-service-broker/pkg/apb"
 	ft "github.com/openshift/ansible-service-broker/pkg/fusortest"
@@ -23,13 +25,34 @@ const PlanFree = true
 const PlanBindable = true
 
 var PlanParams = []apb.ParameterDescriptor{
-	apb.ParameterDescriptor{
+	{
 		Name:        "email_address",
 		Title:       "Email Address",
 		Type:        "enum",
 		Description: "example enum parameter",
 		Enum:        []string{"google@gmail.com", "redhat@redhat.com"},
 		Default:     float64(9001),
+	},
+	{
+		Name:        "password",
+		Title:       "Password",
+		Type:        "string",
+		Description: "example string parameter with a display type",
+		DisplayType: "password",
+	},
+	{
+		Name:         "first_name",
+		Title:        "First Name",
+		Type:         "string",
+		Description:  "example grouped string parameter",
+		DisplayGroup: "User Information",
+	},
+	{
+		Name:         "last_name",
+		Title:        "Last Name",
+		Type:         "string",
+		Description:  "example grouped string parameter",
+		DisplayGroup: "User Information",
 	},
 }
 
@@ -85,6 +108,62 @@ func TestSpecToService(t *testing.T) {
 	ft.AssertEqual(t, svc.Name, expectedsvc.Name, "name is not equal")
 	ft.AssertEqual(t, svc.Description, expectedsvc.Description, "description is not equal")
 	ft.AssertEqual(t, svc.Bindable, expectedsvc.Bindable, "bindable wrong")
+}
+
+func TestUpdateMetadata(t *testing.T) {
+	planMetadata := updateMetadata(PlanMetadata, PlanParams)
+	ft.AssertNotNil(t, planMetadata, "plan metadata is empty")
+
+	verifyFormDefinition(t, planMetadata, []string{"schemas", "service_instance", "create"})
+
+	updateFormDefnMap := verifyMapPath(t, planMetadata, []string{"schemas", "service_instance", "update"})
+	ft.AssertEqual(t, len(updateFormDefnMap), 0, "schemas.service_instance.update is not empty")
+
+	verifyFormDefinition(t, planMetadata, []string{"schemas", "service_binding", "create"})
+}
+
+func verifyFormDefinition(t *testing.T, planMetadata map[string]interface{}, path []string) {
+
+	formDefnMap := verifyMapPath(t, planMetadata, path)
+	formDefnMetadata, correctType := formDefnMap["form_definition"].([]interface{})
+	ft.AssertTrue(t, correctType, strings.Join(path, ".")+" Form definition is of the wrong type")
+	ft.AssertNotNil(t, formDefnMetadata, "Form definition is nil")
+
+	passwordParam, correctType := formDefnMetadata[1].(map[string]string)
+	ft.AssertTrue(t, correctType, strings.Join(path, ".")+" Form definition password param is of the wrong type")
+	ft.AssertNotNil(t, passwordParam)
+	ft.AssertEqual(t, passwordParam["key"], PlanParams[1].Name, "Password parameter has the wrong name")
+	ft.AssertEqual(t, passwordParam["type"], PlanParams[1].DisplayType, "Password parameter display type is incorrect")
+
+	group, correctType := formDefnMetadata[2].(map[string]interface{})
+	ft.AssertTrue(t, correctType, strings.Join(path, ".")+" Form definition parameter group is of the wrong type")
+	ft.AssertNotNil(t, group, "Parameter group is empty")
+	ft.AssertEqual(t, group["type"], "fieldset")
+
+	groupedItems, correctType := group["items"].([]interface{})
+	ft.AssertTrue(t, correctType, strings.Join(path, ".")+" Form definition parameter group items are the wrong type")
+	ft.AssertNotNil(t, groupedItems, "Group missing parameter items")
+	ft.AssertEqual(t, len(groupedItems), 2, "Incorrect number of parameters in group")
+
+	firstNameParam, correctType := groupedItems[0].(string)
+	ft.AssertTrue(t, correctType, "first_name is of the wrong type")
+	ft.AssertEqual(t, firstNameParam, PlanParams[2].Name, "Incorrect name for first_name")
+
+	lastNameParam, correctType := groupedItems[1].(string)
+	ft.AssertTrue(t, correctType, "last_name is of the wrong type")
+	ft.AssertEqual(t, lastNameParam, PlanParams[3].Name, "Incorrect name for last_name")
+}
+
+func verifyMapPath(t *testing.T, planMetadata map[string]interface{}, path []string) map[string]interface{} {
+	currentMap := planMetadata
+	var correctType bool
+	for _, jsonKey := range path {
+		currentMap, correctType = currentMap[jsonKey].(map[string]interface{})
+		ft.AssertTrue(t, correctType, "incorrectly typed "+jsonKey+" metadata")
+		ft.AssertNotNil(t, currentMap, jsonKey+" metadata empty")
+	}
+
+	return currentMap
 }
 
 func TestParametersToSchema(t *testing.T) {

--- a/pkg/broker/util_test.go
+++ b/pkg/broker/util_test.go
@@ -125,23 +125,22 @@ func TestUpdateMetadata(t *testing.T) {
 func verifyFormDefinition(t *testing.T, planMetadata map[string]interface{}, path []string) {
 
 	formDefnMap := verifyMapPath(t, planMetadata, path)
-	formDefnMetadata, correctType := formDefnMap["form_definition"].([]interface{})
+	formDefnMetadata, correctType := formDefnMap["openshift_form_definition"].([]interface{})
 	ft.AssertTrue(t, correctType, strings.Join(path, ".")+" Form definition is of the wrong type")
 	ft.AssertNotNil(t, formDefnMetadata, "Form definition is nil")
 
-	passwordParam, correctType := formDefnMetadata[1].(map[string]string)
+	passwordParam, correctType := formDefnMetadata[1].(formItem)
 	ft.AssertTrue(t, correctType, strings.Join(path, ".")+" Form definition password param is of the wrong type")
 	ft.AssertNotNil(t, passwordParam)
-	ft.AssertEqual(t, passwordParam["key"], PlanParams[1].Name, "Password parameter has the wrong name")
-	ft.AssertEqual(t, passwordParam["type"], PlanParams[1].DisplayType, "Password parameter display type is incorrect")
+	ft.AssertEqual(t, passwordParam.Key, PlanParams[1].Name, "Password parameter has the wrong name")
+	ft.AssertEqual(t, passwordParam.Type, PlanParams[1].DisplayType, "Password parameter display type is incorrect")
 
-	group, correctType := formDefnMetadata[2].(map[string]interface{})
+	group, correctType := formDefnMetadata[2].(formItem)
 	ft.AssertTrue(t, correctType, strings.Join(path, ".")+" Form definition parameter group is of the wrong type")
 	ft.AssertNotNil(t, group, "Parameter group is empty")
-	ft.AssertEqual(t, group["type"], "fieldset")
+	ft.AssertEqual(t, group.Type, "fieldset")
 
-	groupedItems, correctType := group["items"].([]interface{})
-	ft.AssertTrue(t, correctType, strings.Join(path, ".")+" Form definition parameter group items are the wrong type")
+	groupedItems := group.Items
 	ft.AssertNotNil(t, groupedItems, "Group missing parameter items")
 	ft.AssertEqual(t, len(groupedItems), 2, "Incorrect number of parameters in group")
 

--- a/pkg/broker/work_engine.go
+++ b/pkg/broker/work_engine.go
@@ -2,6 +2,7 @@ package broker
 
 import (
 	"errors"
+
 	"github.com/pborman/uuid"
 )
 

--- a/pkg/clients/clients.go
+++ b/pkg/clients/clients.go
@@ -1,9 +1,10 @@
 package clients
 
 import (
+	"sync"
+
 	etcd "github.com/coreos/etcd/client"
 	k8s "k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
-	"sync"
 )
 
 var instances struct {

--- a/pkg/clients/kubernetes.go
+++ b/pkg/clients/kubernetes.go
@@ -2,6 +2,7 @@ package clients
 
 import (
 	"errors"
+
 	logging "github.com/op/go-logging"
 	restclient "k8s.io/client-go/rest"
 

--- a/pkg/registries/adapters/openshift_adapter.go
+++ b/pkg/registries/adapters/openshift_adapter.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	b64 "encoding/base64"
+
 	logging "github.com/op/go-logging"
 	"github.com/openshift/ansible-service-broker/pkg/apb"
 )


### PR DESCRIPTION
Added UI form information to metadata fields for parsing by OpenShift UI.

https://github.com/openshift/ansible-service-broker/blob/master/docs/proposals/form-metadata.md

Changes proposed in this pull request
 - Add json regarding parameter order, groups, and display type to metadata in the json-schema-form definition.
 - Unit tests
