### PR TITLE
 Bug 1498933 - Do not delete apb-push sourced specs when bootstrapping 

### DIFF
--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -221,9 +221,14 @@ func (a AnsibleBroker) Bootstrap() (*BootstrapResponse, error) {
 	// Remove all specs that have been saved.
 	dir := "/spec"
 	specs, err = a.dao.BatchGetSpecs(dir)
+	pushedSpecs := []*apb.Spec{}
 	if err != nil {
 		a.log.Error("Something went real bad trying to retrieve batch specs for deletion... - %v", err)
 		return nil, err
+	}
+	for _, spec := range specs {
+		a.log.Info("HERE")
+		pushedSpecs = append(pushedSpecs, spec)
 	}
 	err = a.dao.BatchDeleteSpecs(specs)
 	if err != nil {


### PR DESCRIPTION
This PR checks the list of bootstrapped specs for apb-push sourced specs before deleting the entire set of APBs. It then saves the apb-pushed specs to a new array, and adds them back in after the bootstrap. We need this because without apb-push sourced specs are being deleted.

Changes proposed in this pull request
 - Check for apb-push sourced specs, if they exist save them and append them to spec list after the bootstrap


**Which issue this PR fixes (This will close that issue when PR gets merged)**
fixes https://github.com/openshift/ansible-service-broker/issues/391
