### PR TITLE
Bug 1497766 - Adding ablity to specify keeping namespace alive

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -160,7 +160,7 @@ registry:
 | image_pull_policy | When to pull the image | Y |
 | sandbox_role | Role to give to apb sandbox environment | Y |
 | keep_namespace | Always keep namespace after apb execution | N |
-| Keep_namespace_on_error | Keep namespace after apb execution has an error | N |
+| keep_namespace_on_error | Keep namespace after apb execution has an error | N |
 
 ## Broker Configuration
 The broker config section will tell the broker what functionality should be enabled

--- a/docs/config.md
+++ b/docs/config.md
@@ -159,6 +159,8 @@ registry:
 | bearer_token_file | Location of bearer token to be used | N |
 | image_pull_policy | When to pull the image | Y |
 | sandbox_role | Role to give to apb sandbox environment | Y |
+| keep_namespace | Always keep namespace after apb execution | N |
+| Keep_namespace_on_error | Keep namespace after apb execution has an error | N |
 
 ## Broker Configuration
 The broker config section will tell the broker what functionality should be enabled

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -19,7 +19,7 @@ DEV_BROKER | true | Include Broker Development Endpoint (true/false)
 AUTO_ESCALATE | true | Auto escalate the users permissions when running an APB 
 BROKER_CA_CERT | "" | Tells the broker that the ca that has signed the SSL Cert and Key
 KEEP_NAMESPACE | false | Always keep the APB namespace after execution.
-KEEP_NAMESPACE_ON_ERROR | true | Keeps the APB namespace after a error during execution.
+KEEP_NAMESPACE_ON_ERROR | true | Keeps the APB namespace after an error during execution.
 
 ## Template
 The following is the template used to deploy the ASB:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -18,6 +18,8 @@ REGISTRY_URL | docker.io | Registry URL
 DEV_BROKER | true | Include Broker Development Endpoint (true/false) 
 AUTO_ESCALATE | true | Auto escalate the users permissions when running an APB 
 BROKER_CA_CERT | "" | Tells the broker that the ca that has signed the SSL Cert and Key
+KEEP_NAMESPACE | false | Always keep the APB namespace after execution.
+KEEP_NAMESPACE_ON_ERROR | true | Keeps the APB namespace after a error during execution.
 
 ## Template
 The following is the template used to deploy the ASB:

--- a/etc/example-config.yaml
+++ b/etc/example-config.yaml
@@ -33,6 +33,8 @@ openshift:
   bearer_token_file: ""
   image_pull_policy: IfNotPresent
   sandbox_role: "edit"
+  keep_namespace: false
+  keep_namespace_on_error: false
 broker:
   bootstrap_on_startup: true
   dev_broker: true

--- a/etc/example-config.yaml
+++ b/etc/example-config.yaml
@@ -34,7 +34,7 @@ openshift:
   image_pull_policy: IfNotPresent
   sandbox_role: "edit"
   keep_namespace: false
-  keep_namespace_on_error: false
+  keep_namespace_on_error: true
 broker:
   bootstrap_on_startup: true
   dev_broker: true

--- a/pkg/apb/bind.go
+++ b/pkg/apb/bind.go
@@ -55,7 +55,7 @@ func Bind(
 	creds, err := ExtractCredentials(executionContext.PodName, executionContext.Namespace, log)
 
 	sm := NewServiceAccountManager(log)
-	err = sm.DestroyApbSandbox(executionContext, clusterConfig.Namespace)
+	err = sm.DestroyApbSandbox(executionContext, clusterConfig)
 
 	return executionContext.PodName, creds, err
 }

--- a/pkg/apb/deprovision.go
+++ b/pkg/apb/deprovision.go
@@ -67,7 +67,7 @@ func Deprovision(
 	}
 
 	sm := NewServiceAccountManager(log)
-	err = sm.DestroyApbSandbox(executionContext, clusterConfig.Namespace)
+	err = sm.DestroyApbSandbox(executionContext, clusterConfig)
 
 	return executionContext.PodName, err
 }

--- a/pkg/apb/provision.go
+++ b/pkg/apb/provision.go
@@ -89,7 +89,7 @@ func Provision(
 	}
 
 	sm := NewServiceAccountManager(log)
-	sm.DestroyApbSandbox(executionContext, clusterConfig.Namespace)
+	sm.DestroyApbSandbox(executionContext, clusterConfig)
 	if err != nil {
 		log.Error("apb::Provision error occurred.")
 		log.Error("%s", err.Error())

--- a/pkg/apb/svc_acct.go
+++ b/pkg/apb/svc_acct.go
@@ -237,7 +237,7 @@ func (s *ServiceAccountManager) DestroyApbSandbox(executionContext ExecutionCont
 	if err != nil {
 		s.log.Errorf("Unable to retrieve pod - %v", err)
 	}
-	if shouldDeleteNamspace(clusterConfig, pod, err) {
+	if shouldDeleteNamespace(clusterConfig, pod, err) {
 		if clusterConfig.Namespace != executionContext.Namespace {
 			s.log.Debug("Deleting namespace %s", executionContext.Namespace)
 			k8scli.CoreV1().Namespaces().Delete(executionContext.Namespace, &metav1.DeleteOptions{})
@@ -287,7 +287,7 @@ func (s *ServiceAccountManager) DestroyApbSandbox(executionContext ExecutionCont
 	return nil
 }
 
-func shouldDeleteNamspace(clusterConfig ClusterConfig, pod *apicorev1.Pod, getPodErr error) bool {
+func shouldDeleteNamespace(clusterConfig ClusterConfig, pod *apicorev1.Pod, getPodErr error) bool {
 	if clusterConfig.KeepNamespace {
 		return false
 	}

--- a/pkg/apb/svc_acct.go
+++ b/pkg/apb/svc_acct.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/openshift/ansible-service-broker/pkg/clients"
 	"github.com/openshift/ansible-service-broker/pkg/runtime"
+	apicorev1 "k8s.io/kubernetes/pkg/api/v1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -222,7 +223,7 @@ func (s *ServiceAccountManager) createFile(handle string) (string, error) {
 }
 
 // DestroyApbSandbox - Destroys the apb sandbox
-func (s *ServiceAccountManager) DestroyApbSandbox(executionContext ExecutionContext, asbNamespace string) error {
+func (s *ServiceAccountManager) DestroyApbSandbox(executionContext ExecutionContext, clusterConfig ClusterConfig) error {
 	s.log.Info("Destroying APB sandbox...")
 	if executionContext.PodName == "" {
 		s.log.Info("Requested destruction of APB sandbox with empty handle, skipping.")
@@ -232,12 +233,19 @@ func (s *ServiceAccountManager) DestroyApbSandbox(executionContext ExecutionCont
 	if err != nil {
 		return err
 	}
-
-	if asbNamespace != executionContext.Namespace {
-		s.log.Debug("Deleting namespace %s", executionContext.Namespace)
-		k8scli.CoreV1().Namespaces().Delete(executionContext.Namespace, &metav1.DeleteOptions{})
-
+	pod, err := k8scli.CoreV1().Pods(executionContext.Namespace).Get(executionContext.PodName, metav1.GetOptions{})
+	if err != nil {
+		s.log.Errorf("Unable to retrieve pod - %v", err)
 	}
+	if shouldDeleteNamspace(clusterConfig, pod, err) {
+		if clusterConfig.Namespace != executionContext.Namespace {
+			s.log.Debug("Deleting namespace %s", executionContext.Namespace)
+			k8scli.CoreV1().Namespaces().Delete(executionContext.Namespace, &metav1.DeleteOptions{})
+		}
+	} else {
+		s.log.Debugf("Keeping namespace alive due to configuration")
+	}
+
 	s.log.Debugf("Deleting rolebinding %s, namespace %s", executionContext.PodName, executionContext.Namespace)
 	output, err := runtime.RunCommand(
 		"oc", "delete", "rolebinding", executionContext.PodName, "--namespace="+executionContext.Namespace,
@@ -277,6 +285,19 @@ func (s *ServiceAccountManager) DestroyApbSandbox(executionContext ExecutionCont
 	os.Remove(filePathFromHandle(executionContext.PodName))
 
 	return nil
+}
+
+func shouldDeleteNamspace(clusterConfig ClusterConfig, pod *apicorev1.Pod, getPodErr error) bool {
+	if clusterConfig.KeepNamespace {
+		return false
+	}
+
+	if clusterConfig.KeepNamespaceOnError {
+		if pod.Status.Phase == apicorev1.PodFailed || pod.Status.Phase == apicorev1.PodUnknown || getPodErr != nil {
+			return false
+		}
+	}
+	return true
 }
 
 func resourceDir() string {

--- a/pkg/apb/types.go
+++ b/pkg/apb/types.go
@@ -97,12 +97,14 @@ type JobState struct {
 
 // ClusterConfig - Configuration for the cluster.
 type ClusterConfig struct {
-	Host            string `yaml:"host"`
-	CAFile          string `yaml:"ca_file"`
-	BearerTokenFile string `yaml:"bearer_token_file"`
-	PullPolicy      string `yaml:"image_pull_policy"`
-	SandboxRole     string `yaml:"sandbox_role"`
-	Namespace       string `yaml:"namespace"`
+	Host                 string `yaml:"host"`
+	CAFile               string `yaml:"ca_file"`
+	BearerTokenFile      string `yaml:"bearer_token_file"`
+	PullPolicy           string `yaml:"image_pull_policy"`
+	SandboxRole          string `yaml:"sandbox_role"`
+	Namespace            string `yaml:"namespace"`
+	KeepNamespace        bool   `yaml:"keep_namespace"`
+	KeepNamespaceOnError bool   `yaml:"keep_namespace_on_error"`
 }
 
 const (

--- a/pkg/apb/unbind.go
+++ b/pkg/apb/unbind.go
@@ -46,6 +46,6 @@ func Unbind(instance *ServiceInstance, parameters *Parameters, clusterConfig Clu
 	}
 
 	sm := NewServiceAccountManager(log)
-	err = sm.DestroyApbSandbox(executionContext, clusterConfig.Namespace)
+	err = sm.DestroyApbSandbox(executionContext, clusterConfig)
 	return err
 }

--- a/scripts/prep_local_devel_env.sh
+++ b/scripts/prep_local_devel_env.sh
@@ -230,6 +230,8 @@ openshift:
   image_pull_policy: ${IMAGE_PULL_POLICY}
   sandbox_role: ${SANDBOX_ROLE:-edit}
   namespace: ${NAMESPACE:-ansible-service-broker}
+  keep_namespace: ${KEEP_NAMESPACE:-false}
+  keep_namespace_on_error: ${KEEP_NAMESPACE_ON_ERROR:-true}
 broker:
   dev_broker: true
   launch_apb_on_bind: false

--- a/templates/deploy-ansible-service-broker.template.yaml
+++ b/templates/deploy-ansible-service-broker.template.yaml
@@ -207,6 +207,8 @@ objects:
         bearer_token_file: "${BEARER_TOKEN_FILE}"
         image_pull_policy: "${IMAGE_PULL_POLICY}"
         sandbox_role: "${SANDBOX_ROLE}"
+        keep_namespace: ${KEEP_NAMESPACE}
+        keep_namespace_on_error: ${KEEP_NAMESPACE_ON_ERROR}
       broker:
         dev_broker: ${DEV_BROKER}
         bootstrap_on_startup: ${BOOTSTRAP_ON_STARTUP}
@@ -460,4 +462,13 @@ parameters:
   name: SANDBOX_ROLE
   value: "edit"
 
+- description: Always keep the namespace after an APB is executed.
+  displayname: Always keep the namespace after an APB is executed.
+  name: KEEP_NAMESPACE
+  value: "false"
+
+- description: Always keep the namespace after an APB is executed and has errored.
+  displayname: Always keep the namespace after an APB is executed and has errored.
+  name: KEEP_NAMESPACE_ON_ERROR
+  value: "true"
 ############################################################


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
Keep namespace alive based on new configuration values
Changes proposed in this pull request
 - Adds new Config options
 - will keep namespace if needed 


**Does this PR depend on another PR (Use this to track when PRs should be merged)**
depends-on <PR>
https://github.com/openshift/ansible-service-broker/pull/464
CATASB PR: https://github.com/fusor/catasb/pull/155
**Which issue this PR fixes (This will close that issue when PR gets merged)**
fixes <issue_number>
