### PR TITLE
Additional workaround for the gate

### DIFF
--- a/scripts/broker-ci/wait-for-resource.sh
+++ b/scripts/broker-ci/wait-for-resource.sh
@@ -8,7 +8,7 @@ NAMESPACE="${NAMESPACE:-default}"
 
 if [ "${RESOURCE}" = "pod" ] && [ "${ACTION}" = "create" ]; then
     for r in $(seq 100); do
-	pod=$(oc get pods -n ${NAMESPACE} | grep ${RESOURCE_NAME} | awk $'{ print $3 }')
+	pod=$(oc get pods -n ${NAMESPACE} | grep ${RESOURCE_NAME} | awk $'{ print $3 }' | grep Running)
 	oc get pods -n default | grep ${RESOURCE_NAME}
 	if [ "${pod}" = 'Running' ]; then
 	    echo "${RESOURCE_NAME} ${RESOURCE} is running"


### PR DESCRIPTION
The gate still occasionally fails on a pod that isn't being removed.  Ignore the 'Terminating' pod by searching for 'Running'.

Changes proposed in this pull request
 - Look only for the running pod and ignore the terminating pod
