### PR TITLE
Default for no filter mode is to not contain a single APB.

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -23,7 +23,7 @@ for APBs. All the registry config options are defined below
 | type          | The type of registry. The only adapters so far are mock, RHCC, openshift, and dockerhub.                                         |     Y    |
 | url           | The url that is used to retrieve image information. Used extensively for RHCC while the docker hub adapter uses hard-coded URLs. |     N    |
 | fail_on_error | Should this registry fail the bootstrap request if it fails. will stop the execution of other registries loading.                |     N    |
-| white_list    | The list of regular expressions used to define which image names should be allowed through.                                      |     N    |
+| white_list    | The list of regular expressions used to define which image names should be allowed through. Must have a white list to allow APBs to be added to the catalog. The most permissive regular expression that you can use is `.*-apb$` if you would want to retrieve all APBs in a registry.                                     |     N    |
 | black_list    | The list of regular expressions used to define which images names should never be allowed through.                               |     N    |
 | images        | The list of images to be used with OpenShift Registry.                                                                           |     N    |
 
@@ -79,6 +79,8 @@ registry:
     org: ansibleplaybookbundle
     user: user
     pass: password
+    white_list:
+      - ".*-apb$"
 ```
 
 ### Red Hat Container Catalog (RHCC) Registry
@@ -89,6 +91,8 @@ registry:
   - name: rhcc
     type: rhcc
     url: <rhcc url>
+    white_list:
+      - ".*-apb$"
 ```
 
 ### OpenShift Registry
@@ -104,6 +108,8 @@ registry:
     images:
       - <image_1>
       - <image_2>
+    white_list:
+      - ".*-apb$"
 ```
 
 There is a limitation when working with the OpenShift Registry right now. We have no capability to search the registry so we require that the user configure the broker with a list of images they would like to source from for when the broker bootstraps. The image name must be the fully qualified name without the registry URL. 
@@ -118,9 +124,13 @@ registry:
     org: ansibleplaybookbundle
     user: user
     pass: password
+    white_list:
+      - ".*-apb$"
   - name: rhcc
     type: rhcc
     url: <rhcc url>
+    white_list:
+      - ".*-apb$"
 ```
 
 ## DAO Configuration

--- a/docs/filtering_apbs.md
+++ b/docs/filtering_apbs.md
@@ -14,6 +14,7 @@ total set of discovered APBs for a given registry, determining matches.
 | only whitelist | matches a regex in list                         | *ANY* APB that does not match        |
 | only blacklist | *ALL* APBs that do not match                    | APBs that match a regex in list      |
 |  both present  | matches regex in whitelist but NOT in blacklist | APBs that match a regex in blacklist |
+|  None | *No* APBs from the registry | *All* APBs from that registry |
 
 ### Examples
 

--- a/etc/example-config.yaml
+++ b/etc/example-config.yaml
@@ -13,6 +13,9 @@ registry:
     fail_on_error: true
     white_list:
       - "^legitimate.*-apb$"    
+      # will allow all the APBs to be included. You must have at least 1 white 
+      # list to retrieve APBs and this is the most permissive 
+      - ".*-apb$" 
     black_list:
       - "malicious.*-apb$"
       - "^specific-blacklist-apb$"

--- a/pkg/registries/filter.go
+++ b/pkg/registries/filter.go
@@ -21,6 +21,7 @@
 package registries
 
 import (
+	"fmt"
 	"regexp"
 	"sync"
 )
@@ -81,7 +82,8 @@ func compileRegexp(regexStrs []string) ([]*regexp.Regexp, []failedRegexp) {
 func (f *Filter) Run(totalList []string) ([]string, []string) {
 	filterMode := f.getFilterMode()
 	if filterMode == filterModeNone {
-		return totalList, nil
+		fmt.Printf("!!!!!!filter mode is none")
+		return nil, nil
 	}
 
 	whiteMatchSet, blackMatchSet := genMatchSets(

--- a/scripts/prep_local_devel_env.sh
+++ b/scripts/prep_local_devel_env.sh
@@ -201,6 +201,10 @@ registry:
     user: ${DOCKERHUB_USERNAME}
     pass: ${DOCKERHUB_PASSWORD}
     org: ${DOCKERHUB_ORG}
+    white_list:
+      # will allow all the APBs to be included. You must have at least 1 white 
+      # list to retrieve APBs and this is the most permissive 
+      - ".*-apb$"
 dao:
   etcd_host: ${ETCD_ROUTE}
   etcd_port: ${ETCD_PORT}

--- a/templates/deploy-ansible-service-broker.template.yaml
+++ b/templates/deploy-ansible-service-broker.template.yaml
@@ -171,6 +171,8 @@ objects:
           pass: "${DOCKERHUB_PASS}"
           org: "${DOCKERHUB_ORG}"
           tag: "${TAG}"
+          white_list:
+            - ".*-apb$"
       dao:
         etcd_host: 0.0.0.0
         etcd_port: 2379


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
The goal of the PR is to make the default behavior for the time when there is no white list or black list to be the most restrictive, and not include any APBs.

Changes proposed in this pull request
 - Default for `NoFilterMode` is to not include any APBs
- Template updates to make catasb behave as it does today. 
- Updates to the `prepare_local_devel_env.sh` so that it will behave as it does today.