### PR TITLE
Bug 1500048 - make plan ids globally unique

### DIFF
--- a/pkg/apb/types.go
+++ b/pkg/apb/types.go
@@ -50,6 +50,7 @@ type ParameterDescriptor struct {
 
 // Plan - Plan object describing an APB deployment plan and associated parameters
 type Plan struct {
+	ID             string                 `json:"id" yaml:"-"`
 	Name           string                 `json:"name"`
 	Description    string                 `json:"description"`
 	Metadata       map[string]interface{} `json:"metadata,omitempty"`

--- a/pkg/apb/types_test.go
+++ b/pkg/apb/types_test.go
@@ -76,6 +76,7 @@ var expectedPlanParameters = []ParameterDescriptor{
 }
 
 var p = Plan{
+	ID:          "",
 	Name:        PlanName,
 	Description: PlanDescription,
 	Metadata:    PlanMetadata,
@@ -93,6 +94,7 @@ const SpecDescription = "Mediawiki123 apb implementation"
 const SpecPlans = `
 [
 	{
+		"id": "",
 		"name": "dev",
 		"description": "Mediawiki123 apb implementation",
 		"free": true,
@@ -191,6 +193,7 @@ func TestSpecDumpJSON(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
+
 	json.Unmarshal([]byte(SpecJSON), &knownMap)
 	json.Unmarshal([]byte(raw), &subjectMap)
 	ft.AssertTrue(t, reflect.DeepEqual(knownMap, subjectMap))

--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -319,16 +319,20 @@ func addNameAndIDForSpec(specs []*apb.Spec, registryName string) {
 
 		// update the id on the plans, doing it here avoids looping through the
 		// specs array again
-		addIDForPlan(spec.Plans)
+		addIDForPlan(spec.Plans, spec.FQName)
 	}
 }
 
 // addIDForPlan - for each of the plans create a new ID
-func addIDForPlan(plans []apb.Plan) {
+func addIDForPlan(plans []apb.Plan, FQSpecName string) {
 
 	// need to use the index into the array to actually update the struct.
-	for i := range plans {
-		plans[i].ID = uuid.New()
+	for i, plan := range plans {
+		//plans[i].ID = uuid.New()
+		FQPlanName := fmt.Sprintf("%s-%s", FQSpecName, plan.Name)
+		hasher := md5.New()
+		hasher.Write([]byte(FQPlanName))
+		plans[i].ID = hex.EncodeToString(hasher.Sum(nil))
 	}
 }
 

--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -277,6 +277,7 @@ func (a AnsibleBroker) Bootstrap() (*BootstrapResponse, error) {
 		for _, p := range s.Plans {
 			if p.ID == "" {
 				a.log.Errorf("We have a plan that did not get its id generated: %v", p.Name)
+				continue
 			}
 			planNameManifest[p.ID] = p.Name
 		}

--- a/pkg/broker/broker_test.go
+++ b/pkg/broker/broker_test.go
@@ -61,3 +61,10 @@ func TestAddNameAndIDForSpecStripsTailingDash(t *testing.T) {
 	ft.AssertEqual(t, "h-1234567890123456789012345678901234567890", spcs[0].FQName)
 	ft.AssertEqual(t, "h-org-hello-world-apb", spcs[1].FQName)
 }
+
+func TestAddIdForPlan(t *testing.T) {
+	plan1 := apb.Plan{Name: "default"}
+	plans := []apb.Plan{plan1}
+	addIDForPlan(plans)
+	ft.AssertNotEqual(t, plans[0].ID, "", "plan id not updated")
+}

--- a/pkg/broker/broker_test.go
+++ b/pkg/broker/broker_test.go
@@ -65,6 +65,6 @@ func TestAddNameAndIDForSpecStripsTailingDash(t *testing.T) {
 func TestAddIdForPlan(t *testing.T) {
 	plan1 := apb.Plan{Name: "default"}
 	plans := []apb.Plan{plan1}
-	addIDForPlan(plans)
+	addIDForPlan(plans, "dh-sns-apb")
 	ft.AssertNotEqual(t, plans[0].ID, "", "plan id not updated")
 }

--- a/pkg/broker/util.go
+++ b/pkg/broker/util.go
@@ -59,7 +59,7 @@ func toBrokerPlans(apbPlans []apb.Plan) []Plan {
 	i := 0
 	for _, plan := range apbPlans {
 		brokerPlans[i] = Plan{
-			ID:          plan.Name,
+			ID:          plan.ID,
 			Name:        plan.Name,
 			Description: plan.Description,
 			Metadata:    extractBrokerPlanMetadata(plan),

--- a/pkg/broker/util_test.go
+++ b/pkg/broker/util_test.go
@@ -29,6 +29,7 @@ import (
 	schema "github.com/lestrrat/go-jsschema"
 	"github.com/openshift/ansible-service-broker/pkg/apb"
 	ft "github.com/openshift/ansible-service-broker/pkg/fusortest"
+	"github.com/pborman/uuid"
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -101,6 +102,7 @@ var PlanBindParams = []apb.ParameterDescriptor{
 }
 
 var p = apb.Plan{
+	ID:             "50eb5637-6ffe-480d-a52e-a7e603a50fca",
 	Name:           PlanName,
 	Description:    PlanDescription,
 	Metadata:       PlanMetadata,
@@ -149,10 +151,14 @@ func TestSpecToService(t *testing.T) {
 		Plans:       nil,
 		Metadata:    descriptors,
 	}
+
 	svc := SpecToService(&spec)
+
 	ft.AssertEqual(t, svc.Name, expectedsvc.Name, "name is not equal")
 	ft.AssertEqual(t, svc.Description, expectedsvc.Description, "description is not equal")
 	ft.AssertEqual(t, svc.Bindable, expectedsvc.Bindable, "bindable wrong")
+	ft.AssertEqual(t, svc.Plans[0].ID, "50eb5637-6ffe-480d-a52e-a7e603a50fca", "plan id didn't match")
+	ft.AssertNotNil(t, uuid.Parse(svc.Plans[0].ID), "plan id is a valid uuid")
 }
 
 func TestUpdateMetadata(t *testing.T) {

--- a/pkg/broker/util_test.go
+++ b/pkg/broker/util_test.go
@@ -29,7 +29,6 @@ import (
 	schema "github.com/lestrrat/go-jsschema"
 	"github.com/openshift/ansible-service-broker/pkg/apb"
 	ft "github.com/openshift/ansible-service-broker/pkg/fusortest"
-	"github.com/pborman/uuid"
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -102,7 +101,7 @@ var PlanBindParams = []apb.ParameterDescriptor{
 }
 
 var p = apb.Plan{
-	ID:             "50eb5637-6ffe-480d-a52e-a7e603a50fca",
+	ID:             "55822a921d2c4858fe6e58f5522429c2", // md5(dh-sns-apb-dev)
 	Name:           PlanName,
 	Description:    PlanDescription,
 	Metadata:       PlanMetadata,
@@ -157,8 +156,7 @@ func TestSpecToService(t *testing.T) {
 	ft.AssertEqual(t, svc.Name, expectedsvc.Name, "name is not equal")
 	ft.AssertEqual(t, svc.Description, expectedsvc.Description, "description is not equal")
 	ft.AssertEqual(t, svc.Bindable, expectedsvc.Bindable, "bindable wrong")
-	ft.AssertEqual(t, svc.Plans[0].ID, "50eb5637-6ffe-480d-a52e-a7e603a50fca", "plan id didn't match")
-	ft.AssertNotNil(t, uuid.Parse(svc.Plans[0].ID), "plan id is a valid uuid")
+	ft.AssertEqual(t, svc.Plans[0].ID, "55822a921d2c4858fe6e58f5522429c2", "plan id didn't match")
 }
 
 func TestUpdateMetadata(t *testing.T) {

--- a/pkg/dao/dao.go
+++ b/pkg/dao/dao.go
@@ -309,6 +309,30 @@ func (d *Dao) GetState(id string, token string) (apb.JobState, error) {
 	return state, nil
 }
 
+// BatchSetPlanNames - set plannames based on PlanNameManifest in the kvp API.
+func (d *Dao) BatchSetPlanNames(planNames map[string]string) error {
+	for id, planName := range planNames {
+		err := d.SetPlanName(id, planName)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// SetPlanName - Set the Plan name in the kvp API for the given id.
+func (d *Dao) SetPlanName(id string, name string) error {
+	// it's just a string so no other work is needed
+	return d.SetRaw(planNameKey(id), name)
+}
+
+// GetPlanName - Retrieve the plan name associated with the ID
+func (d *Dao) GetPlanName(id string) (string, error) {
+	// it's just a string so no other work is needed
+	return d.GetRaw(planNameKey(id))
+}
+
 func (d *Dao) getObject(key string, data interface{}) error {
 	raw, err := d.GetRaw(key)
 	if err != nil {
@@ -354,4 +378,8 @@ func serviceInstanceKey(id string) string {
 
 func bindInstanceKey(id string) string {
 	return fmt.Sprintf("/bind_instance/%s", id)
+}
+
+func planNameKey(id string) string {
+	return fmt.Sprintf("/plan_name/%s", id)
 }


### PR DESCRIPTION
**Describe what this PR does and why we need it**:

With a recent service-catalog change, the serviceplans were moved to top level. We were using the plan.name as the plan.id which was not a problem before because they were namespaced by the serviceclass.

Now that the serviceplans are top level, the names need to be unique. Since we used to rely on the serviceclass name, the new id will be a UUID. We are now storing the id and name in etcd.

```
/plan_names/UUID: plan.name
```


**Which issue this PR fixes (This will close that issue when PR gets merged)**
fixes 1500048
