### PR TITLE
fix asbcli to work with bearer auth

### DIFF
--- a/scripts/asbcli/asbcli
+++ b/scripts/asbcli/asbcli
@@ -11,6 +11,7 @@ import unicodedata
 import uuid
 import yaml
 
+from requests.packages.urllib3.exceptions import InsecureRequestWarning
 from subprocess import Popen, PIPE
 from distutils import spawn
 
@@ -19,8 +20,12 @@ SCRIPT_DIR = sys.path[0]
 RECORDS_FILE = '/tmp/asbcli.dat.json'
 BROKER_IMAGE = 'ansibleplaybookbundle/ansible-service-broker-apb'
 
+proc = Popen(["oc whoami -t"], stdout=PIPE, shell=True)
+(TOKEN, err) = proc.communicate()
+
 BROKER_HEADERS = {
-    'X-Broker-API-Version': '2.9'
+    'X-Broker-API-Version': '2.9',
+    'Authorization': 'Bearer ' + TOKEN.rstrip()
 }
 
 AVAILABLE_COMMANDS = {
@@ -28,6 +33,7 @@ AVAILABLE_COMMANDS = {
     'up': 'Bring up a broker in a target cluster'
 }
 
+requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
 def req(url, **kwargs):
     # merge in broker headers if provided
@@ -39,8 +45,7 @@ def req(url, **kwargs):
 
     verb = kwargs.pop('verb', 'get')
 
-    return getattr(requests, verb)(url, **kwargs)
-
+    return getattr(requests, verb)(url, verify=False, **kwargs)
 
 def consumer_binding_key(key):
     # Need to perform a conversion from whatever binding key
@@ -612,7 +617,7 @@ class App(object):
             print '  %d | %s | %s' % (bb[0], bb[2], bb[1])
 
     def _url(self, path):
-        return 'http://%s/v2%s' % (self.broker_address, path)
+        return 'https://%s/ansible-service-broker/v2%s' % (self.broker_address, path)
 
 
 def subcmd_connect_parser(parser, subcmd):


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
It fixes asbcli. We need it because this should have been done before Bearer Auth was merged.

Changes proposed in this pull request
 - Use SSL (unverified)
 - Retrieve and send the user token in headers
 
**Does this PR depend on another PR (Use this to track when PRs should be merged)**
depends-on

N/A

**Which issue this PR fixes (This will close that issue when PR gets merged)**
fixes

N/A
