### PR TITLE
Bug 1498185 - Adjust versioning check so that it is done in the registry package

### DIFF
--- a/pkg/apb/types.go
+++ b/pkg/apb/types.go
@@ -61,6 +61,7 @@ type Plan struct {
 // Spec - A APB spec
 type Spec struct {
 	ID          string                 `json:"id"`
+	Version     string                 `json:"version"`
 	FQName      string                 `json:"name" yaml:"name"`
 	Image       string                 `json:"image"`
 	Tags        []string               `json:"tags"`

--- a/pkg/apb/types_test.go
+++ b/pkg/apb/types_test.go
@@ -84,6 +84,7 @@ var p = Plan{
 	Parameters:  expectedPlanParameters,
 }
 
+const SpecVersion = "1.0"
 const SpecName = "mediawiki123-apb"
 const SpecImage = "ansibleplaybookbundle/mediawiki123-apb"
 const SpecBindable = false
@@ -146,13 +147,14 @@ var SpecJSON = fmt.Sprintf(`
 	"id": "",
 	"tags": null,
 	"description": "%s",
+	"version": "%s",
 	"name": "%s",
 	"image": "%s",
 	"bindable": %t,
 	"async": "%s",
 	"plans": %s
 }
-`, SpecDescription, SpecName, SpecImage, SpecBindable, SpecAsync, SpecPlans)
+`, SpecDescription, SpecVersion, SpecName, SpecImage, SpecBindable, SpecAsync, SpecPlans)
 
 func TestSpecLoadJSON(t *testing.T) {
 
@@ -164,6 +166,7 @@ func TestSpecLoadJSON(t *testing.T) {
 
 	ft.AssertEqual(t, s.Description, SpecDescription)
 	ft.AssertEqual(t, s.FQName, SpecName)
+	ft.AssertEqual(t, s.Version, SpecVersion)
 	ft.AssertEqual(t, s.Image, SpecImage)
 	ft.AssertEqual(t, s.Bindable, SpecBindable)
 	ft.AssertEqual(t, s.Async, SpecAsync)
@@ -173,6 +176,7 @@ func TestSpecLoadJSON(t *testing.T) {
 func TestSpecDumpJSON(t *testing.T) {
 	s := Spec{
 		Description: SpecDescription,
+		Version:     SpecVersion,
 		FQName:      SpecName,
 		Image:       SpecImage,
 		Bindable:    SpecBindable,

--- a/pkg/registries/adapters/adapter.go
+++ b/pkg/registries/adapters/adapter.go
@@ -26,12 +26,9 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"strconv"
-	"strings"
 
 	logging "github.com/op/go-logging"
 	"github.com/openshift/ansible-service-broker/pkg/apb"
-	"github.com/openshift/ansible-service-broker/pkg/version"
 	yaml "gopkg.in/yaml.v1"
 )
 
@@ -74,8 +71,7 @@ func imageToSpec(log *logging.Logger, req *http.Request, apbtag string) (*apb.Sp
 	defer resp.Body.Close()
 
 	type label struct {
-		Spec    string `json:"com.redhat.apb.spec"`
-		Version string `json:"com.redhat.apb.version"`
+		Spec string `json:"com.redhat.apb.spec"`
 	}
 
 	type config struct {
@@ -110,12 +106,8 @@ func imageToSpec(log *logging.Logger, req *http.Request, apbtag string) (*apb.Sp
 		log.Infof("Did not find v1 Manifest in image history. Skipping image")
 		return nil, nil
 	}
-	if conf.Config.Label.Spec == "" || conf.Config.Label.Version == "" {
-		log.Infof("Didn't find encoded Spec or version label. Assuming image is not APB and skiping")
-		return nil, nil
-	}
-	if isCompatibleVersion(conf.Config.Label.Version, version.MinAPBVersion, version.MaxAPBVersion) != true {
-		log.Infof("APB spec version was incompatible. Assuming image is incompatible and skipping")
+	if conf.Config.Label.Spec == "" {
+		log.Infof("Didn't find encoded Spec label. Assuming image is not APB and skiping")
 		return nil, nil
 	}
 
@@ -137,27 +129,4 @@ func imageToSpec(log *logging.Logger, req *http.Request, apbtag string) (*apb.Sp
 	log.Debugf("Successfully converted Image %s into Spec", spec.Image)
 
 	return spec, nil
-}
-
-func isCompatibleVersion(specVersion string, minVersion string, maxVersion string) bool {
-	if len(strings.Split(specVersion, ".")) != 2 || len(strings.Split(minVersion, ".")) != 2 || len(strings.Split(maxVersion, ".")) != 2 {
-		return false
-	}
-	specMajorVersion, err := strconv.Atoi(strings.Split(specVersion, ".")[0])
-	if err != nil {
-		return false
-	}
-	minMajorVersion, err := strconv.Atoi(strings.Split(minVersion, ".")[0])
-	if err != nil {
-		return false
-	}
-	maxMajorVersion, err := strconv.Atoi(strings.Split(maxVersion, ".")[0])
-	if err != nil {
-		return false
-	}
-
-	if specMajorVersion >= minMajorVersion && specMajorVersion <= maxMajorVersion {
-		return true
-	}
-	return false
 }

--- a/pkg/registries/adapters/adapter_test.go
+++ b/pkg/registries/adapters/adapter_test.go
@@ -29,26 +29,3 @@ import (
 func TestSpecLabel(t *testing.T) {
 	ft.AssertEqual(t, BundleSpecLabel, "com.redhat.apb.spec", "spec label does not match dockerhub")
 }
-
-func TestVersionCheck(t *testing.T) {
-	// Test equal versions
-	ft.AssertTrue(t, isCompatibleVersion("1.0", "1.0", "1.0"))
-	// Test out of range by major version
-	ft.AssertFalse(t, isCompatibleVersion("2.0", "1.0", "1.0"))
-	// Test out of range by minor version
-	ft.AssertTrue(t, isCompatibleVersion("1.10", "1.0", "1.0"))
-	// Test out of range by major and minor version
-	ft.AssertTrue(t, isCompatibleVersion("2.4", "1.0", "2.0"))
-	// Test in range with differing  major and minor version
-	ft.AssertTrue(t, isCompatibleVersion("1.10", "1.0", "2.0"))
-	// Test out of range by major and minor version
-	ft.AssertFalse(t, isCompatibleVersion("0.6", "1.0", "2.0"))
-	// Test out of range by major and minor version and invalid version
-	ft.AssertFalse(t, isCompatibleVersion("0.1.0", "1.0", "1.0"))
-	// Test in range of long possible window
-	ft.AssertTrue(t, isCompatibleVersion("2.5", "1.0", "3.0"))
-	// Test invalid version
-	ft.AssertFalse(t, isCompatibleVersion("1", "1.0", "3.0"))
-	// Test invalid version
-	ft.AssertFalse(t, isCompatibleVersion("2.5", "3.0", "4.0"))
-}


### PR DESCRIPTION
This PR adjusts for the change of moving the APB spec version from an image label into the Spec itself. It also moves the version check out of the adapter package so that it is now obfuscated out of each individual adapter.

Changes proposed in this pull request
 - Move APB spec version check to spec validation in registry package
 - Adds unit tests for specs without versions


This PR fixes https://bugzilla.redhat.com/show_bug.cgi?id=1498185
