### PR TITLE
Bug 1504927 - if apbs fail, mark them as failed.

### DIFF
--- a/pkg/apb/ext_creds.go
+++ b/pkg/apb/ext_creds.go
@@ -76,7 +76,7 @@ func monitorOutput(namespace string, podname string, log *logging.Logger) ([]byt
 			log.Notice("[%s] APB failed", podname)
 			return nil, errors.New("APB failed")
 		} else if podCompleted && err.Error() == failedToExec.Error() {
-			log.Notice("[%s] APB completed", podname)
+			log.Error("[%s] APB completed", podname)
 			return nil, nil
 		} else if err.Error() == failedToExec.Error() {
 			log.Info(string(output))

--- a/pkg/apb/ext_creds.go
+++ b/pkg/apb/ext_creds.go
@@ -39,11 +39,12 @@ func ExtractCredentials(
 ) (*ExtractedCredentials, error) {
 	log.Debug("Calling monitorOutput on " + podname)
 	bindOutput, err := monitorOutput(namespace, podname, log)
-	if bindOutput == nil {
-		return nil, nil
-	}
 	if err != nil {
 		return nil, err
+	}
+
+	if bindOutput == nil {
+		return nil, nil
 	}
 
 	return buildExtractedCredentials(bindOutput)
@@ -61,12 +62,19 @@ func monitorOutput(namespace string, podname string, log *logging.Logger) ([]byt
 		credsNotAvailable := errors.New("exit status 2")
 
 		output, err := runtime.RunCommand("kubectl", "exec", podname, gatherCredentialsCMD, "--namespace="+namespace)
+
+		// cannot exec container, pod is done
+		podFailed := strings.Contains(string(output), "current phase is Failed")
 		podCompleted := strings.Contains(string(output), "current phase is Succeeded") ||
 			strings.Contains(string(output), "cannot exec into a container in a completed pod")
 
 		if err == nil {
 			log.Notice("[%s] Bind credentials found", podname)
 			return output, nil
+		} else if podFailed {
+			// pod has completed but is in failed state
+			log.Notice("[%s] APB failed", podname)
+			return nil, errors.New("APB failed")
 		} else if podCompleted && err.Error() == failedToExec.Error() {
 			log.Notice("[%s] APB completed", podname)
 			return nil, nil


### PR DESCRIPTION
We were ignoring an error when an apb failed during provisioning and
marking the apb as completed. This resulted in failed apbs looking as
though they provisioned fine.

**Which issue this PR fixes (This will close that issue when PR gets merged)**

Fixes #506 - apb provisioning sets ServiceInstance as successful when apb fails
Fixes Bug 1504927 -  ASB Failed provision marked successful even on pod error
Fixes Bug 1470851 - Image Pull Error is being marked as Success
