### PR TITLE
Split the deploy.sh script to work with both kube & openshift

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,67 +1,11 @@
 #!/bin/bash
-source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
-# from makefile
-BROKER_IMAGE=$1
-REGISTRY=$2
-DOCKERHUB_ORG=$3
+BROKER_ROOT=$(dirname "${BASH_SOURCE}")/..
 
-# can be overridden via my_local_dev_vars
-PROJECT=${ASB_PROJECT}
-ROUTING_SUFFIX="172.17.0.1.nip.io"
-OPENSHIFT_TARGET="https://kubernetes.default"
-REGISTRY_TYPE="dockerhub"
-DEV_BROKER="true"
-LAUNCH_APB_ON_BIND="false"
-OUTPUT_REQUEST="true"
-RECOVERY="true"
-REFRESH_INTERVAL="600s"
-SANDBOX_ROLE="edit"
-BROKER_KIND="${BROKER_KIND:-Broker}"
-auth=$(echo -e "{\"basicAuthSecret\":{\"namespace\":\"ansible-service-broker\",\"name\":\"asb-auth-secret\"}}")
-BROKER_AUTH="${BROKER_AUTH:-$auth}"
-ENABLE_BASIC_AUTH=true
-
-# load development variables
-asb::load_vars
-
-# check the variables that do not have defaults
-asb::validate_var "BROKER_IMAGE" $BROKER_IMAGE
-asb::validate_var "REGISTRY" $REGISTRY
-asb::validate_var "DOCKERHUB_USER" $DOCKERHUB_USER
-asb::validate_var "DOCKERHUB_PASS" $DOCKERHUB_PASS
-asb::validate_var "DOCKERHUB_ORG" $DOCKERHUB_ORG
-asb::validate_var "REFRESH_INTERVAL" $REFRESH_INTERVAL
-
-VARS="-p BROKER_IMAGE=${BROKER_IMAGE} \
-  -p ROUTING_SUFFIX=${ROUTING_SUFFIX} \
-  -p OPENSHIFT_TARGET=${OPENSHIFT_TARGET} \
-  -p DOCKERHUB_ORG=${DOCKERHUB_ORG} \
-  -p DOCKERHUB_PASS=${DOCKERHUB_PASS} \
-  -p DOCKERHUB_USER=${DOCKERHUB_USER} \
-  -p REGISTRY_TYPE=${REGISTRY_TYPE} \
-  -p REGISTRY_URL=${REGISTRY} \
-  -p DEV_BROKER=${DEV_BROKER} \
-  -p LAUNCH_APB_ON_BIND=${LAUNCH_APB_ON_BIND} \
-  -p OUTPUT_REQUEST=${OUTPUT_REQUEST} \
-  -p RECOVERY=${RECOVERY} \
-  -p REFRESH_INTERVAL=${REFRESH_INTERVAL} \
-  -p SANDBOX_ROLE=${SANDBOX_ROLE} \
-  -p BROKER_KIND=${BROKER_KIND} \
-  -p BROKER_AUTH=${BROKER_AUTH} \
-  -p ENABLE_BASIC_AUTH=${ENABLE_BASIC_AUTH}"
-
-# cleanup old deployment
-asb::delete_project ${PROJECT}
-
-# delete the broker
-oc delete "${BROKER_KIND}" --ignore-not-found=true ansible-service-broker
-
-# delete the clusterrolebinding to avoid template error
-oc delete clusterrolebindings --ignore-not-found=true asb
-
-# deploy
-oc new-project ${PROJECT}
-oc process -f ${BROKER_TEMPLATE} \
-  -n ${PROJECT} \
-  ${VARS} | oc create -f -
+if [[ "${KUBERNETES}" ]]; then
+    echo "Using Kubernetes"
+    "${BROKER_ROOT}/scripts/kubernetes/deploy.sh"
+else
+    echo "Using OpenShift"
+    "${BROKER_ROOT}/scripts/openshift/deploy.sh"
+fi

--- a/scripts/kubernetes/deploy.sh
+++ b/scripts/kubernetes/deploy.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+source "$(dirname "${BASH_SOURCE}")/../lib/init.sh"
+
+PROJECT=${ASB_PROJECT}
+
+kubectl delete ns ${PROJECT}
+
+retries=25
+for r in $(seq $retries); do
+    kubectl get ns ansible-service-broker | grep ansible-service-broker
+    if [ "$?" -eq 1 ]; then
+	break
+    fi
+    sleep 4
+done
+
+kubectl delete clusterrolebindings --ignore-not-found=true asb
+kubectl delete pv --ignore-not-found=true etcd
+
+# Render the Kubernetes template
+"${TEMPLATE_DIR}/k8s-template.py"
+
+kubectl create -f "${TEMPLATE_DIR}/k8s-ansible-service-broker.yaml"

--- a/scripts/openshift/deploy.sh
+++ b/scripts/openshift/deploy.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+source "$(dirname "${BASH_SOURCE}")/../lib/init.sh"
+
+# from makefile
+BROKER_IMAGE=$1
+REGISTRY=$2
+DOCKERHUB_ORG=$3
+
+# can be overridden via my_local_dev_vars
+PROJECT=${ASB_PROJECT}
+ROUTING_SUFFIX="172.17.0.1.nip.io"
+OPENSHIFT_TARGET="https://kubernetes.default"
+REGISTRY_TYPE="dockerhub"
+DEV_BROKER="true"
+LAUNCH_APB_ON_BIND="false"
+OUTPUT_REQUEST="true"
+RECOVERY="true"
+REFRESH_INTERVAL="600s"
+SANDBOX_ROLE="edit"
+BROKER_KIND="${BROKER_KIND:-Broker}"
+auth=$(echo -e "{\"basicAuthSecret\":{\"namespace\":\"ansible-service-broker\",\"name\":\"asb-auth-secret\"}}")
+BROKER_AUTH="${BROKER_AUTH:-$auth}"
+ENABLE_BASIC_AUTH=true
+
+# load development variables
+asb::load_vars
+
+# check the variables that do not have defaults
+asb::validate_var "BROKER_IMAGE" $BROKER_IMAGE
+asb::validate_var "REGISTRY" $REGISTRY
+asb::validate_var "DOCKERHUB_USER" $DOCKERHUB_USER
+asb::validate_var "DOCKERHUB_PASS" $DOCKERHUB_PASS
+asb::validate_var "DOCKERHUB_ORG" $DOCKERHUB_ORG
+asb::validate_var "REFRESH_INTERVAL" $REFRESH_INTERVAL
+
+VARS="-p BROKER_IMAGE=${BROKER_IMAGE} \
+  -p ROUTING_SUFFIX=${ROUTING_SUFFIX} \
+  -p OPENSHIFT_TARGET=${OPENSHIFT_TARGET} \
+  -p DOCKERHUB_ORG=${DOCKERHUB_ORG} \
+  -p DOCKERHUB_PASS=${DOCKERHUB_PASS} \
+  -p DOCKERHUB_USER=${DOCKERHUB_USER} \
+  -p REGISTRY_TYPE=${REGISTRY_TYPE} \
+  -p REGISTRY_URL=${REGISTRY} \
+  -p DEV_BROKER=${DEV_BROKER} \
+  -p LAUNCH_APB_ON_BIND=${LAUNCH_APB_ON_BIND} \
+  -p OUTPUT_REQUEST=${OUTPUT_REQUEST} \
+  -p RECOVERY=${RECOVERY} \
+  -p REFRESH_INTERVAL=${REFRESH_INTERVAL} \
+  -p SANDBOX_ROLE=${SANDBOX_ROLE} \
+  -p BROKER_KIND=${BROKER_KIND} \
+  -p BROKER_AUTH=${BROKER_AUTH} \
+  -p ENABLE_BASIC_AUTH=${ENABLE_BASIC_AUTH}"
+
+# cleanup old deployment
+asb::delete_project ${PROJECT}
+
+# delete the broker
+oc delete "${BROKER_KIND}" --ignore-not-found=true ansible-service-broker
+
+# delete the clusterrolebinding to avoid template error
+oc delete clusterrolebindings --ignore-not-found=true asb
+
+# deploy
+oc new-project ${PROJECT}
+oc process -f ${BROKER_TEMPLATE} \
+  -n ${PROJECT} \
+  ${VARS} | oc create -f -


### PR DESCRIPTION
These two scripts are very different because one will use OpenShift
templates and the other will use jinja2. I added an intermediate script
that will direct to the proper location.

Changes proposed in this pull request
 - Run ```make deploy``` for both openshift and kubernetes envs
