### PR TITLE
1497819 - Broker should not rely on image field of APB yaml

### DIFF
--- a/pkg/apb/types.go
+++ b/pkg/apb/types.go
@@ -62,7 +62,7 @@ type Plan struct {
 type Spec struct {
 	ID          string                 `json:"id"`
 	FQName      string                 `json:"name" yaml:"name"`
-	Image       string                 `json:"image"`
+	Image       string                 `json:"image,omitempty"`
 	Tags        []string               `json:"tags"`
 	Bindable    bool                   `json:"bindable"`
 	Description string                 `json:"description"`

--- a/pkg/apb/types.go
+++ b/pkg/apb/types.go
@@ -62,7 +62,7 @@ type Plan struct {
 type Spec struct {
 	ID          string                 `json:"id"`
 	FQName      string                 `json:"name" yaml:"name"`
-	Image       string                 `json:"image,omitempty"`
+	Image       string                 `json:"image" yaml:"-"`
 	Tags        []string               `json:"tags"`
 	Bindable    bool                   `json:"bindable"`
 	Description string                 `json:"description"`

--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -268,8 +268,8 @@ func addNameAndIDForSpec(specs []*apb.Spec, registryName string) {
 		// need to make / a hyphen to allow for global uniqueness
 		// but still match spec.
 
-		imageName := strings.Replace(spec.Image, ":", "-", -1)
-		spec.FQName = strings.Replace(fmt.Sprintf("%v-%v", registryName, imageName),
+		spec.FQName = strings.Replace(
+			fmt.Sprintf("%v-%v", registryName, spec.FQName),
 			"/", "-", -1)
 		spec.FQName = fmt.Sprintf("%.51v", spec.FQName)
 		if strings.HasSuffix(spec.FQName, "-") {

--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -27,6 +27,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"reflect"
+	"regexp"
 	"strings"
 
 	"github.com/coreos/etcd/client"
@@ -56,6 +57,8 @@ const (
 	provisionCredentialsKey = "_apb_provision_creds"
 	// bindCredentialsKey - Key used to pas bind credentials to apb.
 	bindCredentialsKey = "_apb_bind_creds"
+	// fqNameRegex - regular expression used when forming FQName.
+	fqNameRegex = "[/.:-]"
 )
 
 // Broker - A broker is used to to compelete all the tasks that a broker must be able to do.
@@ -268,9 +271,10 @@ func addNameAndIDForSpec(specs []*apb.Spec, registryName string) {
 		// need to make / a hyphen to allow for global uniqueness
 		// but still match spec.
 
-		spec.FQName = strings.Replace(
+		re := regexp.MustCompile(fqNameRegex)
+		spec.FQName = re.ReplaceAllLiteralString(
 			fmt.Sprintf("%v-%v", registryName, spec.FQName),
-			"/", "-", -1)
+			"-")
 		spec.FQName = fmt.Sprintf("%.51v", spec.FQName)
 		if strings.HasSuffix(spec.FQName, "-") {
 			spec.FQName = spec.FQName[:len(spec.FQName)-1]

--- a/pkg/broker/broker_test.go
+++ b/pkg/broker/broker_test.go
@@ -54,8 +54,8 @@ func TestUpdate(t *testing.T) {
 }
 
 func TestAddNameAndIDForSpecStripsTailingDash(t *testing.T) {
-	spec1 := apb.Spec{Image: "1234567890123456789012345678901234567890-"}
-	spec2 := apb.Spec{Image: "org/hello-world-apb"}
+	spec1 := apb.Spec{FQName: "1234567890123456789012345678901234567890-"}
+	spec2 := apb.Spec{FQName: "org/hello-world-apb"}
 	spcs := []*apb.Spec{&spec1, &spec2}
 	addNameAndIDForSpec(spcs, "h")
 	ft.AssertEqual(t, "h-1234567890123456789012345678901234567890", spcs[0].FQName)

--- a/pkg/registries/adapters/adapter.go
+++ b/pkg/registries/adapters/adapter.go
@@ -23,7 +23,6 @@ package adapters
 import (
 	b64 "encoding/base64"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -62,7 +61,7 @@ type Configuration struct {
 }
 
 // Retrieve the spec from a registry manifest request
-func imageToSpec(log *logging.Logger, req *http.Request, apbtag string) (*apb.Spec, error) {
+func imageToSpec(log *logging.Logger, req *http.Request, image string) (*apb.Spec, error) {
 	log.Debug("Registry::imageToSpec")
 	spec := &apb.Spec{}
 	req.Header.Add("Accept", "application/json")
@@ -131,7 +130,7 @@ func imageToSpec(log *logging.Logger, req *http.Request, apbtag string) (*apb.Sp
 		return nil, err
 	}
 
-	spec.Image = fmt.Sprintf("%s:%s", spec.Image, apbtag)
+	spec.Image = image
 
 	log.Debugf("adapter::imageToSpec -> Got plans %+v", spec.Plans)
 	log.Debugf("Successfully converted Image %s into Spec", spec.Image)

--- a/pkg/registries/adapters/dockerhub_adapter.go
+++ b/pkg/registries/adapters/dockerhub_adapter.go
@@ -237,7 +237,7 @@ func (r DockerHubAdapter) loadSpec(imageName string) (*apb.Spec, error) {
 		return nil, err
 	}
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %v", token))
-	return imageToSpec(r.Log, req, r.Config.Tag)
+	return imageToSpec(r.Log, req, fmt.Sprintf("%s/%s:%s", r.RegistryName(), imageName, r.Config.Tag))
 }
 
 func (r DockerHubAdapter) getBearerToken(imageName string) (string, error) {

--- a/pkg/registries/adapters/openshift_adapter.go
+++ b/pkg/registries/adapters/openshift_adapter.go
@@ -126,5 +126,5 @@ func (r OpenShiftAdapter) loadSpec(imageName string) (*apb.Spec, error) {
 		return nil, err
 	}
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %v", token))
-	return imageToSpec(r.Log, req, r.Config.Tag)
+	return imageToSpec(r.Log, req, fmt.Sprintf("%s/%s:%s", r.RegistryName(), imageName, r.Config.Tag))
 }

--- a/pkg/registries/adapters/rhcc_adapter.go
+++ b/pkg/registries/adapters/rhcc_adapter.go
@@ -83,7 +83,7 @@ func (r RHCCAdapter) FetchSpecs(imageNames []string) ([]*apb.Spec, error) {
 		if err != nil {
 			return specs, err
 		}
-		spec, err := imageToSpec(r.Log, req, r.Config.Tag)
+		spec, err := imageToSpec(r.Log, req, fmt.Sprintf("%s/%s:%s", r.RegistryName(), imageName, r.Config.Tag))
 		if err != nil {
 			return specs, err
 		}

--- a/scripts/broker-ci/mediawiki123.yaml
+++ b/scripts/broker-ci/mediawiki123.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mediawiki
   namespace: default
 spec:
-  serviceClassName: dh-ansibleplaybookbundle-mediawiki123-apb-latest
+  serviceClassName: dh-mediawiki123-apb
   planName: default
   parameters:
     mediawiki_db_schema: "mediawiki"

--- a/scripts/broker-ci/postgresql.yaml
+++ b/scripts/broker-ci/postgresql.yaml
@@ -4,7 +4,7 @@ metadata:
   name: postgresql
   namespace: default
 spec:
-  serviceClassName: dh-ansibleplaybookbundle-rhscl-postgresql-apb-lates
+  serviceClassName: dh-rhscl-postgresql-apb
   planName: prod
   parameters:
     postgresql_database: "admin"


### PR DESCRIPTION
The purpose of this change is to make it so that the full path to each
image is used when executing APBs instead of relying on what is stated
in the APB yaml.

- Update the Spec to make Image optional (for when we remove it from APB
  yaml)
- Update the registry adapters to store the full path to the image when
  unmarshalling the APB yaml -> APB spec before we store it into `etcd`
- Update the broker to have simpler format for `FQName`

Implements #431
Fixes #288
Bug 1497819