### PR TITLE
Update build to also work with Fedora 27

### DIFF
--- a/ansible-service-broker.spec
+++ b/ansible-service-broker.spec
@@ -150,13 +150,7 @@ cp -r pkg src/github.com/openshift/ansible-service-broker
 
 %build
 export GOPATH=$(pwd):%{gopath}
-export LDFLAGS='-s -w'
-BUILDTAGS="seccomp selinux"
-%if ! 0%{?gobuild:1}
-%define gobuild() go build -ldflags "${LDFLAGS:-} -B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \\n')" -a -v -x %{**};
-%endif
-
-%gobuild -tags "$BUILDTAGS" ./cmd/broker
+go build -tags "seccomp selinux" -ldflags "-s -w" ./cmd/broker
 
 #Build selinux modules
 # create selinux-friendly version from VR and replace it inplace


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
Changes the build command in the RPM spec. We have been getting an error due to using -tags, but it has not been fatal until Fedora 27.

Changes proposed in this pull request
 - On the related bug the suggestion if using any other flag besides -o is to use the go build command directly rather than %gobuild, so I am doing that.
 - https://bugzilla.redhat.com/show_bug.cgi?id=1409931

**Does this PR depend on another PR (Use this to track when PRs should be merged)**
depends-on <PR>
N/A

**Which issue this PR fixes (This will close that issue when PR gets merged)**
fixes <issue_number>
N/A