### PR TITLE
Look at the apbs in the catalog for a matching name when creating a secret

### DIFF
--- a/scripts/create_broker_secret.py
+++ b/scripts/create_broker_secret.py
@@ -138,13 +138,13 @@ def format_config(config):
 
 
 def broker_auth(config):
-    credentials = {}
+    credentials = {'basic_auth_username': None, 'basic_auth_password': None}
     auth_settings = config['data']['broker-config']['broker'].get('auth')[0]
     if auth_settings.get('type') == 'basic' and auth_settings.get('enabled'):
         secret = yaml.load(runcmd('oc get secret asb-auth-secret -o yaml'))
         credentials = {
-            "basic_auth_username": base64.b64decode(secret['data']['username']),
-            "basic_auth_password": base64.b64decode(secret['data']['password'])
+            "basic_auth_{}".format(k): base64.b64decode(v)
+            for (k, v) in secret['data'].items()
         }
     return credentials
 

--- a/scripts/create_broker_secret.py
+++ b/scripts/create_broker_secret.py
@@ -149,9 +149,11 @@ def fqname(apb):
     ]
 
     if not matches:
-        msg = "This script assumes the apb you are associating has already been discovered by the broker. Please add the apb and rerun this script\n\
-apbs found: \n\t- {}".format('\n\t- '.join(map(lambda x: x['name'], candidates)))
-        raise Exception(msg)
+        print("ERROR: No matches found for {}".format(apb))
+        print("apbs found: \n\t- {}".format('\n\t- '.join(
+            map(lambda x: x['name'], candidates))
+        ))
+        sys.exit(1)
     elif len(matches) > 1:
         print("Multiple apbs match...\n")
         for i, match in enumerate(matches):


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
Running the `./scripts/create_broker_secret.py` script will now check the catalog for a FQName that looks like the image passed in. This should make it work with non-dockerhub registries as well as locally pushed images.

Changes proposed in this pull request
 - Added dependency on requests library to use the script
 - Get a list of apbs from `/v2/catalog`
 - Match the provided org, image, and tag to the apbs in the broker
  - If multiple match, prompt the user to pick one

depends on https://github.com/ansibleplaybookbundle/ansible-playbook-bundle/pull/143
