### PR TITLE
Bug 1498954 - Broker in developer mode must support apb push

### DIFF
--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -898,6 +898,7 @@ func (a AnsibleBroker) LastOperation(instanceUUID uuid.UUID, req *LastOperationR
 // AddSpec - adding the spec to the catalog for local development
 func (a AnsibleBroker) AddSpec(spec apb.Spec) (*CatalogResponse, error) {
 	a.log.Debug("broker::AddSpec")
+	spec.Image = spec.FQName
 	addNameAndIDForSpec([]*apb.Spec{&spec}, apbPushRegName)
 	a.log.Debugf("Generated name for pushed APB: [%s], ID: [%s]", spec.FQName, spec.ID)
 


### PR DESCRIPTION
# Testing for this PR

Just used the apb tool to push an image to the broker and looked at how the image was stored by looking at the logs of the broker.

## Before Change:

```
[2017-10-05T14:22:55.126Z] [DEBUG] handler::apbAddSpec
[2017-10-05T14:22:55.126Z] [DEBUG] Successfully decoded pushed spec:
[2017-10-05T14:22:55.126Z] [DEBUG] version: 1.0
name: hello-world-apb
description: deploys hello-world web application
bindable: False
async: optional
metadata:
  displayName: Hello World (APB)
  longDescription: A sample APB which deploys a containerized Hello World web application
  dependencies: ['docker.io/ansibleplaybookbundle/hello-world:latest']
  providerDisplayName: "Red Hat, Inc."
plans:
  - name: default
    description: A sample APB which deploys Hello World
    free: True
    metadata:
      displayName: Default
      longDescription: This plan deploys a Python web application displaying Hello World
      cost: $0.00
    parameters: []
 
[2017-10-05T14:22:55.127Z] [DEBUG] Unmarshalled into apb.Spec:
[2017-10-05T14:22:55.127Z] [DEBUG] {ID: Version:1.0 FQName:hello-world-apb Image: Tags:[] Bindable:false Description:deploys hello-world web application Metadata:map[displayName:Hello World (APB) longDescription:A sample APB which deploys a containerized Hello World web application dependencies:[docker.io/ansibleplaybookbundle/hello-world:latest] providerDisplayName:Red Hat, Inc.] Async:optional Plans:[{Name:default Description:A sample APB which deploys Hello World Metadata:map[displayName:Default longDescription:This plan deploys a Python web application displaying Hello World cost:$0.00] Free:true Bindable:false Parameters:[]}]}
```

## After Change:

```
[2017-10-05T15:23:16.817Z] [DEBUG] handler::apbAddSpec
[2017-10-05T15:23:16.817Z] [DEBUG] Successfully decoded pushed spec:
[2017-10-05T15:23:16.817Z] [DEBUG] version: 1.0
name: hello-world-apb
description: deploys hello-world web application
bindable: False
async: optional
metadata:
  displayName: Hello World (APB)
  longDescription: A sample APB which deploys a containerized Hello World web application
  dependencies: ['docker.io/ansibleplaybookbundle/hello-world:latest']
  providerDisplayName: "Red Hat, Inc."
plans:
  - name: default
    description: A sample APB which deploys Hello World
    free: True
    metadata:
      displayName: Default
      longDescription: This plan deploys a Python web application displaying Hello World
      cost: $0.00
    parameters: []
 
[2017-10-05T15:23:16.817Z] [DEBUG] Unmarshalled into apb.Spec:
[2017-10-05T15:23:16.818Z] [DEBUG] {ID: Version:1.0 FQName:hello-world-apb Image:hello-world-apb Tags:[] Bindable:false Description:deploys hello-world web application Metadata:map[displayName:Hello World (APB) longDescription:A sample APB which deploys a containerized Hello World web application dependencies:[docker.io/ansibleplaybookbundle/hello-world:latest] providerDisplayName:Red Hat, Inc.] Async:optional Plans:[{Name:default Description:A sample APB which deploys Hello World Metadata:map[displayName:Default longDescription:This plan deploys a Python web application displaying Hello World cost:$0.00] Free:true Bindable:false Parameters:[]}]}
```