### PR TITLE
adding broker build to build of image.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ $(KUBERNETES_FILES):
 prepare-local-env: $(KUBERNETES_FILES) ## Prepare the local environment for running the broker locally
 	@echo > /dev/null
 
-build-image: ## Build a docker image with the broker binary
+build-image: broker | ## Build a docker image with the broker binary
 	cp broker build/broker
 	docker build -f ${BUILD_DIR}/Dockerfile-localdev -t ${BROKER_IMAGE}:${TAG} ${BUILD_DIR}
 	@echo

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ $(KUBERNETES_FILES):
 prepare-local-env: $(KUBERNETES_FILES) ## Prepare the local environment for running the broker locally
 	@echo > /dev/null
 
-build-image: broker | ## Build a docker image with the broker binary
+build-image: broker ## Build a docker image with the broker binary
 	cp broker build/broker
 	docker build -f ${BUILD_DIR}/Dockerfile-localdev -t ${BROKER_IMAGE}:${TAG} ${BUILD_DIR}
 	@echo


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
Adds the build of the broker to the build-image target
Changes proposed in this pull request
 - add the broker build step to the build-image target

**Which issue this PR fixes (This will close that issue when PR gets merged)**
fixes #394 
