### PR TITLE
Bug 1508724 - Fixing RHCC registry name

### DIFF
--- a/pkg/registries/adapters/rhcc_adapter.go
+++ b/pkg/registries/adapters/rhcc_adapter.go
@@ -55,7 +55,10 @@ type RHCCImageResponse struct {
 
 // RegistryName - retrieve the registry prefix
 func (r RHCCAdapter) RegistryName() string {
-	return r.Config.URL.String()
+	if r.Config.URL.Host == "" {
+		return r.Config.URL.Path
+	}
+	return r.Config.URL.Host
 }
 
 // GetImageNames - retrieve the images from the registry


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
`.String()` will add the scheme to the URL. We will need to ignore that, therefore if the Host value is not set, the Path vale will be set. 

example: 
https://play.golang.org/p/5UrBpwtNeA

**Which issue this PR fixes (This will close that issue when PR gets merged)**
fixes bz#1508724