### PR TITLE
Fixed duplicate parameter after group.

### DIFF
--- a/pkg/broker/util.go
+++ b/pkg/broker/util.go
@@ -93,9 +93,7 @@ func updateMetadata(metadata map[string]interface{}, params []apb.ParameterDescr
 }
 
 func createUIFormGroup(params []apb.ParameterDescriptor, groupName string, paramIndex int) (formItem, int) {
-	var item interface{}
 	items := []interface{}{}
-	numItems := 0
 
 	for paramIndex < len(params) {
 		pd := params[paramIndex]
@@ -103,7 +101,7 @@ func createUIFormGroup(params []apb.ParameterDescriptor, groupName string, param
 			break
 		}
 
-		item, numItems = createUIFormItem(pd, paramIndex)
+		item, numItems := createUIFormItem(pd, paramIndex)
 		items = append(items, item)
 		paramIndex = paramIndex + numItems
 	}
@@ -113,7 +111,7 @@ func createUIFormGroup(params []apb.ParameterDescriptor, groupName string, param
 		Items: items,
 	}
 
-	return group, numItems
+	return group, len(items)
 }
 
 func createUIFormItem(pd apb.ParameterDescriptor, paramIndex int) (interface{}, int) {

--- a/pkg/broker/util_test.go
+++ b/pkg/broker/util_test.go
@@ -128,6 +128,7 @@ func verifyFormDefinition(t *testing.T, planMetadata map[string]interface{}, pat
 	formDefnMetadata, correctType := formDefnMap["openshift_form_definition"].([]interface{})
 	ft.AssertTrue(t, correctType, strings.Join(path, ".")+" Form definition is of the wrong type")
 	ft.AssertNotNil(t, formDefnMetadata, "Form definition is nil")
+	ft.AssertEqual(t, len(formDefnMetadata), 3, "Incorrect number of parameters in form definition")
 
 	passwordParam, correctType := formDefnMetadata[1].(formItem)
 	ft.AssertTrue(t, correctType, strings.Join(path, ".")+" Form definition password param is of the wrong type")


### PR DESCRIPTION
While making fixes in previous PR, I accidentally misnamed a variable and was duplicating the last parameter when creating a form definition.  That is fixed and a test case added.
