### PR TITLE
Bug 1504729 - Log job state when getting last op

### DIFF
--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -1012,7 +1012,7 @@ func (a AnsibleBroker) LastOperation(instanceUUID uuid.UUID, req *LastOperationR
 	*/
 	a.log.Debugf("service_id: %s", req.ServiceID)
 	a.log.Debugf("plan_id: %s", req.PlanID)
-	a.log.Debugf("operation:  %s", req.Operation) // this is provided with the provision. task id from the work_engine
+	a.log.Debugf("operation:  %s", req.Operation) // Operation is the job token id from the work_engine
 
 	// TODO:validate the format to avoid some sort of injection hack
 	jobstate, err := a.dao.GetState(instanceUUID.String(), req.Operation)

--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -1010,9 +1010,9 @@ func (a AnsibleBroker) LastOperation(instanceUUID uuid.UUID, req *LastOperationR
 
 		if async, provision: it should create a Job that calls apb.Provision. And write the output to etcd.
 	*/
-	a.log.Debug(fmt.Sprintf("service_id: %s", req.ServiceID)) // optional
-	a.log.Debug(fmt.Sprintf("plan_id: %s", req.PlanID))       // optional
-	a.log.Debug(fmt.Sprintf("operation:  %s", req.Operation)) // this is provided with the provision. task id from the work_engine
+	a.log.Debugf("service_id: %s", req.ServiceID)
+	a.log.Debugf("plan_id: %s", req.PlanID)
+	a.log.Debugf("operation:  %s", req.Operation) // this is provided with the provision. task id from the work_engine
 
 	// TODO:validate the format to avoid some sort of injection hack
 	jobstate, err := a.dao.GetState(instanceUUID.String(), req.Operation)
@@ -1022,6 +1022,7 @@ func (a AnsibleBroker) LastOperation(instanceUUID uuid.UUID, req *LastOperationR
 	}
 
 	state := StateToLastOperation(jobstate.State)
+	a.log.Debugf("state: %s", state)
 	return &LastOperationResponse{State: state, Description: ""}, err
 }
 


### PR DESCRIPTION
Simple enhancement so that we can see the state of the last operation when the service-catalog requests it.