### PR TITLE
Added versioning check to Broker on bootstrap

### DIFF
--- a/.tito/tito.props
+++ b/.tito/tito.props
@@ -6,4 +6,4 @@ changelog_format = %s (%ae)
 
 [version_template]
 template_file = ./templates/version.go.tmpl
-destination_file = ./pkg/app/version.go
+destination_file = ./pkg/version/version.go

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -47,6 +47,7 @@ import (
 	"github.com/openshift/ansible-service-broker/pkg/dao"
 	"github.com/openshift/ansible-service-broker/pkg/handler"
 	"github.com/openshift/ansible-service-broker/pkg/registries"
+	"github.com/openshift/ansible-service-broker/pkg/version"
 )
 
 var (
@@ -136,7 +137,7 @@ func CreateApp() App {
 	}
 
 	if app.args.Version {
-		fmt.Println(Version)
+		fmt.Println(version.Version)
 		os.Exit(0)
 	}
 

--- a/pkg/registries/adapters/adapter.go
+++ b/pkg/registries/adapters/adapter.go
@@ -147,15 +147,7 @@ func isCompatibleVersion(specVersion string, minVersion string, maxVersion strin
 	if err != nil {
 		return false
 	}
-	specMinorVersion, err := strconv.Atoi(strings.Split(specVersion, ".")[1])
-	if err != nil {
-		return false
-	}
 	minMajorVersion, err := strconv.Atoi(strings.Split(minVersion, ".")[0])
-	if err != nil {
-		return false
-	}
-	minMinorVersion, err := strconv.Atoi(strings.Split(minVersion, ".")[1])
 	if err != nil {
 		return false
 	}
@@ -163,25 +155,9 @@ func isCompatibleVersion(specVersion string, minVersion string, maxVersion strin
 	if err != nil {
 		return false
 	}
-	maxMinorVersion, err := strconv.Atoi(strings.Split(maxVersion, ".")[1])
-	if err != nil {
-		return false
-	}
 
-	if minMajorVersion == maxMajorVersion {
-		if specMajorVersion >= minMajorVersion && specMajorVersion <= maxMajorVersion {
-			if specMinorVersion >= minMinorVersion && specMinorVersion <= maxMinorVersion {
-				return true
-			}
-		}
-	} else if minMajorVersion < maxMajorVersion {
-		if specMajorVersion == minMajorVersion && specMinorVersion >= minMinorVersion {
-			return true
-		} else if specMajorVersion == maxMajorVersion && specMinorVersion <= maxMinorVersion {
-			return true
-		} else if specMajorVersion > minMajorVersion && specMajorVersion < maxMajorVersion {
-			return true
-		}
+	if specMajorVersion >= minMajorVersion && specMajorVersion <= maxMajorVersion {
+		return true
 	}
 	return false
 }

--- a/pkg/registries/adapters/adapter.go
+++ b/pkg/registries/adapters/adapter.go
@@ -110,12 +110,8 @@ func imageToSpec(log *logging.Logger, req *http.Request, apbtag string) (*apb.Sp
 		log.Infof("Did not find v1 Manifest in image history. Skipping image")
 		return nil, nil
 	}
-	if conf.Config.Label.Spec == "" {
-		log.Infof("Didn't find encoded Spec label. Assuming image is not APB and skiping")
-		return nil, nil
-	}
-	if conf.Config.Label.Version == "" {
-		log.Infof("Didn't find encoded Version label. Assuming image is not APB and skipping")
+	if conf.Config.Label.Spec == "" || conf.Config.Label.Version == "" {
+		log.Infof("Didn't find encoded Spec label and version. Assuming image is not APB and skiping")
 		return nil, nil
 	}
 	if isCompatibleVersion(conf.Config.Label.Version, version.MinAPBVersion, version.MaxAPBVersion) != true {

--- a/pkg/registries/adapters/adapter.go
+++ b/pkg/registries/adapters/adapter.go
@@ -145,14 +145,30 @@ func imageToSpec(log *logging.Logger, req *http.Request, apbtag string) (*apb.Sp
 
 func isCompatibleVersion(specVersion string, minVersion string, maxVersion string) bool {
 	specMajorVersion, err := strconv.Atoi(strings.Split(specVersion, ".")[0])
+	if err != nil {
+		return false
+	}
 	specMinorVersion, err := strconv.Atoi(strings.Split(specVersion, ".")[1])
+	if err != nil {
+		return false
+	}
 	minMajorVersion, err := strconv.Atoi(strings.Split(minVersion, ".")[0])
+	if err != nil {
+		return false
+	}
 	minMinorVersion, err := strconv.Atoi(strings.Split(minVersion, ".")[1])
+	if err != nil {
+		return false
+	}
 	maxMajorVersion, err := strconv.Atoi(strings.Split(maxVersion, ".")[0])
+	if err != nil {
+		return false
+	}
 	maxMinorVersion, err := strconv.Atoi(strings.Split(maxVersion, ".")[1])
 	if err != nil {
 		return false
 	}
+
 	if minMajorVersion == maxMajorVersion {
 		if specMajorVersion >= minMajorVersion && specMajorVersion <= maxMajorVersion {
 			if specMinorVersion >= minMinorVersion && specMinorVersion <= maxMinorVersion {

--- a/pkg/registries/adapters/adapter.go
+++ b/pkg/registries/adapters/adapter.go
@@ -144,6 +144,9 @@ func imageToSpec(log *logging.Logger, req *http.Request, apbtag string) (*apb.Sp
 }
 
 func isCompatibleVersion(specVersion string, minVersion string, maxVersion string) bool {
+	if len(strings.Split(specVersion, ".")) != 2 || len(strings.Split(minVersion, ".")) != 2 || len(strings.Split(maxVersion, ".")) != 2 {
+		return false
+	}
 	specMajorVersion, err := strconv.Atoi(strings.Split(specVersion, ".")[0])
 	if err != nil {
 		return false
@@ -179,6 +182,8 @@ func isCompatibleVersion(specVersion string, minVersion string, maxVersion strin
 		if specMajorVersion == minMajorVersion && specMinorVersion >= minMinorVersion {
 			return true
 		} else if specMajorVersion == maxMajorVersion && specMinorVersion <= maxMinorVersion {
+			return true
+		} else if specMajorVersion > minMajorVersion && specMajorVersion < maxMajorVersion {
 			return true
 		}
 	}

--- a/pkg/registries/adapters/adapter.go
+++ b/pkg/registries/adapters/adapter.go
@@ -111,7 +111,7 @@ func imageToSpec(log *logging.Logger, req *http.Request, apbtag string) (*apb.Sp
 		return nil, nil
 	}
 	if conf.Config.Label.Spec == "" || conf.Config.Label.Version == "" {
-		log.Infof("Didn't find encoded Spec label and version. Assuming image is not APB and skiping")
+		log.Infof("Didn't find encoded Spec or version label. Assuming image is not APB and skiping")
 		return nil, nil
 	}
 	if isCompatibleVersion(conf.Config.Label.Version, version.MinAPBVersion, version.MaxAPBVersion) != true {

--- a/pkg/registries/adapters/adapter_test.go
+++ b/pkg/registries/adapters/adapter_test.go
@@ -45,5 +45,10 @@ func TestVersionCheck(t *testing.T) {
 	ft.AssertFalse(t, isCompatibleVersion("0.6", "1.0", "2.1"))
 	// Test out of range by major and minor version and invalid version
 	ft.AssertFalse(t, isCompatibleVersion("0.1.0", "1.0", "1.0"))
-
+	// Test in range of long possible window
+	ft.AssertTrue(t, isCompatibleVersion("2.5", "1.0", "3.5"))
+	// Test invalid version
+	ft.AssertFalse(t, isCompatibleVersion("1", "1.0", "3.5"))
+	// Test invalid version
+	ft.AssertFalse(t, isCompatibleVersion("2.5", "3.0", "4.2"))
 }

--- a/pkg/registries/adapters/adapter_test.go
+++ b/pkg/registries/adapters/adapter_test.go
@@ -29,3 +29,21 @@ import (
 func TestSpecLabel(t *testing.T) {
 	ft.AssertEqual(t, BundleSpecLabel, "com.redhat.apb.spec", "spec label does not match dockerhub")
 }
+
+func TestVersionCheck(t *testing.T) {
+	// Test equal versions
+	ft.AssertTrue(t, isCompatibleVersion("1.0", "1.0", "1.0"))
+	// Test out of range by major version
+	ft.AssertFalse(t, isCompatibleVersion("2.0", "1.0", "1.9"))
+	// Test out of range by minor version
+	ft.AssertFalse(t, isCompatibleVersion("1.10", "1.0", "1.9"))
+	// Test out of range by major and minor version
+	ft.AssertFalse(t, isCompatibleVersion("2.4", "1.0", "2.1"))
+	// Test in range with differing  major and minor version
+	ft.AssertTrue(t, isCompatibleVersion("1.10", "1.0", "2.1"))
+	// Test out of range by major and minor version
+	ft.AssertFalse(t, isCompatibleVersion("0.6", "1.0", "2.1"))
+	// Test out of range by major and minor version and invalid version
+	ft.AssertFalse(t, isCompatibleVersion("0.1.0", "1.0", "1.0"))
+
+}

--- a/pkg/registries/adapters/adapter_test.go
+++ b/pkg/registries/adapters/adapter_test.go
@@ -34,21 +34,21 @@ func TestVersionCheck(t *testing.T) {
 	// Test equal versions
 	ft.AssertTrue(t, isCompatibleVersion("1.0", "1.0", "1.0"))
 	// Test out of range by major version
-	ft.AssertFalse(t, isCompatibleVersion("2.0", "1.0", "1.9"))
+	ft.AssertFalse(t, isCompatibleVersion("2.0", "1.0", "1.0"))
 	// Test out of range by minor version
-	ft.AssertFalse(t, isCompatibleVersion("1.10", "1.0", "1.9"))
+	ft.AssertTrue(t, isCompatibleVersion("1.10", "1.0", "1.0"))
 	// Test out of range by major and minor version
-	ft.AssertFalse(t, isCompatibleVersion("2.4", "1.0", "2.1"))
+	ft.AssertTrue(t, isCompatibleVersion("2.4", "1.0", "2.0"))
 	// Test in range with differing  major and minor version
-	ft.AssertTrue(t, isCompatibleVersion("1.10", "1.0", "2.1"))
+	ft.AssertTrue(t, isCompatibleVersion("1.10", "1.0", "2.0"))
 	// Test out of range by major and minor version
-	ft.AssertFalse(t, isCompatibleVersion("0.6", "1.0", "2.1"))
+	ft.AssertFalse(t, isCompatibleVersion("0.6", "1.0", "2.0"))
 	// Test out of range by major and minor version and invalid version
 	ft.AssertFalse(t, isCompatibleVersion("0.1.0", "1.0", "1.0"))
 	// Test in range of long possible window
-	ft.AssertTrue(t, isCompatibleVersion("2.5", "1.0", "3.5"))
+	ft.AssertTrue(t, isCompatibleVersion("2.5", "1.0", "3.0"))
 	// Test invalid version
-	ft.AssertFalse(t, isCompatibleVersion("1", "1.0", "3.5"))
+	ft.AssertFalse(t, isCompatibleVersion("1", "1.0", "3.0"))
 	// Test invalid version
-	ft.AssertFalse(t, isCompatibleVersion("2.5", "3.0", "4.2"))
+	ft.AssertFalse(t, isCompatibleVersion("2.5", "3.0", "4.0"))
 }

--- a/pkg/version/apbversion.go
+++ b/pkg/version/apbversion.go
@@ -3,5 +3,9 @@ package version
 // These constants describe the minimum and maximum
 // accepted APB spec versions. They are used to filter
 // acceptible APBs.
+
+// MinAPBVersion constant to describe minimum supported spec version
 const MinAPBVersion = "1.0"
+
+// MaxAPBVersion contant to describe maximum supported spec version
 const MaxAPBVersion = "1.0"

--- a/pkg/version/apbversion.go
+++ b/pkg/version/apbversion.go
@@ -1,0 +1,4 @@
+package version
+
+var MinAPBVersion = "1.0"
+var MaxAPBVersion = "1.0"

--- a/pkg/version/apbversion.go
+++ b/pkg/version/apbversion.go
@@ -1,4 +1,7 @@
 package version
 
-var MinAPBVersion = "1.0"
-var MaxAPBVersion = "1.0"
+// These constants describe the minimum and maximum
+// accepted APB spec versions. They are used to filter
+// acceptible APBs.
+const MinAPBVersion = "1.0"
+const MaxAPBVersion = "1.0"

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,4 +1,4 @@
-package app
+package version
 
 // Version contains the broker version.
 // DO NOT EDIT GENERATED FILE.

--- a/templates/version.go.tmpl
+++ b/templates/version.go.tmpl
@@ -1,4 +1,4 @@
-package app
+package version
 
 // Version contains the broker version.
 // DO NOT EDIT GENERATED FILE.


### PR DESCRIPTION
This PR adds version checks to the broker when bootstrapping an APB

Changes proposed in this pull request
 - Move version.go to its own version pkg
 - Add version check on imageToSpec conversion
 - Add unit tests for compatible version checks

Note:
I plan to open an issue to move the version to the spec itself so that this check moves out of the adapter pkg.
