### PR TITLE
pass in BROKER_KIND

### DIFF
--- a/scripts/run_latest_build.sh
+++ b/scripts/run_latest_build.sh
@@ -70,6 +70,7 @@ DOCKERHUB_USER=${DOCKERHUB_USER:-"changeme"} # DockerHub login username, default
 DOCKERHUB_PASS=${DOCKERHUB_PASS:-"changeme"} # DockerHub login password, default 'changeme'
 DOCKERHUB_ORG=${DOCKERHUB_ORG:-"ansibleplaybookbundle"} # DocherHub org where APBs can be found, default 'ansibleplaybookbundle'
 ENABLE_BASIC_AUTH=${ENABLE_BASIC_AUTH:-"false"} # Secure broker with basic authentication, default 'false'. Disabling basic auth allows "apb push" to work.
+BROKER_KIND=${BROKER_KIND:-"Broker"} # allow users to override the broker kind type to work with 3.7
 
 curl -s $TEMPLATE_URL \
   | oc process \
@@ -77,6 +78,7 @@ curl -s $TEMPLATE_URL \
   -p DOCKERHUB_USER="$DOCKERHUB_USER" \
   -p DOCKERHUB_PASS="$DOCKERHUB_PASS" \
   -p DOCKERHUB_ORG="$DOCKERHUB_ORG" \
+  -p BROKER_KIND="$BROKER_KIND" \
   -p ENABLE_BASIC_AUTH="$ENABLE_BASIC_AUTH" -f - | oc create -f -
 
 if [ "$?" -ne 0 ]; then


### PR DESCRIPTION
thomasmckay in irc was trying to run the latest service broker with a 3.7 server. The template uses `Broker` kind by default instead of the required `ServiceBroker`. Defaulting to `Broker` so that it works with 3.6 and folks can override it:

```
BROKER_KIND="ServiceBroker" ./scripts/run_latest_build.sh
```