### PR TITLE
Remove provision parameters from being reused as binding parameters.

### DIFF
--- a/pkg/broker/util.go
+++ b/pkg/broker/util.go
@@ -104,9 +104,7 @@ func updateMetadata(metadata map[string]interface{}, params []apb.ParameterDescr
 			"update": map[string]interface{}{},
 		},
 		"service_binding": map[string]interface{}{
-			"create": map[string]interface{}{
-				"openshift_form_definition": formDefinition,
-			},
+			"create": map[string]interface{}{},
 		},
 	}
 
@@ -235,7 +233,7 @@ func parametersToSchema(params []apb.ParameterDescriptor) Schema {
 				"parameters": {
 					SchemaRef:  schema.SchemaURL,
 					Type:       []schema.PrimitiveType{schema.ObjectType},
-					Properties: properties,
+					Properties: make(map[string]*schema.Schema),
 				},
 			},
 		},

--- a/pkg/broker/util_test.go
+++ b/pkg/broker/util_test.go
@@ -138,8 +138,6 @@ func TestUpdateMetadata(t *testing.T) {
 
 	updateFormDefnMap := verifyMapPath(t, planMetadata, []string{"schemas", "service_instance", "update"})
 	ft.AssertEqual(t, len(updateFormDefnMap), 0, "schemas.service_instance.update is not empty")
-
-	verifyFormDefinition(t, planMetadata, []string{"schemas", "service_binding", "create"})
 }
 
 func verifyFormDefinition(t *testing.T, planMetadata map[string]interface{}, path []string) {


### PR DESCRIPTION
Currently, broker is listing all parameters intended for provision as binding parameters when creating a binding.  Until binding parameters in the broker is implemented, we need to remove these parameters as they are not currently used and add confusion to the user experience.

Removes the service_binding.create paramaters and openshift_form_definition from the catalog request.