### PR TITLE
Expose the pod name/namespace to APB

### DIFF
--- a/pkg/apb/executor.go
+++ b/pkg/apb/executor.go
@@ -128,6 +128,24 @@ func ExecuteApb(
 						"--extra-vars",
 						extraVars,
 					},
+					Env: []v1.EnvVar{
+						v1.EnvVar{
+							Name: "POD_NAME",
+							ValueFrom: &v1.EnvVarSource{
+								FieldRef: &v1.ObjectFieldSelector{
+									FieldPath: "metadata.name",
+								},
+							},
+						},
+						v1.EnvVar{
+							Name: "POD_NAMESPACE",
+							ValueFrom: &v1.EnvVarSource{
+								FieldRef: &v1.ObjectFieldSelector{
+									FieldPath: "metadata.namespace",
+								},
+							},
+						},
+					},
 					ImagePullPolicy: pullPolicy,
 					VolumeMounts:    volumeMounts,
 				},


### PR DESCRIPTION
Use kubernetes downward API to expose the pod name and namespace to the
APB. This will give us more flexibility w.r.t. managing APB execution,
secrets, and annotations.