### PR TITLE
ignore the broker only at the root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,9 +31,9 @@ etc/prod.config.yaml
 etc/mock.config.yaml
 
 #Compiled binaries
-broker
+/broker
 build/broker
-!pkg/broker
+#!pkg/broker
 
 # python artifacts
 .python-version


### PR DESCRIPTION
The ag search tool respects the .gitignore file but having broker alone
was too aggressive for the tool. So by adding the / it tells git to
ignore broker only at the project root.
