### PR TITLE
Bug 1501523 - Add spec plan to image during apb push

### DIFF
--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -1310,6 +1310,9 @@ func (a AnsibleBroker) AddSpec(spec apb.Spec) (*CatalogResponse, error) {
 	spec.Image = spec.FQName
 	addNameAndIDForSpec([]*apb.Spec{&spec}, apbPushRegName)
 	a.log.Debugf("Generated name for pushed APB: [%s], ID: [%s]", spec.FQName, spec.ID)
+	for _, p := range spec.Plans {
+		a.dao.SetPlanName(p.ID, p.Name)
+	}
 
 	if err := a.dao.SetSpec(spec.ID, &spec); err != nil {
 		return nil, err


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
Replaces the fix for setting the plan ID for the spec during apb push.

Changes proposed in this pull request
 - Sets plan ID in AddSpec
