### PR TITLE
Fix spelling in logs

### DIFF
--- a/pkg/apb/ext_creds.go
+++ b/pkg/apb/ext_creds.go
@@ -36,7 +36,7 @@ func monitorOutput(namespace string, podname string, log *logging.Logger) ([]byt
 
 	for r := 1; r <= apbWatchRetries; r++ {
 		// err will be the return code from the exec command
-		// Use the error code to deterine the state
+		// Use the error code to determine the state
 		failedToExec := errors.New("exit status 1")
 		credsNotAvailable := errors.New("exit status 2")
 
@@ -55,7 +55,7 @@ func monitorOutput(namespace string, podname string, log *logging.Logger) ([]byt
 			log.Warning("[%s] Retry attempt %d: Failed to exec into the container", podname, r)
 		} else if err.Error() == credsNotAvailable.Error() {
 			log.Info(string(output))
-			log.Warning("[%s] Retry attempt %d: Bind credentials not availble yet", podname, r)
+			log.Warning("[%s] Retry attempt %d: Bind credentials not available yet", podname, r)
 		} else {
 			log.Info(string(output))
 			log.Warning("[%s] Retry attempt %d: Failed to exec into the container", podname, r)

--- a/scripts/broker-ci/local-ci.sh
+++ b/scripts/broker-ci/local-ci.sh
@@ -50,23 +50,23 @@ function bind-credential-check {
 	# Filter for 'podpreset.admission.kubernetes.io' in the pod
 	preset_test=$(oc get pods $(oc get pods -n default | grep mediawiki | awk $'{ print $1 }') -o yaml -n default | grep podpreset | awk $'{ print $1}' | cut -f 1 -d '/')
 	if [ "${preset_test}" = "podpreset.admission.kubernetes.io" ]; then
-	    print-with-green "Pod presets found in the Mediawiki pod"
+	    print-with-green "Pod presets found in the MediaWiki pod"
 	    break
 	else
-	    print-with-yellow "Pod presets not found in the Mediawiki pod"
+	    print-with-yellow "Pod presets not found in the MediaWiki pod"
 	    print-with-yellow "Retrying..."
 	fi
     done
 
     if [ "${x}" -eq "${RETRIES}" ]; then
-	print-with-red "Pod presets aren't in the Mediawiki pod"
+	print-with-red "Pod presets aren't in the MediaWiki pod"
 	BIND_ERROR=true
     fi
     set -x
 }
 
 function pickup-pod-presets {
-    print-with-green "Checking if mediawiki recieved bind credentials"
+    print-with-green "Checking if MediaWiki received bind credentials"
     bind-credential-check
 
     error-check "pickup-pod-presets"


### PR DESCRIPTION


**Describe what this PR does and why we need it**:

I noticed when running the local-ci script that there were spelling
mistakes in both the local-ci script and the logs being dumped for the
broker. As going through all files would be a long process, this change
addresses all the issues found in the two files I noticed had issues
from the logs.

**Does this PR depend on another PR (Use this to track when PRs should be merged)**
N/A

**Which issue this PR fixes (This will close that issue when PR gets merged)**
N/A
