### PR TITLE
Bug 1496572 - Clean up error message for invalid registry credentials.

### DIFF
--- a/pkg/registries/adapters/adapter.go
+++ b/pkg/registries/adapters/adapter.go
@@ -85,6 +85,11 @@ func imageToSpec(log *logging.Logger, req *http.Request, image string) (*apb.Spe
 		Config *config `json:"config"`
 	}{}
 
+	if resp.StatusCode == http.StatusUnauthorized {
+		log.Errorf("Unable to authenticate to the registry, registry credentials could be invalid.")
+		return nil, nil
+	}
+
 	err = json.NewDecoder(resp.Body).Decode(&hist)
 	if err != nil {
 		log.Errorf("Error grabbing JSON body from response: %s", err)


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
Update error message to deal with unauthorized users to a registry

**Changes proposed in this pull request**
 - Add a check for the `Unauthorized` status response

**Does this PR depend on another PR (Use this to track when PRs should be merged)**
depends-on <PR>
N/A

**Which issue this PR fixes (This will close that issue when PR gets merged)**
fixes 1496572
