### PR TITLE
making the deployment template use v1beta1 api version

### DIFF
--- a/templates/deploy-ansible-service-broker.template.yaml
+++ b/templates/deploy-ansible-service-broker.template.yaml
@@ -263,7 +263,7 @@ objects:
     tls:
       termination: reencrypt
 
-- apiVersion: servicecatalog.k8s.io/v1alpha1
+- apiVersion: servicecatalog.k8s.io/v1beta1
   kind: ${BROKER_KIND}
   metadata:
     name: ansible-service-broker
@@ -277,7 +277,7 @@ parameters:
 - description: Service Broker kind. Newer service-catalogs use ServiceBroker
   displayname: Service Broker kind. Newer service-catalogs use ServiceBroker
   name: BROKER_KIND
-  value: ServiceBroker
+  value: ClusterServiceBroker
 
 - description: Service Broker CA Cert. 
   displayname: Service Broker kind.


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
Updates template to work with latest service catalog
Changes proposed in this pull request
 - update default kind to ClusterServiceBroker
 -
 -

# This will render this template useless for 3.6
