### PR TITLE
Bug 1507111 - Do not force image tag to be IP + Port

### DIFF
--- a/pkg/registries/adapters/local_openshift_adapter.go
+++ b/pkg/registries/adapters/local_openshift_adapter.go
@@ -91,7 +91,7 @@ func (r LocalOpenShiftAdapter) FetchSpecs(imageNames []string) ([]*apb.Spec, err
 			continue
 		}
 		if strings.HasPrefix(image.Name, registryIP) == false {
-			r.Log.Debugf("Image does not have a registry IP as prefix. Assuming it is using hostname.")
+			r.Log.Debugf("Image does not have a registry IP as prefix. This might cause problems but not erroring out.")
 		}
 		if r.Config.Namespaces == nil {
 			r.Log.Debugf("Namespace not set. Assuming `openshift`")

--- a/pkg/registries/adapters/local_openshift_adapter.go
+++ b/pkg/registries/adapters/local_openshift_adapter.go
@@ -90,18 +90,20 @@ func (r LocalOpenShiftAdapter) FetchSpecs(imageNames []string) ([]*apb.Spec, err
 			r.Log.Errorf("Failed to load image spec")
 			continue
 		}
-		if strings.HasPrefix(image.Name, registryIP) {
-			// Image has proper registry IP prefix
-			spec.Image = image.Name
-			namespace := strings.Split(image.Name, "/")[1]
-			for _, ns := range r.Config.Namespaces {
-				if ns == namespace {
-					r.Log.Debugf("Image [%v] is in configured namespace [%v]. Adding to SpecList.", image.Name, ns)
-					specList = append(specList, spec)
-				}
+		if strings.HasPrefix(image.Name, registryIP) == false {
+			r.Log.Debugf("Image does not have a registry IP as prefix. Assuming it is using hostname.")
+		}
+		if r.Config.Namespaces == nil {
+			r.Log.Debugf("Namespace not set. Assuming `openshift`")
+			r.Config.Namespaces = append(r.Config.Namespaces, "openshift")
+		}
+		spec.Image = image.Name
+		namespace := strings.Split(image.Name, "/")[1]
+		for _, ns := range r.Config.Namespaces {
+			if ns == namespace {
+				r.Log.Debugf("Image [%v] is in configured namespace [%v]. Adding to SpecList.", image.Name, ns)
+				specList = append(specList, spec)
 			}
-		} else {
-			r.Log.Debugf("Image does not have proper registry IP prefix. Something went wrong.")
 		}
 	}
 

--- a/pkg/registries/adapters/local_openshift_adapter.go
+++ b/pkg/registries/adapters/local_openshift_adapter.go
@@ -98,7 +98,19 @@ func (r LocalOpenShiftAdapter) FetchSpecs(imageNames []string) ([]*apb.Spec, err
 			r.Config.Namespaces = append(r.Config.Namespaces, "openshift")
 		}
 		spec.Image = image.Name
-		namespace := strings.Split(image.Name, "/")[1]
+		ns_list := strings.Split(image.Name, "/")
+		var namespace string
+		if len(ns_list) == 0 {
+			r.Log.Errorf("Image [%v] is not in the proper format. Erroring.")
+			continue
+		} else if len(ns_list) < 3 {
+			// Image does not have any registry prefix. May be a product of S2I
+			// Expecting openshift/foo-apb
+			namespace = ns_list[0]
+		} else {
+			// Expecting format: 172.30.1.1:5000/openshift/foo-apb
+			namespace = ns_list[1]
+		}
 		for _, ns := range r.Config.Namespaces {
 			if ns == namespace {
 				r.Log.Debugf("Image [%v] is in configured namespace [%v]. Adding to SpecList.", image.Name, ns)

--- a/pkg/registries/adapters/local_openshift_adapter.go
+++ b/pkg/registries/adapters/local_openshift_adapter.go
@@ -101,7 +101,7 @@ func (r LocalOpenShiftAdapter) FetchSpecs(imageNames []string) ([]*apb.Spec, err
 		ns_list := strings.Split(image.Name, "/")
 		var namespace string
 		if len(ns_list) == 0 {
-			r.Log.Errorf("Image [%v] is not in the proper format. Erroring.")
+			r.Log.Errorf("Image [%v] is not in the proper format. Erroring.", image.Name)
 			continue
 		} else if len(ns_list) < 3 {
 			// Image does not have any registry prefix. May be a product of S2I

--- a/pkg/registries/adapters/local_openshift_adapter.go
+++ b/pkg/registries/adapters/local_openshift_adapter.go
@@ -98,18 +98,18 @@ func (r LocalOpenShiftAdapter) FetchSpecs(imageNames []string) ([]*apb.Spec, err
 			r.Config.Namespaces = append(r.Config.Namespaces, "openshift")
 		}
 		spec.Image = image.Name
-		ns_list := strings.Split(image.Name, "/")
+		nsList := strings.Split(image.Name, "/")
 		var namespace string
-		if len(ns_list) == 0 {
+		if len(nsList) == 0 {
 			r.Log.Errorf("Image [%v] is not in the proper format. Erroring.", image.Name)
 			continue
-		} else if len(ns_list) < 3 {
+		} else if len(nsList) < 3 {
 			// Image does not have any registry prefix. May be a product of S2I
 			// Expecting openshift/foo-apb
-			namespace = ns_list[0]
+			namespace = nsList[0]
 		} else {
 			// Expecting format: 172.30.1.1:5000/openshift/foo-apb
-			namespace = ns_list[1]
+			namespace = nsList[1]
 		}
 		for _, ns := range r.Config.Namespaces {
 			if ns == namespace {


### PR DESCRIPTION
This PR changes default behavior of local registry adapter to not error out if APB name does not start with IP+port. This was erroring out when a user's image was being tagged with the svc name instead.

Changes proposed in this pull request
 - Change error to debug statement and continue
 - Set default namespace to `openshift` if not set

