### PR TITLE
Smallfix: grep for correct asb-token for local dev.

### DIFF
--- a/scripts/prep_local_devel_env.sh
+++ b/scripts/prep_local_devel_env.sh
@@ -58,7 +58,7 @@ fi
 
 
 # Determine the name of the secret which has the 'asb' service account info
-BROKER_SVC_ACCT_SECRET_NAME=`kubectl get serviceaccount asb -n ansible-service-broker -o jsonpath='{.secrets[0].name}'`
+BROKER_SVC_ACCT_SECRET_NAME=`kubectl get serviceaccount asb -n ansible-service-broker -o yaml | grep -o asb-token-[a-z0-9]*`
 REGISTRY_SECRET_NAME="registry-auth-secret"
 echo "Broker Service Account Token is in secret: ${BROKER_SVC_ACCT_SECRET_NAME}"
 


### PR DESCRIPTION
prep local fails sometimes when the asb-token isn't listed first.