### PR TITLE
Force delete the mediawiki pod

### DIFF
--- a/scripts/broker-ci/local-ci.sh
+++ b/scripts/broker-ci/local-ci.sh
@@ -60,7 +60,7 @@ function bind-credential-check {
     set +x
     RETRIES=10
     for x in $(seq $RETRIES); do
-	oc delete pods $(oc get pods -o name -l app=mediawiki123 -n default | head -1 | cut -f 2 -d '/') -n default || BIND_ERROR=true
+	oc delete pods $(oc get pods -o name -l app=mediawiki123 -n default | head -1 | cut -f 2 -d '/') -n default  --force --grace-period=10 || BIND_ERROR=true
 	./scripts/broker-ci/wait-for-resource.sh create pod mediawiki >> /tmp/wait-for-pods-log 2>&1
 
 	# Filter for 'podpreset.admission.kubernetes.io' in the pod


### PR DESCRIPTION
Sometimes the mediawiki pod complains about a secrent not being
    mounted from the service account APB. I'm not sure why yet,
    but this will at least be a work around for now.
