### PR TITLE
Update template to support newer service-catalogs

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -123,6 +123,24 @@ spec:
       name: asb-auth-secret
 ```
 
+Starting wtih v0.0.17 of the service catalog the broker resource configuration changes.
+
+```yaml
+apiVersion: servicecatalog.k8s.io/v1alpha1
+kind: ServiceBroker
+metadata:
+  name: ansible-service-broker
+spec:
+  url: https://asb-1338-ansible-service-broker.172.17.0.1.nip.io
+  authInfo:
+    basic:
+      secretRef:
+        namespace: ansible-service-broker
+        name: asb-auth-secret
+```
+
+
+
 *NOTE*: this section is highly dependent on what the service catalog expects. If
 the format for the secret changes we will need to create a separate secret for
 just the service catalog today OR we need to add a new `UserServiceAdapter` that

--- a/templates/deploy-ansible-service-broker.template.yaml
+++ b/templates/deploy-ansible-service-broker.template.yaml
@@ -54,6 +54,7 @@ objects:
       targetPort: port-1338
     tls:
       termination: ${TERMINATION}
+      insecureEdgeTerminationPolicy: ${{INSECURE_EDGE}}
 
 - apiVersion: v1
   kind: PersistentVolumeClaim
@@ -199,17 +200,25 @@ objects:
             enabled: ${ENABLE_BASIC_AUTH}
 
 - apiVersion: servicecatalog.k8s.io/v1alpha1
-  kind: Broker
+  kind: ${BROKER_KIND}
   metadata:
     name: ansible-service-broker
   spec:
     url: ${ASB_SCHEME}://asb-1338-ansible-service-broker.${ROUTING_SUFFIX}
     authInfo:
-      basicAuthSecret:
-        namespace: ansible-service-broker
-        name: asb-auth-secret
+      ${{BROKER_AUTH}}
 
 parameters:
+- description: Service Broker kind. Newer service-catalogs use ServiceBroker
+  displayname: Service Broker kind. Newer service-catalogs use ServiceBroker
+  name: BROKER_KIND
+  value: Broker
+
+- description: Broker Auth Info
+  displayname: Broker Auth Info
+  name: BROKER_AUTH
+  value: '{ "basicAuthSecret": { "namespace": "ansible-service-broker", "name": "asb-auth-secret" }}'
+
 - description: Scheme for ansible service broker (http/https)
   displayname: Scheme for ansible service broker (http/https)
   name: ASB_SCHEME
@@ -240,12 +249,17 @@ parameters:
   name: BROKER_CONFIG
   value: /etc/ansible-service-broker/config.yaml
 
-# SSL enabled: INSECURE="false", TERMINATION=Reencrypt
-# Insecure enabled: INSECURE="true", TERMINATION=edge
+# SSL enabled: INSECURE="false", INSECURE_EDGE="None", TERMINATION="Reencrypt", ASB_SCHEME="https"
+# Insecure enabled: INSECURE="true", INSECURE_EDGE="Allow", TERMINATION="edge", ASB_SCHEME="http"
 - description: Run in insecure mode
   displayname: Ansible Service Broker Insecure
   name: INSECURE
   value: "false"
+
+- description: Insecure Edge Termination Policy
+  displayname: Insecure Edge Termination Policy
+  name: INSECURE_EDGE
+  value: "None"
 
 - description: Secure the route with TLS
   displayname: Ansible Service Broker Termination


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
In order to work with newer service-catalogs we need a way to specify in the template the Kind and Auth for the broker.

We can do this for instance with catasb by adding to the template processing:
```
  - name: Update Broker Kind and Auth when using coalmine
    set_fact:
      cmd_process_asb_template: >-
        {{ cmd_process_asb_template }}
        -p BROKER_KIND="ServiceBroker"
        -p BROKER_AUTH='{ "basic": { "secretRef": { "namespace": "ansible-service-broker", "name": "asb-auth-secret" } } }'
    when: coalmine is defined and coalmine
```

Changes proposed in this pull request
 - Add support to specify BROKER_KIND and BROKER_AUTH in the openshift template
 - Set defaults for current service-catalog images in dockerhub openshift repos

**Does this PR depend on another PR (Use this to track when PRs should be merged)**
depends-on <PR>
Might be good to go in with or before @djzager s PR when it's been tested a little more.
https://github.com/fusor/catasb/pull/131

**Which issue this PR fixes (This will close that issue when PR gets merged)**
fixes <issue_number>
N/A

There's probably more to go here. I get a successful catasb run now, but I don't see any APB's populated with 3.6 or 3.7 and oc get serviceclasses returns nothing even though the broker appears to have found them all.

```
ERROR: logging before flag.Parse: I0906 15:16:26.770523      11 leaderelection.go:204] successfully renewed lease kube-service-catalog/service-catalog-controller-manager
ERROR: logging before flag.Parse: I0906 15:16:26.991390      11 reflector.go:236] Listing and watching *v1alpha1.ServiceInstance from github.com/kubernetes-incubator/service-catalog/pkg/client/informers_generated/externalversions/factory.go:61
ERROR: logging before flag.Parse: I0906 15:16:26.992395      11 reflector.go:236] Listing and watching *v1alpha1.ServiceInstanceCredential from github.com/kubernetes-incubator/service-catalog/pkg/client/informers_generated/externalversions/factory.go:61
ERROR: logging before flag.Parse: I0906 15:16:26.993546      11 reflector.go:236] Listing and watching *v1alpha1.ServiceBroker from github.com/kubernetes-incubator/service-catalog/pkg/client/informers_generated/externalversions/factory.go:61
ERROR: logging before flag.Parse: E0906 15:16:27.000550      11 reflector.go:201] github.com/kubernetes-incubator/service-catalog/pkg/client/informers_generated/externalversions/factory.go:61: Failed to list *v1alpha1.ServiceInstance: User "system:serviceaccount:kube-service-catalog:service-catalog-controller" cannot list all serviceinstances.servicecatalog.k8s.io in the cluster
ERROR: logging before flag.Parse: E0906 15:16:27.000597      11 reflector.go:201] github.com/kubernetes-incubator/service-catalog/pkg/client/informers_generated/externalversions/factory.go:61: Failed to list *v1alpha1.ServiceInstanceCredential: User "system:serviceaccount:kube-service-catalog:service-catalog-controller" cannot list all serviceinstancecredentials.servicecatalog.k8s.io in the cluster
ERROR: logging before flag.Parse: E0906 15:16:27.001251      11 reflector.go:201] github.com/kubernetes-incubator/service-catalog/pkg/client/informers_generated/externalversions/factory.go:61: Failed to list *v1alpha1.ServiceBroker: User "system:serviceaccount:kube-service-catalog:service-catalog-controller" cannot list all servicebrokers.servicecatalog.k8s.io in the cluster
```