### PR TITLE
Use the Kubernetes API for namespaces check

### DIFF
--- a/pkg/apb/provision_or_update.go
+++ b/pkg/apb/provision_or_update.go
@@ -18,10 +18,8 @@ package apb
 
 import (
 	"errors"
-	"fmt"
 	logging "github.com/op/go-logging"
 	"github.com/openshift/ansible-service-broker/pkg/metrics"
-	"github.com/openshift/ansible-service-broker/pkg/runtime"
 )
 
 type executionMethod string
@@ -47,13 +45,6 @@ func provisionOrUpdate(
 		log.Error("apb instance.Spec requires [name] and [image] fields to be separate")
 		log.Error("Are you trying to run a legacy ansibleapp without an image field?")
 		return "", nil, errors.New("No image field found on instance.Spec")
-	}
-
-	ns := instance.Context.Namespace
-	log.Info("Checking if project %s exists...", ns)
-	if !projectExists(ns) {
-		log.Errorf("Project %s does NOT exist! Cannot provision requested %s", ns, instance.Spec.FQName)
-		return "", nil, fmt.Errorf("Project %s does not exist", ns)
 	}
 
 	metrics.ActionStarted(string(method))
@@ -86,9 +77,4 @@ func provisionOrUpdate(
 	}
 
 	return executionContext.PodName, creds, err
-}
-
-func projectExists(project string) bool {
-	_, _, code := runtime.RunCommandWithExitCode("kubectl", "get", "project", project)
-	return code == 0
 }

--- a/pkg/apb/provision_or_update.go
+++ b/pkg/apb/provision_or_update.go
@@ -62,7 +62,7 @@ func provisionOrUpdate(
 	log.Info("Checking if namespace %s exists.", ns)
 	_, err = k8scli.CoreV1().Namespaces().Get(ns, metav1.GetOptions{})
 	if err != nil {
-		return "", nil, errors.New(fmt.Sprintf("Project %s does NOT exist!", ns))
+		return "", nil, fmt.Errorf("Project %s does not exist", ns)
 	}
 
 	metrics.ActionStarted(string(method))

--- a/pkg/apb/svc_acct.go
+++ b/pkg/apb/svc_acct.go
@@ -229,7 +229,7 @@ func (s *ServiceAccountManager) DestroyApbSandbox(executionContext ExecutionCont
 	}
 	k8scli, err := clients.Kubernetes(s.log)
 	if err != nil {
-		s.log.Error("Soemthing went wrong getting kubernetes client")
+		s.log.Error("Something went wrong getting kubernetes client")
 		s.log.Errorf("%s", err.Error())
 		return
 	}


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
Verify that a namespace exists using the kubernetes API.

Changes proposed in this pull request
 - Fixes issue in k8s where projects don't exist

