### PR TITLE
add 3.7 releaser to releasers.conf

### DIFF
--- a/.tito/releasers.conf
+++ b/.tito/releasers.conf
@@ -13,6 +13,10 @@ remote_location = http://repos.fedorapeople.org/asb/
 copr_options = --timeout 600
 builder.test = 1
 
-[asb-brew]
+[asb-brew-36]
 releaser = tito.release.DistGitReleaser
 branches = rhaos-3.6-asb-rhel-7
+
+[asb-brew-37]
+releaser = tito.release.DistGitReleaser
+branches = rhaos-3.7-asb-rhel-7


### PR DESCRIPTION
Had to add the 3.7 brew releaser so we can build against the 3.7 buildroot.