### PR TITLE
Bug 1507111 - Add support for a local OpenShift Registry adapter

### DIFF
--- a/pkg/registries/adapters/adapter.go
+++ b/pkg/registries/adapters/adapter.go
@@ -49,12 +49,13 @@ const BundleSpecLabel = "com.redhat.apb.spec"
 // Configuration - Adapter configuration. Contains the info that the adapter
 // would need to complete its request to the images.
 type Configuration struct {
-	URL    *url.URL
-	User   string
-	Pass   string
-	Org    string
-	Images []string
-	Tag    string
+	URL        *url.URL
+	User       string
+	Pass       string
+	Org        string
+	Images     []string
+	Namespaces []string
+	Tag        string
 }
 
 // Retrieve the spec from a registry manifest request

--- a/pkg/registries/adapters/local_openshift_adapter.go
+++ b/pkg/registries/adapters/local_openshift_adapter.go
@@ -1,0 +1,137 @@
+//
+// Copyright (c) 2017 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Red Hat trademarks are not licensed under Apache License, Version 2.
+// No permission is granted to use or replicate Red Hat trademarks that
+// are incorporated in this software or its documentation.
+//
+
+package adapters
+
+import (
+	logging "github.com/op/go-logging"
+	"github.com/openshift/ansible-service-broker/pkg/apb"
+	"github.com/openshift/ansible-service-broker/pkg/clients"
+	yaml "gopkg.in/yaml.v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"strings"
+)
+
+const localOpenShiftName = "openshift-registry"
+
+// LocalOpenShiftAdapter - Docker Hub Adapter
+type LocalOpenShiftAdapter struct {
+	Config Configuration
+	Log    *logging.Logger
+}
+
+// RegistryName - Retrieve the registry name
+func (r LocalOpenShiftAdapter) RegistryName() string {
+	return localOpenShiftName
+}
+
+// GetImageNames - retrieve the images
+func (r LocalOpenShiftAdapter) GetImageNames() ([]string, error) {
+	r.Log.Debug("LocalOpenShiftAdapter::GetImageNames")
+	r.Log.Debug("BundleSpecLabel: %s", BundleSpecLabel)
+
+	openshiftClient, err := clients.Openshift(r.Log)
+	if err != nil {
+		r.Log.Errorf("Failed to instantiate OpenShift client")
+		return nil, err
+	}
+
+	images, err := openshiftClient.ListRegistryImages(r.Log)
+	if err != nil {
+		r.Log.Errorf("Failed to load registry images")
+		return nil, err
+	}
+
+	return images, nil
+}
+
+// FetchSpecs - retrieve the spec for the image names.
+func (r LocalOpenShiftAdapter) FetchSpecs(imageNames []string) ([]*apb.Spec, error) {
+	r.Log.Debug("LocalOpenShiftAdapter::FetchSpecs")
+	specList := []*apb.Spec{}
+	registryIP, err := r.getServiceIP("docker-registry", "default")
+	if err != nil {
+		r.Log.Errorf("Failed get docker-registry service information.")
+		return nil, err
+	}
+
+	openshiftClient, err := clients.Openshift(r.Log)
+	if err != nil {
+		r.Log.Errorf("Failed to instantiate OpenShift client.")
+		return nil, err
+	}
+
+	fqImages, err := openshiftClient.ConvertRegistryImagesToSpecs(r.Log, imageNames)
+	if err != nil {
+		r.Log.Errorf("Failed to load registry images")
+		return nil, err
+	}
+
+	for _, image := range fqImages {
+		spec, err := r.loadSpec(image.DecodedSpec)
+		if err != nil {
+			r.Log.Errorf("Failed to load image spec")
+			continue
+		}
+		if strings.HasPrefix(image.Name, registryIP) {
+			// Image has proper registry IP prefix
+			spec.Image = image.Name
+			namespace := strings.Split(image.Name, "/")[1]
+			for _, ns := range r.Config.Namespaces {
+				if ns == namespace {
+					r.Log.Debugf("Image [%v] is in configured namespace [%v]. Adding to SpecList.", image.Name, ns)
+					specList = append(specList, spec)
+				}
+			}
+		} else {
+			r.Log.Debugf("Image does not have proper registry IP prefix. Something went wrong.")
+		}
+	}
+
+	return specList, nil
+}
+
+func (r LocalOpenShiftAdapter) loadSpec(yamlSpec []byte) (*apb.Spec, error) {
+	r.Log.Debug("LocalOpenShiftAdapter::LoadSpec")
+	spec := &apb.Spec{}
+
+	err := yaml.Unmarshal(yamlSpec, spec)
+	if err != nil {
+		r.Log.Errorf("Something went wrong loading decoded spec yaml, %s", err)
+		return nil, err
+	}
+	return spec, nil
+}
+
+func (r LocalOpenShiftAdapter) getServiceIP(service string, namespace string) (string, error) {
+	k8scli, err := clients.Kubernetes(r.Log)
+	if err != nil {
+		return "", err
+	}
+
+	serviceData, err := k8scli.CoreV1().Services(namespace).Get(service, meta_v1.GetOptions{})
+	if err != nil {
+		r.Log.Warningf("Unable to load service '%s' from namespace '%s'", service, namespace)
+		return "", err
+	}
+	r.Log.Debugf("Found service with name %v", service)
+
+	return serviceData.Spec.ClusterIP, nil
+}

--- a/pkg/registries/adapters/local_openshift_adapter_test.go
+++ b/pkg/registries/adapters/local_openshift_adapter_test.go
@@ -1,0 +1,32 @@
+//
+// Copyright (c) 2017 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Red Hat trademarks are not licensed under Apache License, Version 2.
+// No permission is granted to use or replicate Red Hat trademarks that
+// are incorporated in this software or its documentation.
+//
+
+package adapters
+
+import (
+	"testing"
+
+	ft "github.com/openshift/ansible-service-broker/pkg/fusortest"
+)
+
+func TestLocalOpenshiftName(t *testing.T) {
+	loa := LocalOpenShiftAdapter{}
+	ft.AssertEqual(t, loa.RegistryName(), "openshift-registry", "local_openshift name does not match openshift-registry")
+}

--- a/pkg/registries/registry.go
+++ b/pkg/registries/registry.go
@@ -45,15 +45,16 @@ type Config struct {
 	//   Valid options: `secret`, `file`
 	// AuthName is used to define the location of the credentials
 	//   Valid options: `<secret-name>`, `<file_location>`
-	AuthType string `yaml:"auth_type"`
-	AuthName string `yaml:"auth_name"`
-	User     string
-	Pass     string
-	Org      string
-	Tag      string
-	Type     string
-	Name     string
-	Images   []string
+	AuthType   string `yaml:"auth_type"`
+	AuthName   string `yaml:"auth_name"`
+	User       string
+	Pass       string
+	Org        string
+	Tag        string
+	Type       string
+	Name       string
+	Images     []string
+	Namespaces []string
 	// Fail will tell the registry that it is ok to fail the bootstrap if
 	// just this registry has failed.
 	Fail      bool     `yaml:"fail_on_error"`
@@ -197,11 +198,12 @@ func NewRegistry(config Config, log *logging.Logger) (Registry, error) {
 		u.Scheme = "http"
 	}
 	c := adapters.Configuration{URL: u,
-		User:   config.User,
-		Pass:   config.Pass,
-		Org:    config.Org,
-		Images: config.Images,
-		Tag:    config.Tag}
+		User:       config.User,
+		Pass:       config.Pass,
+		Org:        config.Org,
+		Images:     config.Images,
+		Namespaces: config.Namespaces,
+		Tag:        config.Tag}
 
 	switch strings.ToLower(config.Type) {
 	case "rhcc":
@@ -212,6 +214,8 @@ func NewRegistry(config Config, log *logging.Logger) (Registry, error) {
 		adapter = &adapters.MockAdapter{Config: c, Log: log}
 	case "openshift":
 		adapter = &adapters.OpenShiftAdapter{Config: c, Log: log}
+	case "local_openshift":
+		adapter = &adapters.LocalOpenShiftAdapter{Config: c, Log: log}
 	default:
 		panic("Unknown registry")
 	}

--- a/templates/deploy-ansible-service-broker.template.yaml
+++ b/templates/deploy-ansible-service-broker.template.yaml
@@ -58,6 +58,10 @@ objects:
   - apiGroups: ["authentication.k8s.io"]
     resources: ["tokenreviews"]
     verbs: ["create"]
+  - apiGroups: ["image.openshift.io", ""]
+    attributeRestrictions: null
+    resources: ["images"]
+    verbs: ["get", "list"]
 
 - apiVersion: rbac.authorization.k8s.io/v1beta1
   kind: ClusterRoleBinding
@@ -79,10 +83,6 @@ objects:
   rules:
   - nonResourceURLs: ["${BROKER_URL_PREFIX}", "${BROKER_URL_PREFIX}/*"]
     verbs: ["get", "post", "put", "patch", "delete"]
-  - apiGroups: ["image.openshift.io", ""]
-    attributeRestrictions: null
-    resources: ["images"]
-    verbs: ["get", "list"]
 
 - apiVersion: v1
   kind: PersistentVolumeClaim

--- a/templates/deploy-ansible-service-broker.template.yaml
+++ b/templates/deploy-ansible-service-broker.template.yaml
@@ -81,6 +81,35 @@ objects:
     verbs: ["get", "post", "put", "patch", "delete"]
 
 - apiVersion: v1
+  kind: ClusterRole
+  metadata:
+    creationTimestamp: null
+    name: image-access
+  rules:
+  - apiGroups:
+    - image.openshift.io
+    - ""
+    attributeRestrictions: null
+    resources:
+    - images
+    verbs:
+    - get
+    - list
+
+- apiVersion: v1
+  groupNames: null
+  kind: ClusterRoleBinding
+  metadata:
+    creationTimestamp: null
+    name: add-access-images
+  roleRef:
+    name: image-access
+  subjects:
+  - kind: ServiceAccount
+    name: asb
+    namespace: ansible-service-broker
+
+- apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
     name: etcd

--- a/templates/deploy-ansible-service-broker.template.yaml
+++ b/templates/deploy-ansible-service-broker.template.yaml
@@ -79,35 +79,10 @@ objects:
   rules:
   - nonResourceURLs: ["${BROKER_URL_PREFIX}", "${BROKER_URL_PREFIX}/*"]
     verbs: ["get", "post", "put", "patch", "delete"]
-
-- apiVersion: v1
-  kind: ClusterRole
-  metadata:
-    creationTimestamp: null
-    name: image-access
-  rules:
-  - apiGroups:
-    - image.openshift.io
-    - ""
+  - apiGroups: ["image.openshift.io", ""]
     attributeRestrictions: null
-    resources:
-    - images
-    verbs:
-    - get
-    - list
-
-- apiVersion: v1
-  groupNames: null
-  kind: ClusterRoleBinding
-  metadata:
-    creationTimestamp: null
-    name: add-access-images
-  roleRef:
-    name: image-access
-  subjects:
-  - kind: ServiceAccount
-    name: asb
-    namespace: ansible-service-broker
+    resources: ["images"]
+    verbs: ["get", "list"]
 
 - apiVersion: v1
   kind: PersistentVolumeClaim


### PR DESCRIPTION
This PR addresses Bug 1507111 to add an adapter for the internal OpenShift registry.

Changes proposed in this pull request
 - New adapter file
 - New clusterrolebindings for asb service account to access imagestream resource
 - More openshift client changes so that we can access the imagestream resource
