### PR TITLE
when building the broker for image always build for linux OS.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,8 +47,8 @@ $(KUBERNETES_FILES):
 prepare-local-env: $(KUBERNETES_FILES) ## Prepare the local environment for running the broker locally
 	@echo > /dev/null
 
-build-image: broker ## Build a docker image with the broker binary
-	cp broker build/broker
+build-image: ## Build a docker image with the broker binary
+	env GOOS=linux go build -i -ldflags="-s -s" -o ${BUILD_DIR}/broker ./cmd/broker
 	docker build -f ${BUILD_DIR}/Dockerfile-localdev -t ${BROKER_IMAGE}:${TAG} ${BUILD_DIR}
 	@echo
 	@echo "Remember you need to push your image before calling make deploy"


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
Always build the broker binary for OS of Linux and output to the build directory

**Which issue this PR fixes (This will close that issue when PR gets merged)**
fixes #521 
