### PR TITLE
remove unneeded paragraph from license header

### DIFF
--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Red Hat trademarks are not licensed under Apache License, Version 2.
-// No permission is granted to use or replicate Red Hat trademarks that
-// are incorporated in this software or its documentation.
-//
 
 package main
 

--- a/pkg/apb/bind.go
+++ b/pkg/apb/bind.go
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Red Hat trademarks are not licensed under Apache License, Version 2.
-// No permission is granted to use or replicate Red Hat trademarks that
-// are incorporated in this software or its documentation.
-//
 
 package apb
 

--- a/pkg/apb/bind_test.go
+++ b/pkg/apb/bind_test.go
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Red Hat trademarks are not licensed under Apache License, Version 2.
-// No permission is granted to use or replicate Red Hat trademarks that
-// are incorporated in this software or its documentation.
-//
 
 package apb
 

--- a/pkg/apb/deprovision.go
+++ b/pkg/apb/deprovision.go
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Red Hat trademarks are not licensed under Apache License, Version 2.
-// No permission is granted to use or replicate Red Hat trademarks that
-// are incorporated in this software or its documentation.
-//
 
 package apb
 

--- a/pkg/apb/executor.go
+++ b/pkg/apb/executor.go
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Red Hat trademarks are not licensed under Apache License, Version 2.
-// No permission is granted to use or replicate Red Hat trademarks that
-// are incorporated in this software or its documentation.
-//
 
 package apb
 

--- a/pkg/apb/executor_test.go
+++ b/pkg/apb/executor_test.go
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Red Hat trademarks are not licensed under Apache License, Version 2.
-// No permission is granted to use or replicate Red Hat trademarks that
-// are incorporated in this software or its documentation.
-//
 
 package apb
 

--- a/pkg/apb/ext_creds.go
+++ b/pkg/apb/ext_creds.go
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Red Hat trademarks are not licensed under Apache License, Version 2.
-// No permission is granted to use or replicate Red Hat trademarks that
-// are incorporated in this software or its documentation.
-//
 
 package apb
 

--- a/pkg/apb/ext_creds_test.go
+++ b/pkg/apb/ext_creds_test.go
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Red Hat trademarks are not licensed under Apache License, Version 2.
-// No permission is granted to use or replicate Red Hat trademarks that
-// are incorporated in this software or its documentation.
-//
 
 package apb
 

--- a/pkg/apb/provision.go
+++ b/pkg/apb/provision.go
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Red Hat trademarks are not licensed under Apache License, Version 2.
-// No permission is granted to use or replicate Red Hat trademarks that
-// are incorporated in this software or its documentation.
-//
 
 package apb
 

--- a/pkg/apb/provision_or_update.go
+++ b/pkg/apb/provision_or_update.go
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Red Hat trademarks are not licensed under Apache License, Version 2.
-// No permission is granted to use or replicate Red Hat trademarks that
-// are incorporated in this software or its documentation.
-//
 
 package apb
 

--- a/pkg/apb/secrets.go
+++ b/pkg/apb/secrets.go
@@ -1,3 +1,19 @@
+//
+// Copyright (c) 2017 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
 package apb
 
 import (

--- a/pkg/apb/svc_acct.go
+++ b/pkg/apb/svc_acct.go
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Red Hat trademarks are not licensed under Apache License, Version 2.
-// No permission is granted to use or replicate Red Hat trademarks that
-// are incorporated in this software or its documentation.
-//
 
 package apb
 

--- a/pkg/apb/types.go
+++ b/pkg/apb/types.go
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Red Hat trademarks are not licensed under Apache License, Version 2.
-// No permission is granted to use or replicate Red Hat trademarks that
-// are incorporated in this software or its documentation.
-//
 
 package apb
 

--- a/pkg/apb/types_test.go
+++ b/pkg/apb/types_test.go
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Red Hat trademarks are not licensed under Apache License, Version 2.
-// No permission is granted to use or replicate Red Hat trademarks that
-// are incorporated in this software or its documentation.
-//
 
 package apb
 

--- a/pkg/apb/unbind.go
+++ b/pkg/apb/unbind.go
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Red Hat trademarks are not licensed under Apache License, Version 2.
-// No permission is granted to use or replicate Red Hat trademarks that
-// are incorporated in this software or its documentation.
-//
 
 package apb
 

--- a/pkg/apb/update.go
+++ b/pkg/apb/update.go
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Red Hat trademarks are not licensed under Apache License, Version 2.
-// No permission is granted to use or replicate Red Hat trademarks that
-// are incorporated in this software or its documentation.
-//
 
 package apb
 

--- a/pkg/apb/watch_pod.go
+++ b/pkg/apb/watch_pod.go
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Red Hat trademarks are not licensed under Apache License, Version 2.
-// No permission is granted to use or replicate Red Hat trademarks that
-// are incorporated in this software or its documentation.
-//
 
 package apb
 

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Red Hat trademarks are not licensed under Apache License, Version 2.
-// No permission is granted to use or replicate Red Hat trademarks that
-// are incorporated in this software or its documentation.
-//
 
 package app
 

--- a/pkg/app/args.go
+++ b/pkg/app/args.go
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Red Hat trademarks are not licensed under Apache License, Version 2.
-// No permission is granted to use or replicate Red Hat trademarks that
-// are incorporated in this software or its documentation.
-//
 
 package app
 

--- a/pkg/app/config.go
+++ b/pkg/app/config.go
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Red Hat trademarks are not licensed under Apache License, Version 2.
-// No permission is granted to use or replicate Red Hat trademarks that
-// are incorporated in this software or its documentation.
-//
 
 package app
 

--- a/pkg/app/config_test.go
+++ b/pkg/app/config_test.go
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Red Hat trademarks are not licensed under Apache License, Version 2.
-// No permission is granted to use or replicate Red Hat trademarks that
-// are incorporated in this software or its documentation.
-//
 
 package app
 

--- a/pkg/app/logger.go
+++ b/pkg/app/logger.go
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Red Hat trademarks are not licensed under Apache License, Version 2.
-// No permission is granted to use or replicate Red Hat trademarks that
-// are incorporated in this software or its documentation.
-//
 
 package app
 

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Red Hat trademarks are not licensed under Apache License, Version 2.
-// No permission is granted to use or replicate Red Hat trademarks that
-// are incorporated in this software or its documentation.
-//
 
 package auth
 

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Red Hat trademarks are not licensed under Apache License, Version 2.
-// No permission is granted to use or replicate Red Hat trademarks that
-// are incorporated in this software or its documentation.
-//
 
 package auth
 

--- a/pkg/auth/basic_auth.go
+++ b/pkg/auth/basic_auth.go
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Red Hat trademarks are not licensed under Apache License, Version 2.
-// No permission is granted to use or replicate Red Hat trademarks that
-// are incorporated in this software or its documentation.
-//
 
 package auth
 

--- a/pkg/auth/basic_auth_test.go
+++ b/pkg/auth/basic_auth_test.go
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Red Hat trademarks are not licensed under Apache License, Version 2.
-// No permission is granted to use or replicate Red Hat trademarks that
-// are incorporated in this software or its documentation.
-//
 
 package auth
 

--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Red Hat trademarks are not licensed under Apache License, Version 2.
-// No permission is granted to use or replicate Red Hat trademarks that
-// are incorporated in this software or its documentation.
-//
 
 package broker
 

--- a/pkg/broker/broker_test.go
+++ b/pkg/broker/broker_test.go
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Red Hat trademarks are not licensed under Apache License, Version 2.
-// No permission is granted to use or replicate Red Hat trademarks that
-// are incorporated in this software or its documentation.
-//
 
 package broker
 

--- a/pkg/broker/deprovision_job.go
+++ b/pkg/broker/deprovision_job.go
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Red Hat trademarks are not licensed under Apache License, Version 2.
-// No permission is granted to use or replicate Red Hat trademarks that
-// are incorporated in this software or its documentation.
-//
 
 package broker
 

--- a/pkg/broker/deprovision_subscriber.go
+++ b/pkg/broker/deprovision_subscriber.go
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Red Hat trademarks are not licensed under Apache License, Version 2.
-// No permission is granted to use or replicate Red Hat trademarks that
-// are incorporated in this software or its documentation.
-//
 
 package broker
 

--- a/pkg/broker/notimplemented.go
+++ b/pkg/broker/notimplemented.go
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Red Hat trademarks are not licensed under Apache License, Version 2.
-// No permission is granted to use or replicate Red Hat trademarks that
-// are incorporated in this software or its documentation.
-//
 
 package broker
 

--- a/pkg/broker/provision_job.go
+++ b/pkg/broker/provision_job.go
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Red Hat trademarks are not licensed under Apache License, Version 2.
-// No permission is granted to use or replicate Red Hat trademarks that
-// are incorporated in this software or its documentation.
-//
 
 package broker
 

--- a/pkg/broker/provision_subscriber.go
+++ b/pkg/broker/provision_subscriber.go
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Red Hat trademarks are not licensed under Apache License, Version 2.
-// No permission is granted to use or replicate Red Hat trademarks that
-// are incorporated in this software or its documentation.
-//
 
 package broker
 

--- a/pkg/broker/types.go
+++ b/pkg/broker/types.go
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Red Hat trademarks are not licensed under Apache License, Version 2.
-// No permission is granted to use or replicate Red Hat trademarks that
-// are incorporated in this software or its documentation.
-//
 
 package broker
 

--- a/pkg/broker/update_job.go
+++ b/pkg/broker/update_job.go
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Red Hat trademarks are not licensed under Apache License, Version 2.
-// No permission is granted to use or replicate Red Hat trademarks that
-// are incorporated in this software or its documentation.
-//
 
 package broker
 

--- a/pkg/broker/update_subscriber.go
+++ b/pkg/broker/update_subscriber.go
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Red Hat trademarks are not licensed under Apache License, Version 2.
-// No permission is granted to use or replicate Red Hat trademarks that
-// are incorporated in this software or its documentation.
-//
 
 package broker
 

--- a/pkg/broker/util.go
+++ b/pkg/broker/util.go
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Red Hat trademarks are not licensed under Apache License, Version 2.
-// No permission is granted to use or replicate Red Hat trademarks that
-// are incorporated in this software or its documentation.
-//
 
 package broker
 

--- a/pkg/broker/util_test.go
+++ b/pkg/broker/util_test.go
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Red Hat trademarks are not licensed under Apache License, Version 2.
-// No permission is granted to use or replicate Red Hat trademarks that
-// are incorporated in this software or its documentation.
-//
 
 package broker
 

--- a/pkg/broker/work_engine.go
+++ b/pkg/broker/work_engine.go
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Red Hat trademarks are not licensed under Apache License, Version 2.
-// No permission is granted to use or replicate Red Hat trademarks that
-// are incorporated in this software or its documentation.
-//
 
 package broker
 

--- a/pkg/broker/work_engine_test.go
+++ b/pkg/broker/work_engine_test.go
@@ -1,3 +1,19 @@
+//
+// Copyright (c) 2017 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
 package broker
 
 import (

--- a/pkg/broker/work_subscriber.go
+++ b/pkg/broker/work_subscriber.go
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Red Hat trademarks are not licensed under Apache License, Version 2.
-// No permission is granted to use or replicate Red Hat trademarks that
-// are incorporated in this software or its documentation.
-//
 
 package broker
 

--- a/pkg/clients/clients.go
+++ b/pkg/clients/clients.go
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Red Hat trademarks are not licensed under Apache License, Version 2.
-// No permission is granted to use or replicate Red Hat trademarks that
-// are incorporated in this software or its documentation.
-//
 
 package clients
 

--- a/pkg/clients/etcd.go
+++ b/pkg/clients/etcd.go
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Red Hat trademarks are not licensed under Apache License, Version 2.
-// No permission is granted to use or replicate Red Hat trademarks that
-// are incorporated in this software or its documentation.
-//
 
 package clients
 

--- a/pkg/clients/kubernetes.go
+++ b/pkg/clients/kubernetes.go
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Red Hat trademarks are not licensed under Apache License, Version 2.
-// No permission is granted to use or replicate Red Hat trademarks that
-// are incorporated in this software or its documentation.
-//
 
 package clients
 

--- a/pkg/clients/openshift.go
+++ b/pkg/clients/openshift.go
@@ -1,3 +1,19 @@
+//
+// Copyright (c) 2017 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
 package clients
 
 import (

--- a/pkg/dao/dao.go
+++ b/pkg/dao/dao.go
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Red Hat trademarks are not licensed under Apache License, Version 2.
-// No permission is granted to use or replicate Red Hat trademarks that
-// are incorporated in this software or its documentation.
-//
 
 package dao
 

--- a/pkg/dao/filters.go
+++ b/pkg/dao/filters.go
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Red Hat trademarks are not licensed under Apache License, Version 2.
-// No permission is granted to use or replicate Red Hat trademarks that
-// are incorporated in this software or its documentation.
-//
 
 package dao
 

--- a/pkg/fusortest/util.go
+++ b/pkg/fusortest/util.go
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Red Hat trademarks are not licensed under Apache License, Version 2.
-// No permission is granted to use or replicate Red Hat trademarks that
-// are incorporated in this software or its documentation.
-//
 
 package fusortest
 

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Red Hat trademarks are not licensed under Apache License, Version 2.
-// No permission is granted to use or replicate Red Hat trademarks that
-// are incorporated in this software or its documentation.
-//
 
 package handler
 

--- a/pkg/handler/handler_test.go
+++ b/pkg/handler/handler_test.go
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Red Hat trademarks are not licensed under Apache License, Version 2.
-// No permission is granted to use or replicate Red Hat trademarks that
-// are incorporated in this software or its documentation.
-//
 
 package handler
 

--- a/pkg/handler/io.go
+++ b/pkg/handler/io.go
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Red Hat trademarks are not licensed under Apache License, Version 2.
-// No permission is granted to use or replicate Red Hat trademarks that
-// are incorporated in this software or its documentation.
-//
 
 package handler
 

--- a/pkg/handler/io_test.go
+++ b/pkg/handler/io_test.go
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Red Hat trademarks are not licensed under Apache License, Version 2.
-// No permission is granted to use or replicate Red Hat trademarks that
-// are incorporated in this software or its documentation.
-//
 
 package handler
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,3 +1,19 @@
+//
+// Copyright (c) 2017 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
 package metrics
 
 import (

--- a/pkg/registries/adapters/adapter.go
+++ b/pkg/registries/adapters/adapter.go
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Red Hat trademarks are not licensed under Apache License, Version 2.
-// No permission is granted to use or replicate Red Hat trademarks that
-// are incorporated in this software or its documentation.
-//
 
 package adapters
 

--- a/pkg/registries/adapters/adapter_test.go
+++ b/pkg/registries/adapters/adapter_test.go
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Red Hat trademarks are not licensed under Apache License, Version 2.
-// No permission is granted to use or replicate Red Hat trademarks that
-// are incorporated in this software or its documentation.
-//
 
 package adapters
 

--- a/pkg/registries/adapters/dockerhub_adapter.go
+++ b/pkg/registries/adapters/dockerhub_adapter.go
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Red Hat trademarks are not licensed under Apache License, Version 2.
-// No permission is granted to use or replicate Red Hat trademarks that
-// are incorporated in this software or its documentation.
-//
 
 package adapters
 

--- a/pkg/registries/adapters/dockerhub_adapter_test.go
+++ b/pkg/registries/adapters/dockerhub_adapter_test.go
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Red Hat trademarks are not licensed under Apache License, Version 2.
-// No permission is granted to use or replicate Red Hat trademarks that
-// are incorporated in this software or its documentation.
-//
 
 package adapters
 

--- a/pkg/registries/adapters/local_openshift_adapter.go
+++ b/pkg/registries/adapters/local_openshift_adapter.go
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Red Hat trademarks are not licensed under Apache License, Version 2.
-// No permission is granted to use or replicate Red Hat trademarks that
-// are incorporated in this software or its documentation.
-//
 
 package adapters
 

--- a/pkg/registries/adapters/local_openshift_adapter_test.go
+++ b/pkg/registries/adapters/local_openshift_adapter_test.go
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Red Hat trademarks are not licensed under Apache License, Version 2.
-// No permission is granted to use or replicate Red Hat trademarks that
-// are incorporated in this software or its documentation.
-//
 
 package adapters
 

--- a/pkg/registries/adapters/mock_adapter.go
+++ b/pkg/registries/adapters/mock_adapter.go
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Red Hat trademarks are not licensed under Apache License, Version 2.
-// No permission is granted to use or replicate Red Hat trademarks that
-// are incorporated in this software or its documentation.
-//
 
 package adapters
 

--- a/pkg/registries/adapters/openshift_adapter.go
+++ b/pkg/registries/adapters/openshift_adapter.go
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Red Hat trademarks are not licensed under Apache License, Version 2.
-// No permission is granted to use or replicate Red Hat trademarks that
-// are incorporated in this software or its documentation.
-//
 
 package adapters
 

--- a/pkg/registries/adapters/rhcc_adapter.go
+++ b/pkg/registries/adapters/rhcc_adapter.go
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Red Hat trademarks are not licensed under Apache License, Version 2.
-// No permission is granted to use or replicate Red Hat trademarks that
-// are incorporated in this software or its documentation.
-//
 
 package adapters
 

--- a/pkg/registries/adapters/rhcc_adapter_test.go
+++ b/pkg/registries/adapters/rhcc_adapter_test.go
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Red Hat trademarks are not licensed under Apache License, Version 2.
-// No permission is granted to use or replicate Red Hat trademarks that
-// are incorporated in this software or its documentation.
-//
 
 package adapters
 

--- a/pkg/registries/filter.go
+++ b/pkg/registries/filter.go
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Red Hat trademarks are not licensed under Apache License, Version 2.
-// No permission is granted to use or replicate Red Hat trademarks that
-// are incorporated in this software or its documentation.
-//
 
 package registries
 

--- a/pkg/registries/filter_test.go
+++ b/pkg/registries/filter_test.go
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Red Hat trademarks are not licensed under Apache License, Version 2.
-// No permission is granted to use or replicate Red Hat trademarks that
-// are incorporated in this software or its documentation.
-//
 
 package registries
 

--- a/pkg/registries/registry.go
+++ b/pkg/registries/registry.go
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Red Hat trademarks are not licensed under Apache License, Version 2.
-// No permission is granted to use or replicate Red Hat trademarks that
-// are incorporated in this software or its documentation.
-//
 
 package registries
 

--- a/pkg/registries/registry_test.go
+++ b/pkg/registries/registry_test.go
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Red Hat trademarks are not licensed under Apache License, Version 2.
-// No permission is granted to use or replicate Red Hat trademarks that
-// are incorporated in this software or its documentation.
-//
 
 package registries
 

--- a/pkg/runtime/hack.go
+++ b/pkg/runtime/hack.go
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Red Hat trademarks are not licensed under Apache License, Version 2.
-// No permission is granted to use or replicate Red Hat trademarks that
-// are incorporated in this software or its documentation.
-//
 
 package runtime
 

--- a/pkg/version/apbversion.go
+++ b/pkg/version/apbversion.go
@@ -1,3 +1,19 @@
+//
+// Copyright (c) 2017 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
 package version
 
 // These constants describe the minimum and maximum

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,3 +1,19 @@
+//
+// Copyright (c) 2017 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
 package version
 
 // Version contains the broker version.

--- a/templates/version.go.tmpl
+++ b/templates/version.go.tmpl
@@ -1,3 +1,19 @@
+//
+// Copyright (c) 2017 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
 package version
 
 // Version contains the broker version.


### PR DESCRIPTION
We were asked to remove the unneeded paragraph regarding trademarks as it was older language that is no longer used. I copied the original header from some old code :) 