### PR TITLE
changing default for 3.6 run_latest_build to function correctly

### DIFF
--- a/scripts/run_latest_build.sh
+++ b/scripts/run_latest_build.sh
@@ -69,7 +69,7 @@ TEMPLATE_URL="https://raw.githubusercontent.com/openshift/ansible-service-broker
 DOCKERHUB_USER=${DOCKERHUB_USER:-"changeme"} # DockerHub login username, default 'changeme'
 DOCKERHUB_PASS=${DOCKERHUB_PASS:-"changeme"} # DockerHub login password, default 'changeme'
 DOCKERHUB_ORG=${DOCKERHUB_ORG:-"ansibleplaybookbundle"} # DocherHub org where APBs can be found, default 'ansibleplaybookbundle'
-ENABLE_BASIC_AUTH=${ENABLE_BASIC_AUTH:-"false"} # Secure broker with basic authentication, default 'false'. Disabling basic auth allows "apb push" to work.
+ENABLE_BASIC_AUTH=${ENABLE_BASIC_AUTH:-"true"} # Secure broker with basic authentication, default 'false'. Disabling basic auth allows "apb push" to work.
 BROKER_KIND=${BROKER_KIND:-"Broker"} # allow users to override the broker kind type to work with 3.7
 
 auth=$(echo -e "{\"basicAuthSecret\":{\"namespace\":\"ansible-service-broker\",\"name\":\"asb-auth-secret\"}}")

--- a/scripts/run_latest_build.sh
+++ b/scripts/run_latest_build.sh
@@ -69,7 +69,7 @@ TEMPLATE_URL="https://raw.githubusercontent.com/openshift/ansible-service-broker
 DOCKERHUB_USER=${DOCKERHUB_USER:-"changeme"} # DockerHub login username, default 'changeme'
 DOCKERHUB_PASS=${DOCKERHUB_PASS:-"changeme"} # DockerHub login password, default 'changeme'
 DOCKERHUB_ORG=${DOCKERHUB_ORG:-"ansibleplaybookbundle"} # DocherHub org where APBs can be found, default 'ansibleplaybookbundle'
-ENABLE_BASIC_AUTH=${ENABLE_BASIC_AUTH:-"true"} # Secure broker with basic authentication, default 'false'. Disabling basic auth allows "apb push" to work.
+ENABLE_BASIC_AUTH=${ENABLE_BASIC_AUTH:-"true"} # Secure broker with basic authentication, default 'true'. When using a bearer token auth this should be set to false.
 BROKER_KIND=${BROKER_KIND:-"Broker"} # allow users to override the broker kind type to work with 3.7
 
 auth=$(echo -e "{\"basicAuthSecret\":{\"namespace\":\"ansible-service-broker\",\"name\":\"asb-auth-secret\"}}")


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
Fixing run latest to start with the correct defautl after the bearer token auth merge.
This should have been apart of that PR.
Changes proposed in this pull request
 - Change default for basic auth to true for the broker.


**Does this PR depend on another PR (Use this to track when PRs should be merged)**
depends-on <PR>
N/A
**Which issue this PR fixes (This will close that issue when PR gets merged)**
fixes <issue_number>
N/A