### PR TITLE
Bug 1476173 - Cleanup deleting namespaces

### DIFF
--- a/pkg/apb/deprovision.go
+++ b/pkg/apb/deprovision.go
@@ -22,11 +22,8 @@ package apb
 
 import (
 	logging "github.com/op/go-logging"
-	"github.com/openshift/ansible-service-broker/pkg/clients"
 	"github.com/openshift/ansible-service-broker/pkg/metrics"
 	"github.com/pkg/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/kubernetes/pkg/api/v1"
 )
 
 // Deprovision - runs the abp with the deprovision action.
@@ -54,18 +51,6 @@ func Deprovision(
 		return "", errors.New("No image field found on instance.Spec")
 	}
 
-	nsDeleted, err := isNamespaceDeleted(instance.Context.Namespace, log)
-	if err != nil {
-		return "", err
-	}
-
-	// If the namespace is gone or terminating, assume that we don't need to deprovision
-	// because everything is going to be deleted.  We may need to revisit this and perform
-	// the deprovision inside a terminating namespace.
-	if nsDeleted {
-		return "", nil
-	}
-
 	// Might need to change up this interface to feed in instance ids
 	sm := NewServiceAccountManager(log)
 	metrics.ActionStarted("deprovision")
@@ -87,18 +72,4 @@ func Deprovision(
 	}
 
 	return executionContext.PodName, err
-}
-
-func isNamespaceDeleted(name string, log *logging.Logger) (bool, error) {
-	k8scli, err := clients.Kubernetes(log)
-	if err != nil {
-		return false, err
-	}
-
-	namespace, err := k8scli.CoreV1().Namespaces().Get(name, metav1.GetOptions{})
-	if err != nil {
-		return false, err
-	}
-
-	return namespace == nil || namespace.Status.Phase == v1.NamespaceTerminating, nil
 }

--- a/pkg/broker/deprovision_subscriber.go
+++ b/pkg/broker/deprovision_subscriber.go
@@ -74,7 +74,7 @@ func (d *DeprovisionWorkSubscriber) Subscribe(msgBuffer <-chan WorkMsg) {
 			}
 
 			// Job is not reporting error, cleanup after deprovision
-			err = cleanupDeprovision(dmsg.PodName, instance, d.dao, d.log)
+			err = cleanupDeprovision(instance, d.dao, d.log)
 			if err != nil {
 				d.log.Error("Failed cleaning up deprovision after job, error: %s", err.Error())
 				// Cleanup is reporting something has gone wrong. Deprovision overall
@@ -105,7 +105,7 @@ func setFailedDeprovisionJob(dao *dao.Dao, dmsg *DeprovisionMsg) {
 }
 
 func cleanupDeprovision(
-	podName string, instance *apb.ServiceInstance, dao *dao.Dao, log *logging.Logger,
+	instance *apb.ServiceInstance, dao *dao.Dao, log *logging.Logger,
 ) error {
 	var err error
 	id := instance.ID.String()

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -548,7 +548,7 @@ func (h handler) unbind(w http.ResponseWriter, r *http.Request, params map[strin
 		h.log.Debugf("Auto Escalate has been set to true, we are escalating permissions")
 	}
 
-	resp, err := h.broker.Unbind(serviceInstance, bindingUUID, planID)
+	resp, err := h.broker.Unbind(serviceInstance, bindingUUID, planID, nsDeleted)
 
 	if errors.IsNotFound(err) {
 		writeResponse(w, http.StatusGone, resp)

--- a/pkg/handler/handler_test.go
+++ b/pkg/handler/handler_test.go
@@ -93,7 +93,7 @@ func (m MockBroker) Update(uuid.UUID, *broker.UpdateRequest, bool) (*broker.Upda
 	m.called("update", true)
 	return nil, m.Err
 }
-func (m MockBroker) Deprovision(apb.ServiceInstance, string, bool) (*broker.DeprovisionResponse, error) {
+func (m MockBroker) Deprovision(apb.ServiceInstance, string, bool, bool) (*broker.DeprovisionResponse, error) {
 	m.called("deprovision", true)
 	return nil, m.Err
 }

--- a/pkg/handler/handler_test.go
+++ b/pkg/handler/handler_test.go
@@ -101,7 +101,7 @@ func (m MockBroker) Bind(apb.ServiceInstance, uuid.UUID, *broker.BindRequest) (*
 	m.called("bind", true)
 	return nil, m.Err
 }
-func (m MockBroker) Unbind(apb.ServiceInstance, uuid.UUID, string) (*broker.UnbindResponse, error) {
+func (m MockBroker) Unbind(apb.ServiceInstance, uuid.UUID, string, bool) (*broker.UnbindResponse, error) {
 	m.called("unbind", true)
 	return nil, m.Err
 }


### PR DESCRIPTION
Redo deprovision of apbs in terminating namespaces to work when autoescalate is false.  Skip user permission verification if the namespace is being deleted and clean up our etcd without running deprovision.
