### PR TITLE
Bug 1508084 - Add ServiceClassID and ServiceInstanceID params during provision and bind

### DIFF
--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -636,6 +636,12 @@ func (a AnsibleBroker) Provision(instanceUUID uuid.UUID, req *ProvisionRequest, 
 		"Injecting PlanID as parameter: { %s: %s }",
 		planParameterKey, planName)
 	parameters[planParameterKey] = planName
+	a.log.Debugf("Injecting ServiceClassID as parameter: { %s: %s }",
+		serviceClassIDKey, req.ServiceID)
+	parameters[serviceClassIDKey] = req.ServiceID
+	a.log.Debugf("Injecting ServiceInstanceID as parameter: { %s: %s }",
+		serviceInstIDKey, instanceUUID.String())
+	parameters[serviceInstIDKey] = instanceUUID.String()
 
 	// Build and persist record of service instance
 	serviceInstance := &apb.ServiceInstance{
@@ -854,6 +860,12 @@ func (a AnsibleBroker) Bind(instance apb.ServiceInstance, bindingUUID uuid.UUID,
 		"Injecting PlanID as parameter: { %s: %s }",
 		planParameterKey, planName)
 	params[planParameterKey] = planName
+	a.log.Debugf("Injecting ServiceClassID as parameter: { %s: %s }",
+		serviceClassIDKey, req.ServiceID)
+	params[serviceClassIDKey] = req.ServiceID
+	a.log.Debugf("Injecting ServiceInstanceID as parameter: { %s: %s }",
+		serviceInstIDKey, instance.ID.String())
+	params[serviceInstIDKey] = instance.ID.String()
 
 	// Create a BindingInstance with a reference to the serviceinstance.
 	bindingInstance := &apb.BindInstance{

--- a/pkg/broker/types.go
+++ b/pkg/broker/types.go
@@ -32,7 +32,9 @@ const (
 )
 
 const (
-	planParameterKey = "_apb_plan_id"
+	planParameterKey  = "_apb_plan_id"
+	serviceClassIDKey = "_apb_service_class_id"
+	serviceInstIDKey  = "_apb_service_instance_id"
 )
 
 // WorkTopic - Topic jobs can publish messages to, and subscribers can listen to


### PR DESCRIPTION
This PR resolves issue https://github.com/openshift/ansible-service-broker/issues/481
and part of https://github.com/openshift/ansible-service-broker/issues/470
Changes proposed in this pull request
 - pass through the serviceClassID and serviceInstanceID to provision and bind apbs
 

**Note**
Not currently passing through the user as is mentioned in issue 470. Is this still something that is wanted? I can see the user is resolved and could be passed down to the broker methods. 
If we wanted to pass the user would we pass the entire user object or just the username perhaps?

**Testing**

The unit tests for the broker seemed a bit lacking so tested this manually: The apb and asb logs appeared as follows:
Is this sufficient?

```
[[ provision --extra-vars {"_apb_plan_id":"default","_apb_service_class_id":"b43a4272a6efcaaa3e0b9616324f1099","_apb_service_instance_id":"64f8056d-bc9a-4aa7-b6d1-de80f9b23e96","namespace":"test","postgresql_database":"admin","postgresql_password":"admin","postgresql_user":"admin"} == *\s\2\i\/\a\s\s\e\m\b\l\e* ]]
```

```
[2017-10-24T11:50:59.947Z] [WARNING] Broker configured to *NOT* launch and run APB bind
172.17.0.2 - - [24/Oct/2017:11:50:59 +0000] "PUT /ansible-service-broker/v2/service_instances/64f8056d-bc9a-4aa7-b6d1-de80f9b23e96/service_bindings/9f23a35d-4f8b-4ba9-b60a-d1c9e32cbe41 HTTP/1.1" 201 185
[2017-10-24T11:51:00.096Z] [DEBUG] Auto Escalate has been set to true, we are escalating permissions
[2017-10-24T11:51:00.096Z] [DEBUG] Injecting PlanID as parameter: { _apb_plan_id: default }
[2017-10-24T11:51:00.096Z] [DEBUG] Injecting ServiceClassID as parameter: { _apb_service_class_id: b43a4272a6efcaaa3e0b9616324f1099 }
[2017-10-24T11:51:00.096Z] [DEBUG] Injecting ServiceInstanceID as parameter: { _apb_service_instance_id: 64f8056d-bc9a-4aa7-b6d1-de80f9b23e96 }
```
