### PR TITLE
Bug 1497839 - copy secrets to transient namespace and always run

### DIFF
--- a/pkg/apb/executor.go
+++ b/pkg/apb/executor.go
@@ -203,10 +203,12 @@ func checkPullPolicy(policy string) (v1.PullPolicy, error) {
 	return value, nil
 }
 
-func copySecretsToNamespace(executionContext ExecutionContext,
+func copySecretsToNamespace(
+	executionContext ExecutionContext,
 	clusterConfig ClusterConfig,
 	k8scli *clientset.Clientset,
-	secrets []string) error {
+	secrets []string,
+) error {
 	for _, secrectName := range secrets {
 		secretData, err := k8scli.CoreV1().Secrets(clusterConfig.Namespace).Get(secrectName, metav1.GetOptions{})
 		if err != nil {

--- a/pkg/apb/svc_acct.go
+++ b/pkg/apb/svc_acct.go
@@ -243,7 +243,7 @@ func (s *ServiceAccountManager) DestroyApbSandbox(executionContext ExecutionCont
 			s.log.Debug("Deleting namespace %s", executionContext.Namespace)
 			k8scli.CoreV1().Namespaces().Delete(executionContext.Namespace, &metav1.DeleteOptions{})
 		} else {
-			//We should not be attempting to run pods in the ASB namespace, if we are, something is seriously wrong.
+			// We should not be attempting to run pods in the ASB namespace, if we are, something is seriously wrong.
 			panic(fmt.Errorf("Broker is attempting to delete its own namespace"))
 		}
 

--- a/pkg/apb/svc_acct.go
+++ b/pkg/apb/svc_acct.go
@@ -21,6 +21,7 @@
 package apb
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -241,11 +242,14 @@ func (s *ServiceAccountManager) DestroyApbSandbox(executionContext ExecutionCont
 		if clusterConfig.Namespace != executionContext.Namespace {
 			s.log.Debug("Deleting namespace %s", executionContext.Namespace)
 			k8scli.CoreV1().Namespaces().Delete(executionContext.Namespace, &metav1.DeleteOptions{})
+		} else {
+			//We should not be attempting to run pods in the ASB namespace, if we are, something is seriously wrong.
+			panic(fmt.Errorf("Broker is attempting to delete its own namespace"))
 		}
+
 	} else {
 		s.log.Debugf("Keeping namespace alive due to configuration")
 	}
-
 	s.log.Debugf("Deleting rolebinding %s, namespace %s", executionContext.PodName, executionContext.Namespace)
 	output, err := runtime.RunCommand(
 		"oc", "delete", "rolebinding", executionContext.PodName, "--namespace="+executionContext.Namespace,


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
Removes split code path based on secrets to run the APB in the transient namespace always
Changes proposed in this pull request
 - remove branch on secrets 
 - copy secrets to the transient namespace
 - panic the broker if we are attempting to delete its namespace.

**Does this PR depend on another PR (Use this to track when PRs should be merged)**
depends-on <PR>
N/A
**Which issue this PR fixes (This will close that issue when PR gets merged)**
N/A

Fixes: #385 