### PR TITLE
Label APBs with their FQNames

### DIFF
--- a/pkg/apb/executor.go
+++ b/pkg/apb/executor.go
@@ -64,6 +64,9 @@ func ExecuteApb(
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: apbID,
+			Labels: map[string]string{
+				"apb-fqname": spec.FQName,
+			},
 		},
 		Spec: v1.PodSpec{
 			Containers: []v1.Container{


### PR DESCRIPTION
Adds some additional identifying metadata in the form of a label to help users identify what services apb pods are deploying.