### PR TITLE
Provide an environment variable to deploy latest with run_latest_build

### DIFF
--- a/scripts/run_latest_build.sh
+++ b/scripts/run_latest_build.sh
@@ -37,7 +37,8 @@ DOCKER_IP="$(ip addr show docker0 | grep -Po 'inet \K[\d.]+')"
 PUBLIC_IP=${PUBLIC_IP:-$DOCKER_IP}
 HOSTNAME=${PUBLIC_IP}.nip.io
 ROUTING_SUFFIX="${HOSTNAME}"
-oc cluster up --image=openshift/origin --version=v3.6.0 --service-catalog=true --routing-suffix=${ROUTING_SUFFIX} --public-hostname=${HOSTNAME}
+ORIGIN_VERSION=${ORIGIN_VERSION:-"v3.6.0"} # allow users to override version and set to latest
+oc cluster up --image=openshift/origin --version=${ORIGIN_VERSION} --service-catalog=true --routing-suffix=${ROUTING_SUFFIX} --public-hostname=${HOSTNAME}
 
 #
 # Logging in as system:admin so we can create a clusterrolebinding and


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
Provide an environment variable to deploy latest with run_latest_build

Changes proposed in this pull request
 - introduces a ORIGIN_VERSION env variable, which default to v3.6.0
 -
 -

**Does this PR depend on another PR (Use this to track when PRs should be merged)**
depends-on <PR>

**Which issue this PR fixes (This will close that issue when PR gets merged)**
fixes <issue_number>
