### PR TITLE
Call the correct service-catalog namespace

### DIFF
--- a/scripts/broker-ci/logs.sh
+++ b/scripts/broker-ci/logs.sh
@@ -55,7 +55,7 @@ function catalog-logs {
     log-header "catlog logs"
     oc get clusterserviceclasses --all-namespaces
     oc get serviceinstances --all-namespaces
-    oc logs $(oc get pods -o name -l app=controller-manager --all-namespaces | cut -f 2 -d '/') -n service-catalog
+    oc logs $(oc get pods -o name -l app=controller-manager --all-namespaces | cut -f 2 -d '/') -n kube-service-catalog
     log-footer "catlog logs"
 }
 


### PR DESCRIPTION
The service-catalog namespace was changed to kube-service-catalog in 3.7.
