### PR TITLE
allowing the user to authenticate to retrieve private repos

### DIFF
--- a/pkg/registries/adapters/dockerhub_adapter.go
+++ b/pkg/registries/adapters/dockerhub_adapter.go
@@ -232,7 +232,7 @@ func (r DockerHubAdapter) loadSpec(imageName string) (*apb.Spec, error) {
 	if err != nil {
 		return nil, err
 	}
-	token, err := getBearerToken(imageName)
+	token, err := r.getBearerToken(imageName)
 	if err != nil {
 		return nil, err
 	}
@@ -240,10 +240,15 @@ func (r DockerHubAdapter) loadSpec(imageName string) (*apb.Spec, error) {
 	return imageToSpec(r.Log, req, r.Config.Tag)
 }
 
-func getBearerToken(imageName string) (string, error) {
-	response, err := http.Get(fmt.Sprintf(
-		"https://auth.docker.io/token?service=registry.docker.io&scope=repository:%v:pull",
-		imageName))
+func (r DockerHubAdapter) getBearerToken(imageName string) (string, error) {
+	req, err := http.NewRequest("GET",
+		fmt.Sprintf("https://auth.docker.io/token?grant_type=password&service=registry.docker.io&scope=repository:%v:pull", imageName),
+		nil)
+	if err != nil {
+		return "", err
+	}
+	req.SetBasicAuth(r.Config.User, r.Config.Pass)
+	response, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return "", err
 	}

--- a/scripts/broker-ci/setup.sh
+++ b/scripts/broker-ci/setup.sh
@@ -16,9 +16,9 @@ function cluster-setup () {
 
     cat <<EOF > "catasb/config/my_vars.yml"
 ---
-dockerhub_user_name: brokerciuser
+dockerhub_user_name: changeme 
 dockerhub_org: ansibleplaybookbundle
-dockerhub_user_password: brokerciuser
+dockerhub_user_password: changeme 
 EOF
 
     pushd catasb/local/gate/
@@ -34,8 +34,8 @@ OPENSHIFT_SERVER_PORT=8443
 # BROKER_IP_ADDR must be the IP address of where to reach broker
 #   it should not be 127.0.0.1, needs to be an address the pods will be able to reach
 BROKER_IP_ADDR=${OPENSHIFT_SERVER_HOST}
-DOCKERHUB_USER="brokerciuser"
-DOCKERHUB_PASS="brokerciuser"
+DOCKERHUB_USER="changeme"
+DOCKERHUB_PASS="changeme"
 DOCKERHUB_ORG="ansibleplaybookbundle"
 BOOTSTRAP_ON_STARTUP="true"
 BEARER_TOKEN_FILE=""


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
Fixes issue 448 
Changes proposed in this pull request
 - Set basic auth on retrieval of the bearer token for the registry service.

**Which issue this PR fixes (This will close that issue when PR gets merged)**
fixes 448