### PR TITLE
Bug 1508724 - Look for the url in the proper place

### DIFF
--- a/pkg/registries/adapters/rhcc_adapter.go
+++ b/pkg/registries/adapters/rhcc_adapter.go
@@ -55,7 +55,7 @@ type RHCCImageResponse struct {
 
 // RegistryName - retrieve the registry prefix
 func (r RHCCAdapter) RegistryName() string {
-	return r.Config.URL.Host
+	return r.Config.URL.String()
 }
 
 // GetImageNames - retrieve the images from the registry


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
If we look at Host in the url go pkg without http, the Host
will show up empty.  Instead, URL has a String() function that
will give us the url we need. It returns: 'String reassembles
the URL into a valid URL string'.


