### PR TITLE
Bump wait times

### DIFF
--- a/scripts/broker-ci/local-ci.sh
+++ b/scripts/broker-ci/local-ci.sh
@@ -44,7 +44,7 @@ function deprovision {
 
 function bind {
     print-with-green "Waiting for services to be ready"
-    sleep 10
+    sleep 30
     oc create -f ./scripts/broker-ci/bind-mediawiki-postgresql.yaml || BIND_ERROR=true
     ./scripts/broker-ci/wait-for-resource.sh create bindings.v1alpha1.servicecatalog.k8s.io mediawiki-postgresql-binding >> /tmp/wait-for-pods-log 2>&1
     error-check "bind"
@@ -59,7 +59,7 @@ function unbind {
 function bind-credential-check {
     set +x
     print-with-green "Waiting for the Bind to be created"
-    sleep 40
+    ./scripts/broker-ci/wait-for-resource.sh create secret mediawiki-postgresql-binding >> /tmp/wait-for-pods-log 2>&1
 
     RETRIES=10
     for x in $(seq $RETRIES); do


### PR DESCRIPTION
The bind is being created before the postgresql pod returns the
bind credentials causing a failure.  Increase that wait time from
10 to 30 seconds.

Add a wait_for_resource for the bind secret to exist before looking
for pod presets in mediawiki.

Changes proposed in this pull request
 - wait 10s increase to 30
 - wait for podpreset secret