### PR TITLE
Setting generated local dev template to autoescalate: false

### DIFF
--- a/scripts/prep_local_devel_env.sh
+++ b/scripts/prep_local_devel_env.sh
@@ -236,6 +236,6 @@ broker:
   ssl_cert_key: ${TLS_KEY}
   ssl_cert: ${TLS_CRT}
   refresh_interval: "600s"
-  auto_escalate: ${AUTO_ESCALATE:-true}
+  auto_escalate: ${AUTO_ESCALATE:-false}
 EOF
 


### PR DESCRIPTION
Make sure we turn off autoescalate by default when doing a `make prep-local-env`.