### PR TITLE
Move the gate to 3.7

### DIFF
--- a/scripts/broker-ci/bind-mediawiki-postgresql.yaml
+++ b/scripts/broker-ci/bind-mediawiki-postgresql.yaml
@@ -1,5 +1,5 @@
-apiVersion: servicecatalog.k8s.io/v1alpha1
-kind: Binding
+apiVersion: servicecatalog.k8s.io/v1beta1
+kind: ServiceBinding
 metadata:
   name: mediawiki-postgresql-binding
   namespace: default
@@ -7,8 +7,3 @@ spec:
   instanceRef:
     name: postgresql
   secretName: mediawiki-postgresql-binding
-  alphaPodPresetTemplate:
-    name: bind-postgresql-mediawiki
-    selector:
-      matchLabels:
-        app: mediawiki123

--- a/scripts/broker-ci/cleanup-ci.sh
+++ b/scripts/broker-ci/cleanup-ci.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
-oc delete bindings.v1alpha1.servicecatalog.k8s.io mediawiki-postgresql-binding -n default
-./scripts/broker-ci/wait-for-resource.sh delete bindings.v1alpha1.servicecatalog.k8s.io mediawiki-postgresql-binding
-oc delete instance postgresql mediawiki -n default
+oc delete -f ./scripts/broker-ci/bind-mediawiki-postgresql.yaml
+./scripts/broker-ci/wait-for-resource.sh delete ServiceBinding mediawiki-postgresql-binding
+oc delete -f ./scripts/broker-ci/mediawiki123.yaml
+oc delete -f ./scripts/broker-ci/postgresql.yaml
 oc delete dc postgresql mediawiki123 -n default
 ./scripts/broker-ci/wait-for-resource.sh delete pod postgresql
 ./scripts/broker-ci/wait-for-resource.sh delete pod mediawiki

--- a/scripts/broker-ci/error.sh
+++ b/scripts/broker-ci/error.sh
@@ -33,9 +33,6 @@ function convert-to-red {
     if ${PROVISION_ERROR}; then
 	PROVISION_ERROR="${color_red}true${color_norm}"
     fi
-    if ${POD_PRESET_ERROR}; then
-	POD_PRESET_ERROR="${color_red}true${color_norm}"
-    fi
     if ${VERIFY_CI_ERROR}; then
 	VERIFY_CI_ERROR="${color_red}true${color_norm}"
     fi
@@ -63,7 +60,6 @@ function error-variables {
     print-with-yellow "RESOURCE_ERROR: ${RESOURCE_ERROR}"
     print-with-yellow "BIND_ERROR: ${BIND_ERROR}"
     print-with-yellow "PROVISION_ERROR: ${PROVISION_ERROR}"
-    print-with-yellow "POD_PRESET_ERROR: ${POD_PRESET_ERROR}"
     print-with-yellow "VERIFY_CI_ERROR: ${VERIFY_CI_ERROR}"
     print-with-yellow "UNBIND_ERROR: ${UNBIND_ERROR}"
     print-with-yellow "DEPROVISION_ERROR: ${DEPROVISION_ERROR}"
@@ -81,7 +77,6 @@ function error-check {
     elif ${BIND_ERROR}; then
 	print-with-red "BIND ERROR reported from ${1}"
 	redirect-output
-	podpreset-logs
 	secret-logs
 	broker-logs
 	catalog-logs
@@ -90,12 +85,6 @@ function error-check {
 	redirect-output
 	pod-logs
 	broker-logs
-    elif ${POD_PRESET_ERROR}; then
-	print-with-red "POD PRESET ERROR reported from ${1}"
-	redirect-output
-	pod-logs
-	secret-logs
-	podpreset-logs
     elif ${VERIFY_CI_ERROR}; then
 	print-with-red "VERIFY CI ERROR reported from ${1}"
 	redirect-output
@@ -114,7 +103,7 @@ function error-check {
 	print-all-logs
     fi
 
-    if ${VERIFY_CI_ERROR} || ${POD_PRESET_ERROR} || ${PROVISION_ERROR} ||
+    if ${VERIFY_CI_ERROR} || ${PROVISION_ERROR} ||
 	${BIND_ERROR} || ${RESOURCE_ERROR} || ${UNBIND_ERROR} || 
     ${DEPROVISION_ERROR} || ${DEVAPI_ERROR} ; then
 	restore-output

--- a/scripts/broker-ci/logs.sh
+++ b/scripts/broker-ci/logs.sh
@@ -45,14 +45,6 @@ function secret-logs {
     log-footer "secrets logs"
 }
 
-function podpreset-logs {
-    log-header "podpreset logs"
-    oc get podpresets -n default
-    oc get pods $(oc get pods -n default | grep mediawiki | awk $'{ print $1 }') -o yaml -n default
-    pod-logs
-    log-footer "podpreset logs"
-}
-
 function broker-logs {
     log-header "broker logs"
     oc logs $(oc get pods -o name -l service=asb --all-namespaces | cut -f 2 -d '/') -c asb -n ansible-service-broker
@@ -61,15 +53,14 @@ function broker-logs {
 
 function catalog-logs {
     log-header "catlog logs"
-    oc get serviceclasses --all-namespaces
-    oc get instances --all-namespaces
+    oc get clusterserviceclasses --all-namespaces
+    oc get serviceinstances --all-namespaces
     oc logs $(oc get pods -o name -l app=controller-manager --all-namespaces | cut -f 2 -d '/') -n service-catalog
     log-footer "catlog logs"
 }
 
 function print-all-logs {
     secret-logs
-    podpreset-logs
     wait-logs
     broker-logs
     catalog-logs

--- a/scripts/broker-ci/mediawiki123.yaml
+++ b/scripts/broker-ci/mediawiki123.yaml
@@ -1,11 +1,11 @@
-apiVersion: servicecatalog.k8s.io/v1alpha1
-kind: Instance
+apiVersion: servicecatalog.k8s.io/v1beta1
+kind: ServiceInstance
 metadata:
   name: mediawiki
   namespace: default
 spec:
-  serviceClassName: dh-mediawiki123-apb
-  planName: default
+  externalClusterServiceClassName: dh-mediawiki123-apb
+  externalClusterServicePlanName: default
   parameters:
     mediawiki_db_schema: "mediawiki"
     mediawiki_site_name: "Mediawiki-CI"

--- a/scripts/broker-ci/postgresql.yaml
+++ b/scripts/broker-ci/postgresql.yaml
@@ -1,11 +1,11 @@
-apiVersion: servicecatalog.k8s.io/v1alpha1
-kind: Instance
+apiVersion: servicecatalog.k8s.io/v1beta1
+kind: ServiceInstance
 metadata:
   name: postgresql
   namespace: default
 spec:
-  serviceClassName: dh-rhscl-postgresql-apb
-  planName: prod
+  externalClusterServiceClassName: dh-rhscl-postgresql-apb
+  externalClusterServicePlanName: prod
   parameters:
     postgresql_database: "admin"
     postgresql_password: "admin"


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
Transition the broker script to work with 3.7

Changes proposed in this pull request
 - Create the bind secret
 - Populate the bindTarget's pod with secret data
 - Transition to 3.7 api types

