### PR TITLE
Smallfix: grep for correct asb-token for local dev.

### DIFF
--- a/scripts/prep_local_devel_env.sh
+++ b/scripts/prep_local_devel_env.sh
@@ -46,7 +46,7 @@ fi
 
 
 # Determine the name of the secret which has the 'asb' service account info
-BROKER_SVC_ACCT_SECRET_NAME=`oc get serviceaccount asb -n ansible-service-broker -o jsonpath='{.secrets[0].name}'`
+BROKER_SVC_ACCT_SECRET_NAME=`oc get serviceaccount asb -n ansible-service-broker -o yaml | grep -Po asb-token-[a-z0-9]*`
 echo "Broker Service Account Token is in secret: ${BROKER_SVC_ACCT_SECRET_NAME}"
 
 ###


### PR DESCRIPTION
prep_local_devel_env was assuming the asb token was always listed first.
Grep for asb-token instead.
