### PR TITLE
Bug 1504250 - Keep listening for deprovision messages

### DIFF
--- a/pkg/broker/deprovision_subscriber.go
+++ b/pkg/broker/deprovision_subscriber.go
@@ -57,8 +57,9 @@ func (d *DeprovisionWorkSubscriber) Subscribe(msgBuffer <-chan WorkMsg) {
 
 			if dmsg.Error != "" {
 				// Job failed, mark failure
+				d.log.Errorf("Deprovision job reporting error: %s", dmsg.Error)
 				setFailedDeprovisionJob(d.dao, dmsg)
-				return
+				continue
 			}
 
 			instance, err := d.dao.GetServiceInstance(dmsg.InstanceUUID)
@@ -69,7 +70,7 @@ func (d *DeprovisionWorkSubscriber) Subscribe(msgBuffer <-chan WorkMsg) {
 				)
 				d.log.Errorf("%s", err.Error())
 				setFailedDeprovisionJob(d.dao, dmsg)
-				return
+				continue
 			}
 
 			// Job is not reporting error, cleanup after deprovision
@@ -79,7 +80,7 @@ func (d *DeprovisionWorkSubscriber) Subscribe(msgBuffer <-chan WorkMsg) {
 				// Cleanup is reporting something has gone wrong. Deprovision overall
 				// has not completed. Mark the job as failed.
 				setFailedDeprovisionJob(d.dao, dmsg)
-				return
+				continue
 			}
 
 			// No errors reported, deprovision action successfully performed and


### PR DESCRIPTION
**Describe what this PR does and why we need it**:

We want the subscriber to keep listening for deprovision messages even if a previous deprovision fails.

See https://bugzilla.redhat.com/show_bug.cgi?id=1504250 for recreation steps.

Before this change 'deprovision complete msg' would be sent to the channel but there would not be a corresponding 'processed deprovision message from buffer'.

After this change (from broker logs):

```
...
[2017-10-19T20:07:53.008Z] [DEBUG] sending deprovision complete msg to channel
[2017-10-19T20:07:53.008Z] [DEBUG] Processed deprovision message from buffer
```