### PR TITLE
updating irc links to go to asbroker channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Check out the [Keynote Demo from Red Hat Summit 2017](https://youtu.be/8MCbJmZQM
 
 - [Documentation](docs/README.md)
 - Our [Trello Board](https://trello.com/b/50JhiC5v/ansible-service-broker)
-- Chat with us on [IRC (Freenode): #asbroker](https://botbot.me/freenode/openshift-dev/)
+- Chat with us on [IRC (Freenode): #asbroker](http://webchat.freenode.net/?channels=%23asbroker)
 - Email us at ansible-service-broker@redhat.com and subscribe to the Ansible Service Broker's
   [mailing list](https://www.redhat.com/mailman/listinfo/ansible-service-broker)
 - Our [YouTube Channel](https://www.youtube.com/channel/UC04eOMIMiV06_RSZPb4OOBw)
@@ -85,7 +85,7 @@ Check out the [Keynote Demo from Red Hat Summit 2017](https://youtu.be/8MCbJmZQM
 First, **start with the** [Contributing Guide](CONTRIBUTING.md).
 
 Contributions are welcome. Open issues for any bugs or problems you may run into,
-ask us questions on [IRC (Freenode): #asbroker](https://botbot.me/freenode/openshift-dev/),
+ask us questions on [IRC (Freenode): #asbroker](http://webchat.freenode.net/?channels=%23asbroker),
 or see what we are working on at our [Trello Board](https://trello.com/b/50JhiC5v/ansible-service-broker).
 
 If you want to run the test suite, when you are ready to submit a PR for example,


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
Fixes location of IRC links to go to our channel and not openshift-dev