### PR TITLE
Bug 1501523 - Set plan name for APB push sourced specs

### DIFF
--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -1009,6 +1009,9 @@ func (a AnsibleBroker) AddSpec(spec apb.Spec) (*CatalogResponse, error) {
 	spec.Image = spec.FQName
 	addNameAndIDForSpec([]*apb.Spec{&spec}, apbPushRegName)
 	a.log.Debugf("Generated name for pushed APB: [%s], ID: [%s]", spec.FQName, spec.ID)
+	for _, p := range spec.Plans {
+		a.dao.SetPlanName(p.ID, p.Name)
+	}
 
 	if err := a.dao.SetSpec(spec.ID, &spec); err != nil {
 		return nil, err


### PR DESCRIPTION
This PR sets the plan name to the corresponding plan ID in etcd when using `apb push`.

Changes proposed in this pull request
 - Set plan name in AddSpec function