### PR TITLE
Integrate with coveralls for code coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,16 @@ ansible/main.retry
 # rendered templates
 templates/k8s-ansible-service-broker.yaml
 apiserver.local.config*
+
+# test artifacts
+adapters.out
+apb.out
+app.out
+auth.out
+broker.out
+coverage-all.out
+coverage.out
+handler.out
+registries.out
+validation.out
+coverage.html

--- a/.gitignore
+++ b/.gitignore
@@ -56,4 +56,3 @@ coverage.out
 handler.out
 registries.out
 validation.out
-coverage.html

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ test-coverage-html: ## checkout the coverage locally of your tests
 	@$(foreach pkg,$(PACKAGES),\
 		go test -coverprofile=coverage.out -covermode=count $(pkg);\
 		tail -n +2 coverage.out >> coverage-all.out;)
-	@go tool cover -html=coverage-all.out # -o coverage.html
+	@go tool cover -html=coverage-all.out
 
 ci-test-coverage: ## CI test coverage, upload to coveralls
 	@echo "mode: count" > coverage-all.out
@@ -85,7 +85,7 @@ push:
 clean: ## Clean up your working environment
 	@rm -f broker
 	@rm -f build/broker
-	@rm -f adapters.out apb.out app.out auth.out broker.out coverage-all.out coverage.out handler.out registries.out validation.out coverage.html
+	@rm -f adapters.out apb.out app.out auth.out broker.out coverage-all.out coverage.out handler.out registries.out validation.out
 
 really-clean: clean cleanup-ci ## Really clean up the working environment
 	@rm -f $(KUBERNETES_FILES)

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,7 @@ push:
 clean: ## Clean up your working environment
 	@rm -f broker
 	@rm -f build/broker
+	@rm -f adapters.out apb.out app.out auth.out broker.out coverage-all.out coverage.out handler.out registries.out validation.out coverage.html
 
 really-clean: clean cleanup-ci ## Really clean up the working environment
 	@rm -f $(KUBERNETES_FILES)

--- a/Makefile
+++ b/Makefile
@@ -35,18 +35,16 @@ fmtcheck: ## Check go formatting
 test: ## Run unit tests
 	@go test -cover ./pkg/...
 
-test-coverage-html: ## checkout the coverage locally of your tests
+coverage-all.out: $(SOURCES)
 	@echo "mode: count" > coverage-all.out
 	@$(foreach pkg,$(PACKAGES),\
 		go test -coverprofile=coverage.out -covermode=count $(pkg);\
 		tail -n +2 coverage.out >> coverage-all.out;)
+
+test-coverage-html: coverage-all.out ## checkout the coverage locally of your tests
 	@go tool cover -html=coverage-all.out
 
-ci-test-coverage: ## CI test coverage, upload to coveralls
-	@echo "mode: count" > coverage-all.out
-	@$(foreach pkg,$(PACKAGES),\
-		go test -coverprofile=coverage.out -covermode=count $(pkg);\
-		tail -n +2 coverage.out >> coverage-all.out;)
+ci-test-coverage: coverage-all.out ## CI test coverage, upload to coveralls
 	@goveralls -coverprofile=coverage-all.out -service $(COVERAGE_SVC)
 
 vet: ## Run go vet

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ Ansible Service Broker
 
 [![Build Status](https://travis-ci.org/openshift/ansible-service-broker.svg?branch=master)](https://travis-ci.org/openshift/ansible-service-broker)
 [![Go_Report_Card](https://goreportcard.com/badge/github.com/openshift/ansible-service-broker)](https://goreportcard.com/report/github.com/openshift/ansible-service-broker)
+[![Coverage Status](https://coveralls.io/repos/github/openshift/ansible-service-broker/badge.svg?branch=coveralls)](https://coveralls.io/github/openshift/ansible-service-broker?branch=coveralls)
 [![Join the chat at freenode:asbroker](https://img.shields.io/badge/irc-freenode%3A%20%23asbroker-blue.svg)](http://webchat.freenode.net/?channels=%23asbroker)
 [![Licensed under Apache License version 2.0](https://img.shields.io/github/license/openshift/origin.svg?maxAge=2592000)](https://www.apache.org/licenses/LICENSE-2.0)
 

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -91,7 +91,7 @@ elif [[ "$action" == "test" ]]; then
   echo "================================="
   echo "              Test               "
   echo "================================="
-  make test
+  make ci-test-coverage
 elif [[ "$action" == "ci" ]]; then
   echo "================================="
   echo "            Broker CI            "

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -51,6 +51,10 @@ elif [[ "$action" == "install" ]]; then
 
   # install golint
   go get -u github.com/golang/lint/golint
+
+  # install goveralls for coveralls integration
+  go get github.com/mattn/goveralls
+
 elif [[ "$action" == "before_script" ]]; then
   echo "================================="
   echo "          Before Script          "


### PR DESCRIPTION
**Describe what this PR does and why we need it**:

Changes proposed in this pull request
 - integrating travis-ci with goveralls (coveralls for golang)
 - generate coverage reports of our code to better understand our testing
 - also added a target for developers to see the coverage locally: `make ci-test-coverage`

**Does this PR depend on another PR (Use this to track when PRs should be merged)**
none

**Which issue this PR fixes (This will close that issue when PR gets merged)**
none
