### PR TITLE
Update broker defaults for current service-catalog version

### DIFF
--- a/templates/deploy-ansible-service-broker.template.yaml
+++ b/templates/deploy-ansible-service-broker.template.yaml
@@ -214,13 +214,12 @@ parameters:
 - description: Service Broker kind. Newer service-catalogs use ServiceBroker
   displayname: Service Broker kind. Newer service-catalogs use ServiceBroker
   name: BROKER_KIND
-  value: Broker
+  value: ServiceBroker
 
 - description: Broker Auth Info
   displayname: Broker Auth Info
   name: BROKER_AUTH
-  value: '{ "basicAuthSecret": { "namespace": "ansible-service-broker", "name": "asb-auth-secret" }}'
-
+  value: '{ "basic": { "secretRef": { "namespace": "ansible-service-broker", "name": "asb-auth-secret" } } }'
 - description: Scheme for ansible service broker (http/https)
   displayname: Scheme for ansible service broker (http/https)
   name: ASB_SCHEME


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
Update the ansible-service-broker template to work with service-catalog 0.0.17 by default since it is now the default in origin:latest

Changes proposed in this pull request
 - Update BROKER_KIND and BROKER_AUTH

**Does this PR depend on another PR (Use this to track when PRs should be merged)**
depends-on <PR>
Merge with: https://github.com/fusor/catasb/pull/139

**Which issue this PR fixes (This will close that issue when PR gets merged)**
fixes N/A
