### PR TITLE
Broker should extract credentials from secret

### DIFF
--- a/docs/proposals/prop-apb-gen-creds.md
+++ b/docs/proposals/prop-apb-gen-creds.md
@@ -23,20 +23,29 @@ successfully.
 
 ## Implementation Details
 
-- [ ] Update the [`asb_encode_binding`
-module](https://github.com/ansibleplaybookbundle/ansible-asb-modules/blob/master/library/asb_encode_binding.py)
-to create a kubernetes secret in the APB sandbox namespace.
-- [ ] Update
+- [x] Update the [`asb_encode_binding` module](https://github.com/ansibleplaybookbundle/ansible-asb-modules/blob/master/library/asb_encode_binding.py)
+  to create a kubernetes secret in the APB sandbox namespace.
+  [ansible-asb-modules#8](https://github.com/ansibleplaybookbundle/ansible-asb-modules/pull/8)
+- [x] Update
   [`apb-base`](https://github.com/ansibleplaybookbundle/apb-base/tree/master/files/usr/bin):
   we no longer need to run `bind-init` or `broker-bind-creds`.
-- [ ] Bump the APB version to `1.1`. This will prevent older broker's from grabbing
-  new APBs that it won't be able to handle and allow us to centrally locate our
-  backwards compatibility in the broker.
-- [ ] Update
+  [apb-base#7](https://github.com/ansibleplaybookbundle/apb-base/pull/7)
+- [x] Add `LABEL "com.redhat.apb.runtime"="2"` to apb-base since this is a
+  runtime change.
+  ~~Bump the APB version to `2.0`. This will prevent older broker's from grabbing~~
+  ~~new APBs that it won't be able to handle and allow us to centrally locate our~~
+  ~~backwards compatibility in the broker.~~
+  ~~[ansible-playbook-bundle#163](https://github.com/ansibleplaybookbundle/ansible-playbook-bundle/pull/163)~~
+- [x] Update broker to evaluate APB runtime versions, support min/max runtime
+  versions, and assume runtime version is `1` if label doesn't exist.
+- [x] Update
   [`pkg/apb/ext_creds.go
-  ExtractCredentials`](https://github.com/openshift/ansible-service-broker/blob/8dda3277/pkg/apb/ext_creds.go#L33):
-  If APB version is `1.0`, do it the way we are currently doing it.
-  If APB version is `1.1`, 1) watch pod and wait for it to complete 2) evaluate
-  success/failure of APB execution 3) read credentials from secret.
-- [ ] Bump [`MaxAPBVersion`](https://github.com/openshift/ansible-service-broker/blob/8dda3277/pkg/version/apbversion.go#L27)
-  to `1.1`
+  ExtractCredentials`](https://github.com/openshift/ansible-service-broker/blob/8dda3277/pkg/apb/ext_creds.go#L33)
+  **if runtime version `== 1`**: Do it the old way
+  **if runtime version `>= 2`**:
+  1) watch pod and wait for it to complete
+  2) evaluate success/failure of APB execution
+  3) read credentials from secret.
+- [x] ~~Bump [`MinAPBVersion`] and~~
+  ~~[`MaxAPBVersion`](https://github.com/openshift/ansible-service-broker/blob/8dda3277/pkg/version/apbversion.go#L27)~~
+  ~~to `2.0`~~

--- a/pkg/apb/bind.go
+++ b/pkg/apb/bind.go
@@ -40,12 +40,16 @@ func Bind(
 	log.Notice("============================================================")
 
 	executionContext, err := ExecuteApb(
-		"bind", clusterConfig, instance.Spec,
-		instance.Context, parameters, log,
+		"bind",
+		clusterConfig,
+		instance.Spec,
+		instance.Context,
+		parameters,
+		log,
 	)
 	defer runtime.Provider.DestroySandbox(executionContext.PodName, executionContext.Namespace, executionContext.Targets, clusterConfig.Namespace, clusterConfig.KeepNamespace, clusterConfig.KeepNamespaceOnError)
 	if err != nil {
-		log.Errorf("Problem executing apb [%s] bind:", executionContext.PodName)
+		log.Errorf("Problem executing apb [%s] bind", executionContext.PodName)
 		return executionContext.PodName, nil, err
 	}
 

--- a/pkg/apb/bind_test.go
+++ b/pkg/apb/bind_test.go
@@ -17,6 +17,7 @@
 package apb
 
 import (
+	"encoding/json"
 	"testing"
 
 	ft "github.com/openshift/ansible-service-broker/pkg/fusortest"
@@ -43,10 +44,13 @@ ok: [localhost] => {
 PLAY RECAP *********************************************************************
 localhost                  : ok=3    changed=1    unreachable=0    failed=0
 `)
-	result, err := decodeOutput(output)
+	decoded, err := decodeOutput(output)
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	result := make(map[string]interface{})
+	json.Unmarshal(decoded, &result)
 
 	ft.AssertNotNil(t, result, "result")
 	ft.AssertEqual(t, result["db"], "fusor_guestbook_db", "db is not fusor_guestbook_db")

--- a/pkg/apb/deprovision.go
+++ b/pkg/apb/deprovision.go
@@ -25,7 +25,9 @@ import (
 
 // Deprovision - runs the abp with the deprovision action.
 func Deprovision(
-	instance *ServiceInstance, clusterConfig ClusterConfig, log *logging.Logger,
+	instance *ServiceInstance,
+	clusterConfig ClusterConfig,
+	log *logging.Logger,
 ) (string, error) {
 	log.Notice("============================================================")
 	log.Notice("                      DEPROVISIONING                        ")
@@ -58,9 +60,22 @@ func Deprovision(
 		instance.Parameters,
 		log,
 	)
-	defer runtime.Provider.DestroySandbox(executionContext.PodName, executionContext.Namespace, executionContext.Targets, clusterConfig.Namespace, clusterConfig.KeepNamespace, clusterConfig.KeepNamespaceOnError)
+	defer runtime.Provider.DestroySandbox(
+		executionContext.PodName,
+		executionContext.Namespace,
+		executionContext.Targets,
+		clusterConfig.Namespace,
+		clusterConfig.KeepNamespace,
+		clusterConfig.KeepNamespaceOnError,
+	)
 	if err != nil {
 		log.Errorf("Problem executing apb [%s] deprovision", executionContext.PodName)
+		return executionContext.PodName, err
+	}
+
+	err = watchPod(executionContext.PodName, executionContext.Namespace, log)
+	if err != nil {
+		log.Errorf("APB Execution failed - %v", err)
 		return executionContext.PodName, err
 	}
 

--- a/pkg/apb/deprovision.go
+++ b/pkg/apb/deprovision.go
@@ -51,19 +51,16 @@ func Deprovision(
 	// Might need to change up this interface to feed in instance ids
 	metrics.ActionStarted("deprovision")
 	executionContext, err := ExecuteApb(
-		"deprovision", clusterConfig, instance.Spec,
-		instance.Context, instance.Parameters, log,
+		"deprovision",
+		clusterConfig,
+		instance.Spec,
+		instance.Context,
+		instance.Parameters,
+		log,
 	)
 	defer runtime.Provider.DestroySandbox(executionContext.PodName, executionContext.Namespace, executionContext.Targets, clusterConfig.Namespace, clusterConfig.KeepNamespace, clusterConfig.KeepNamespaceOnError)
 	if err != nil {
-		log.Errorf("Problem executing apb [%s] deprovision:", executionContext.PodName)
-		return executionContext.PodName, err
-	}
-
-	podOutput, err := watchPod(executionContext.PodName, executionContext.Namespace, log)
-	if err != nil {
-		log.Errorf("Error returned from watching pod\nerror: %s", err.Error())
-		log.Errorf("output: %s", podOutput)
+		log.Errorf("Problem executing apb [%s] deprovision", executionContext.PodName)
 		return executionContext.PodName, err
 	}
 

--- a/pkg/apb/executor.go
+++ b/pkg/apb/executor.go
@@ -116,7 +116,7 @@ func ExecuteApb(
 		Spec: v1.PodSpec{
 			Containers: []v1.Container{
 				{
-					Name:  "apb",
+					Name:  ApbContainerName,
 					Image: spec.Image,
 					Args: []string{
 						action,
@@ -155,12 +155,6 @@ func ExecuteApb(
 	_, err = k8scli.Client.CoreV1().Pods(executionContext.Namespace).Create(pod)
 	if err != nil {
 		log.Errorf("Failed to create pod - %v", err)
-		return executionContext, err
-	}
-
-	err = watchPod(executionContext.PodName, executionContext.Namespace, log)
-	if err != nil {
-		log.Errorf("APB Execution failed - %v", err)
 		return executionContext, err
 	}
 

--- a/pkg/apb/executor.go
+++ b/pkg/apb/executor.go
@@ -153,6 +153,17 @@ func ExecuteApb(
 
 	log.Notice(fmt.Sprintf("Creating pod %q in the %s namespace", pod.Name, executionContext.Namespace))
 	_, err = k8scli.Client.CoreV1().Pods(executionContext.Namespace).Create(pod)
+	if err != nil {
+		log.Errorf("Failed to create pod - %v", err)
+		return executionContext, err
+	}
+
+	err = watchPod(executionContext.PodName, executionContext.Namespace, log)
+	if err != nil {
+		log.Errorf("APB Execution failed - %v", err)
+		return executionContext, err
+	}
+
 	return executionContext, err
 }
 

--- a/pkg/apb/executor.go
+++ b/pkg/apb/executor.go
@@ -153,10 +153,6 @@ func ExecuteApb(
 
 	log.Notice(fmt.Sprintf("Creating pod %q in the %s namespace", pod.Name, executionContext.Namespace))
 	_, err = k8scli.Client.CoreV1().Pods(executionContext.Namespace).Create(pod)
-	if err != nil {
-		log.Errorf("Failed to create pod - %v", err)
-		return executionContext, err
-	}
 
 	return executionContext, err
 }

--- a/pkg/apb/ext_creds.go
+++ b/pkg/apb/ext_creds.go
@@ -19,9 +19,13 @@ package apb
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"strings"
+	"time"
 
 	"github.com/openshift/ansible-service-broker/pkg/clients"
+	"github.com/openshift/ansible-service-broker/pkg/runtime"
 
 	logging "github.com/op/go-logging"
 )
@@ -30,13 +34,97 @@ import (
 func ExtractCredentials(
 	podname string,
 	namespace string,
+	runtimeVersion int,
 	log *logging.Logger,
 ) (*ExtractedCredentials, error) {
-
 	k8scli, err := clients.Kubernetes()
 	if err != nil {
 		return nil, fmt.Errorf("Unable to retrive kubernetes client - %v", err)
 	}
+
+	if runtimeVersion == 1 {
+		return ExtractCredentialsAsFile(
+			podname,
+			namespace,
+			log,
+			k8scli,
+		)
+	} else if runtimeVersion >= 2 {
+		return ExtractCredentialsAsSecret(
+			podname,
+			namespace,
+			log,
+			k8scli,
+		)
+	} else {
+		panic(fmt.Errorf("Unexpected runtime version"))
+	}
+}
+
+// ExtractCredentialsAsFile - Extract credentials from running APB using exec
+func ExtractCredentialsAsFile(
+	podname string,
+	namespace string,
+	log *logging.Logger,
+	k8scli *clients.KubernetesClient,
+) (*ExtractedCredentials, error) {
+	// TODO: Error handling here
+	// It would also be nice to gather the script output that exec runs
+	// instead of only getting the credentials
+
+	for r := 1; r <= apbWatchRetries; r++ {
+		// err will be the return code from the exec command
+		// Use the error code to determine the state
+		failedToExec := errors.New("exit status 1")
+		credsNotAvailable := errors.New("exit status 2")
+
+		output, err := runtime.RunCommand(
+			"kubectl",
+			"exec",
+			podname,
+			GatherCredentialsCommand,
+			"--namespace="+namespace,
+		)
+
+		// cannot exec container, pod is done
+		podFailed := strings.Contains(string(output), "current phase is Failed")
+		podCompleted := strings.Contains(string(output), "current phase is Succeeded") ||
+			strings.Contains(string(output), "cannot exec into a container in a completed pod")
+
+		if err == nil {
+			log.Notice("[%s] Bind credentials found", podname)
+			return buildExtractedCredentials(output)
+		} else if podFailed {
+			// pod has completed but is in failed state
+			return nil, fmt.Errorf("[%s] APB failed", podname)
+		} else if podCompleted && err.Error() == failedToExec.Error() {
+			log.Error("[%s] APB completed", podname)
+			return nil, nil
+		} else if err.Error() == failedToExec.Error() {
+			log.Info(string(output))
+			log.Warning("[%s] Retry attempt %d: Failed to exec into the container", podname, r)
+		} else if err.Error() == credsNotAvailable.Error() {
+			log.Info(string(output))
+			log.Warning("[%s] Retry attempt %d: Bind credentials not available yet", podname, r)
+		} else {
+			log.Info(string(output))
+			log.Warning("[%s] Retry attempt %d: Failed to exec into the container", podname, r)
+		}
+
+		log.Warning("[%s] Retry attempt %d: exec into %s failed", podname, r, podname)
+		time.Sleep(time.Duration(apbWatchInterval) * time.Second)
+	}
+
+	return nil, fmt.Errorf("[%s] ExecTimeout: Failed to gather bind credentials after %d retries", podname, apbWatchRetries)
+}
+
+// ExtractCredentialsAsSecret - Extract credentials from APB as secret in namespace.
+func ExtractCredentialsAsSecret(
+	podname string,
+	namespace string,
+	log *logging.Logger,
+	k8scli *clients.KubernetesClient,
+) (*ExtractedCredentials, error) {
 
 	secretData, err := k8scli.GetSecretData(podname, namespace)
 	if err != nil {

--- a/pkg/apb/ext_creds.go
+++ b/pkg/apb/ext_creds.go
@@ -98,7 +98,7 @@ func ExtractCredentialsAsFile(
 			// pod has completed but is in failed state
 			return nil, fmt.Errorf("[%s] APB failed", podname)
 		} else if podCompleted && err.Error() == failedToExec.Error() {
-			log.Error("[%s] APB completed", podname)
+			log.Notice("[%s] APB completed", podname)
 			return nil, nil
 		} else if err.Error() == failedToExec.Error() {
 			log.Info(string(output))

--- a/pkg/apb/ext_creds_test.go
+++ b/pkg/apb/ext_creds_test.go
@@ -17,6 +17,7 @@
 package apb
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -25,8 +26,12 @@ import (
 
 func TestBuildExtractedCredentials(t *testing.T) {
 	output := []byte("eyJkYiI6ICJmdXNvcl9ndWVzdGJvb2tfZGIiLCAidXNlciI6ICJkdWRlcl90d28iLCAicGFzcyI6ICJkb2c4dHdvIn0=")
+	decoded, err := decodeOutput(output)
+	if err != nil {
+		t.Log(err.Error())
+	}
 
-	bd, _ := buildExtractedCredentials(output)
+	bd, _ := buildExtractedCredentials(decoded)
 	ft.AssertNotNil(t, bd, "credential is nil")
 	ft.AssertEqual(t, bd.Credentials["db"], "fusor_guestbook_db", "db is not fusor_guestbook_db")
 	ft.AssertEqual(t, bd.Credentials["user"], "duder_two", "user is not duder_two")
@@ -43,10 +48,13 @@ func TestExitGracefully(t *testing.T) {
 func TestInt(t *testing.T) {
 	output := []byte("eyJEQl9OQU1FIjogImZvb2JhciIsICJEQl9QQVNTV09SRCI6ICJzdXBlcnNlY3JldCIsICJEQl9UWVBFIjogIm15c3FsIiwgIkRCX1BPUlQiOiAzMzA2LCAiREJfVVNFUiI6ICJkdWRlciIsICJEQl9IT1NUIjogIm15aW5zdGFuY2UuMTIzNDU2Nzg5MDEyLnVzLWVhc3QtMS5yZHMuYW1hem9uYXdzLmNvbSJ9")
 
-	do, err := decodeOutput(output)
+	decoded, err := decodeOutput(output)
 	if err != nil {
 		t.Log(err.Error())
 	}
+
+	do := make(map[string]interface{})
+	json.Unmarshal(decoded, &do)
 	ft.AssertEqual(t, do["DB_NAME"], "foobar", "name does not match")
 	ft.AssertEqual(t, do["DB_PASSWORD"], "supersecret", "password does not match")
 	ft.AssertEqual(t, do["DB_TYPE"], "mysql", "type does not match")

--- a/pkg/apb/provision_or_update.go
+++ b/pkg/apb/provision_or_update.go
@@ -96,6 +96,10 @@ func provisionOrUpdate(
 		}
 	}
 
+	if !instance.Spec.Bindable {
+		return executionContext.PodName, nil, nil
+	}
+
 	creds, err := ExtractCredentials(
 		executionContext.PodName,
 		executionContext.Namespace,

--- a/pkg/apb/provision_or_update.go
+++ b/pkg/apb/provision_or_update.go
@@ -67,7 +67,6 @@ func provisionOrUpdate(
 	}
 
 	metrics.ActionStarted(string(method))
-	sm := NewServiceAccountManager(log)
 	executionContext, err := ExecuteApb(
 		string(method),
 		clusterConfig,

--- a/pkg/apb/types.go
+++ b/pkg/apb/types.go
@@ -158,9 +158,14 @@ const (
 	StateFailed State = "failed"
 
 	// 5s x 7200 retries, 2 hours
-	apbWatchInterval     = 5
-	apbWatchRetries      = 7200
-	gatherCredentialsCMD = "broker-bind-creds"
+	apbWatchInterval = 5
+	apbWatchRetries  = 7200
+
+	// GatherCredentialsCommand - Command used when execing for bind credentials
+	GatherCredentialsCommand = "broker-bind-creds"
+
+	// ApbContainerName - The name of the apb container
+	ApbContainerName = "apb"
 )
 
 // SpecLogDump - log spec for debug

--- a/pkg/apb/types.go
+++ b/pkg/apb/types.go
@@ -72,6 +72,7 @@ func (p *Plan) GetParameter(name string) *ParameterDescriptor {
 // Spec - A APB spec
 type Spec struct {
 	ID          string                 `json:"id"`
+	Runtime     int                    `json:"runtime"`
 	Version     string                 `json:"version"`
 	FQName      string                 `json:"name" yaml:"name"`
 	Image       string                 `json:"image" yaml:"-"`

--- a/pkg/apb/types_test.go
+++ b/pkg/apb/types_test.go
@@ -90,6 +90,7 @@ var p = Plan{
 }
 
 const SpecVersion = "1.0"
+const SpecRuntime = 1
 const SpecName = "mediawiki123-apb"
 const SpecImage = "ansibleplaybookbundle/mediawiki123-apb"
 const SpecBindable = false
@@ -160,13 +161,14 @@ var SpecJSON = fmt.Sprintf(`
 	"tags": null,
 	"description": "%s",
 	"version": "%s",
+	"runtime": %d,
 	"name": "%s",
 	"image": "%s",
 	"bindable": %t,
 	"async": "%s",
 	"plans": %s
 }
-`, SpecDescription, SpecVersion, SpecName, SpecImage, SpecBindable, SpecAsync, SpecPlans)
+`, SpecDescription, SpecVersion, SpecRuntime, SpecName, SpecImage, SpecBindable, SpecAsync, SpecPlans)
 
 func TestSpecLoadJSON(t *testing.T) {
 
@@ -179,6 +181,7 @@ func TestSpecLoadJSON(t *testing.T) {
 	ft.AssertEqual(t, s.Description, SpecDescription)
 	ft.AssertEqual(t, s.FQName, SpecName)
 	ft.AssertEqual(t, s.Version, SpecVersion)
+	ft.AssertEqual(t, s.Runtime, SpecRuntime)
 	ft.AssertEqual(t, s.Image, SpecImage)
 	ft.AssertEqual(t, s.Bindable, SpecBindable)
 	ft.AssertEqual(t, s.Async, SpecAsync)
@@ -188,6 +191,7 @@ func TestSpecLoadJSON(t *testing.T) {
 func TestSpecDumpJSON(t *testing.T) {
 	s := Spec{
 		Description: SpecDescription,
+		Runtime:     SpecRuntime,
 		Version:     SpecVersion,
 		FQName:      SpecName,
 		Image:       SpecImage,

--- a/pkg/apb/unbind.go
+++ b/pkg/apb/unbind.go
@@ -29,7 +29,12 @@ import (
 // github.com/op/go-logging, which is used all over the broker
 // Maybe apb defines its own interface and accepts that optionally
 // Little looser, but still not great
-func Unbind(instance *ServiceInstance, parameters *Parameters, clusterConfig ClusterConfig, log *logging.Logger) error {
+func Unbind(
+	instance *ServiceInstance,
+	parameters *Parameters,
+	clusterConfig ClusterConfig,
+	log *logging.Logger,
+) error {
 	log.Notice("============================================================")
 	log.Notice("                       UNBINDING                            ")
 	log.Notice("============================================================")
@@ -47,9 +52,22 @@ func Unbind(instance *ServiceInstance, parameters *Parameters, clusterConfig Clu
 		parameters,
 		log,
 	)
-	defer runtime.Provider.DestroySandbox(executionContext.PodName, executionContext.Namespace, executionContext.Targets, clusterConfig.Namespace, clusterConfig.KeepNamespace, clusterConfig.KeepNamespaceOnError)
+	defer runtime.Provider.DestroySandbox(
+		executionContext.PodName,
+		executionContext.Namespace,
+		executionContext.Targets,
+		clusterConfig.Namespace,
+		clusterConfig.KeepNamespace,
+		clusterConfig.KeepNamespaceOnError,
+	)
 	if err != nil {
 		log.Errorf("Problem executing apb [%s] unbind", executionContext.PodName)
+		return err
+	}
+
+	err = watchPod(executionContext.PodName, executionContext.Namespace, log)
+	if err != nil {
+		log.Errorf("APB Execution failed - %v", err)
 		return err
 	}
 

--- a/pkg/apb/unbind.go
+++ b/pkg/apb/unbind.go
@@ -31,7 +31,7 @@ import (
 // Little looser, but still not great
 func Unbind(instance *ServiceInstance, parameters *Parameters, clusterConfig ClusterConfig, log *logging.Logger) error {
 	log.Notice("============================================================")
-	log.Notice("                       UNBINDING                              ")
+	log.Notice("                       UNBINDING                            ")
 	log.Notice("============================================================")
 	log.Notice(fmt.Sprintf("ServiceInstance.ID: %s", instance.Spec.ID))
 	log.Notice(fmt.Sprintf("ServiceInstance.Name: %v", instance.Spec.FQName))
@@ -40,12 +40,16 @@ func Unbind(instance *ServiceInstance, parameters *Parameters, clusterConfig Clu
 	log.Notice("============================================================")
 
 	executionContext, err := ExecuteApb(
-		"unbind", clusterConfig, instance.Spec,
-		instance.Context, parameters, log,
+		"unbind",
+		clusterConfig,
+		instance.Spec,
+		instance.Context,
+		parameters,
+		log,
 	)
 	defer runtime.Provider.DestroySandbox(executionContext.PodName, executionContext.Namespace, executionContext.Targets, clusterConfig.Namespace, clusterConfig.KeepNamespace, clusterConfig.KeepNamespaceOnError)
 	if err != nil {
-		log.Errorf("Problem executing apb [%s] unbind:", executionContext.PodName)
+		log.Errorf("Problem executing apb [%s] unbind", executionContext.PodName)
 		return err
 	}
 

--- a/pkg/apb/watch_pod.go
+++ b/pkg/apb/watch_pod.go
@@ -18,53 +18,47 @@ package apb
 
 import (
 	"fmt"
-	"strings"
 	"time"
 
-	"github.com/openshift/ansible-service-broker/pkg/runtime"
+	"github.com/openshift/ansible-service-broker/pkg/clients"
 
 	logging "github.com/op/go-logging"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apicorev1 "k8s.io/kubernetes/pkg/api/v1"
 )
 
-const (
-	podStatusRunning   = "Running"
-	podStatusCompleted = "Completed"
-	podStatusError     = "Error"
-)
-
-func watchPod(podName string, namespace string, log *logging.Logger) (string, error) {
+func watchPod(podName string, namespace string, log *logging.Logger) error {
 	log.Debugf(
-		"Watching pod [ %s ] in namespace [ %s ] for completion", podName, namespace)
+		"Watching pod [ %s ] in namespace [ %s ] for completion",
+		podName,
+		namespace,
+	)
+
+	k8scli, err := clients.Kubernetes()
+	if err != nil {
+		return fmt.Errorf("Unable to retrive kubernetes client - %v", err)
+	}
 
 	for r := 1; r <= apbWatchRetries; r++ {
 		log.Info("Watch pod [ %s ] tick %d", podName, r)
-		output, err := runtime.RunCommand(
-			"kubectl", "get", "pod", "--no-headers=true", "--namespace="+namespace, podName)
-
-		outStr := string(output)
-
-		isPodRunning := strings.Contains(outStr, podStatusRunning)
-		didPodComplete := strings.Contains(outStr, podStatusCompleted)
-		didPodError := strings.Contains(outStr, podStatusError)
-
+		pod, err := k8scli.Client.CoreV1().Pods(namespace).Get(podName, metav1.GetOptions{})
 		if err != nil {
-			log.Infof("Got error from watch pod cmd: %s\n error: %s\n output: %s",
-				podName, string(err.Error()), outStr)
-		} else if didPodError {
-			return outStr, fmt.Errorf("Pod %s is reporting error", podName)
-		} else if didPodComplete {
-			return outStr, nil
-		} else if isPodRunning {
-			log.Info("Pod %s still running, continuing to watch", podName)
-		} else {
-			log.Info("Pod completion not found, continuing to watch")
-			log.Infof("%s", outStr)
+			return fmt.Errorf("Failed to retrive pod [ %s ] in namespace [ %s ]", podName, namespace)
+		}
+
+		//if pod.Status.Phase == apicorev1.PodFailed || pod.Status.Phase == apicorev1.PodUnknown || getPodErr != nil {
+		switch pod.Status.Phase {
+		case apicorev1.PodFailed:
+			return fmt.Errorf("Pod [ %s ] failed - %v", podName, pod.Status.Message)
+		case apicorev1.PodSucceeded:
+			log.Debugf("Pod [ %s ] completed", podName)
+			return nil
+		default:
+			log.Debugf("Pod [ %s ] %s", pod.Status.Phase)
 		}
 
 		time.Sleep(time.Duration(apbWatchInterval) * time.Second)
 	}
 
-	err := fmt.Errorf(
-		"Timed out while watching pod %s for completion", podName)
-	return "", err
+	return fmt.Errorf("Timed out while watching pod %s for completion", podName)
 }

--- a/pkg/apb/watch_pod.go
+++ b/pkg/apb/watch_pod.go
@@ -54,7 +54,7 @@ func watchPod(podName string, namespace string, log *logging.Logger) error {
 			log.Debugf("Pod [ %s ] completed", podName)
 			return nil
 		default:
-			log.Debugf("Pod [ %s ] %s", pod.Status.Phase)
+			log.Debugf("Pod [ %s ] %s", podName, pod.Status.Phase)
 		}
 
 		time.Sleep(time.Duration(apbWatchInterval) * time.Second)

--- a/pkg/apb/watch_pod.go
+++ b/pkg/apb/watch_pod.go
@@ -34,7 +34,7 @@ func watchPod(podName string, namespace string, log *logging.Logger) error {
 		namespace,
 	)
 
-	k8scli, err := clients.Kubernetes()
+	k8scli, err := clients.Kubernetes(log)
 	if err != nil {
 		return fmt.Errorf("Unable to retrive kubernetes client - %v", err)
 	}

--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -455,7 +455,12 @@ func (a AnsibleBroker) Recover() (string, error) {
 			// be and it needs to be broken up.
 
 			// did the pod finish?
-			extCreds, extErr := apb.ExtractCredentials(rs.State.Podname, instance.Context.Namespace, a.log)
+			extCreds, extErr := apb.ExtractCredentials(
+				rs.State.Podname,
+				instance.Context.Namespace,
+				instance.Spec.Runtime,
+				a.log,
+			)
 
 			// NO, pod failed.
 			// TODO: do we restart the job or mark it as failed?

--- a/pkg/clients/kubernetes.go
+++ b/pkg/clients/kubernetes.go
@@ -18,9 +18,11 @@ package clients
 
 import (
 	"errors"
+	"fmt"
 
 	logging "github.com/op/go-logging"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apiv1 "k8s.io/kubernetes/pkg/api/v1"
 
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -57,7 +59,7 @@ func Kubernetes(log *logging.Logger) (*KubernetesClient, error) {
 
 // GetSecretData - Returns the data inside of a given secret
 func (k KubernetesClient) GetSecretData(secretName, namespace string) (map[string][]byte, error) {
-	secretData, err := k.Client.CoreV1().Secrets(namespace).Get(secretName, meta_v1.GetOptions{})
+	secretData, err := k.Client.CoreV1().Secrets(namespace).Get(secretName, metav1.GetOptions{})
 	if err != nil {
 		k.log.Errorf("Unable to load secret '%s' from namespace '%s'", secretName, namespace)
 		return make(map[string][]byte), nil
@@ -65,6 +67,16 @@ func (k KubernetesClient) GetSecretData(secretName, namespace string) (map[strin
 	k.log.Debugf("Found secret with name %v\n", secretName)
 
 	return secretData.Data, nil
+}
+
+// GetPodStatus - Returns the current status of a pod in a specified namespace
+func (k KubernetesClient) GetPodStatus(podName, namespace string) (*apiv1.PodStatus, error) {
+	pod, err := k.Client.CoreV1().Pods(namespace).Get(podName, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("Failed to retrive pod [ %s ] in namespace [ %s ]", podName, namespace)
+	}
+
+	return &pod.Status, nil
 }
 
 func createOnce(log *logging.Logger) {

--- a/pkg/clients/kubernetes.go
+++ b/pkg/clients/kubernetes.go
@@ -20,17 +20,14 @@ import (
 	"errors"
 	"fmt"
 
-	logging "github.com/op/go-logging"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	apiv1 "k8s.io/kubernetes/pkg/api/v1"
-
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/homedir"
 	"k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
 
+	logging "github.com/op/go-logging"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	apicorev1 "k8s.io/kubernetes/pkg/api/v1"
+	apiv1 "k8s.io/kubernetes/pkg/api/v1"
 	rbac "k8s.io/kubernetes/pkg/apis/rbac/v1beta1"
 )
 
@@ -139,7 +136,7 @@ func newKubernetes(log *logging.Logger) (*KubernetesClient, error) {
 
 // CreateServiceAccount - Create a service account
 func (k KubernetesClient) CreateServiceAccount(podName string, namespace string) error {
-	serviceAccount := &apicorev1.ServiceAccount{
+	serviceAccount := &apiv1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: podName,
 		},
@@ -177,7 +174,7 @@ func (k KubernetesClient) CreateRoleBinding(
 
 // DeleteRoleBinding - Delete a Role Binding
 func (k KubernetesClient) DeleteRoleBinding(roleBindingName string, namespace string) error {
-	err := k.Client.RbacV1beta1().RoleBindings(namespace).Delete(roleBindingName, &meta_v1.DeleteOptions{})
+	err := k.Client.RbacV1beta1().RoleBindings(namespace).Delete(roleBindingName, &metav1.DeleteOptions{})
 	if err != nil {
 		return err
 	}

--- a/pkg/dao/dao.go
+++ b/pkg/dao/dao.go
@@ -256,7 +256,7 @@ func (d *Dao) GetSvcInstJobsByState(
 		}
 	}
 
-	d.log.Debugf("Filtered on state: [ %s ], returning %d jobs", len(filtStates))
+	d.log.Debugf("Filtered on state: [ %v ], returning %d jobs", reqState, len(filtStates))
 
 	return filtStates, nil
 }

--- a/pkg/registries/adapters/adapter.go
+++ b/pkg/registries/adapters/adapter.go
@@ -141,7 +141,7 @@ func imageToSpec(log *logging.Logger, req *http.Request, image string) (*apb.Spe
 
 	runtime := conf.Config.Label.Runtime
 	if runtime == "" {
-		log.Infof("No runtime label found, assuming 1")
+		log.Infof("No runtime label found. Set runtime=1. Will use 'exec' to gather bind credentials")
 		spec.Runtime = 1
 	} else {
 		spec.Runtime, err = strconv.Atoi(runtime)

--- a/pkg/registries/adapters/adapter.go
+++ b/pkg/registries/adapters/adapter.go
@@ -23,6 +23,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"strconv"
 
 	logging "github.com/op/go-logging"
 	"github.com/openshift/ansible-service-broker/pkg/apb"
@@ -69,7 +70,8 @@ func imageToSpec(log *logging.Logger, req *http.Request, image string) (*apb.Spe
 	defer resp.Body.Close()
 
 	type label struct {
-		Spec string `json:"com.redhat.apb.spec"`
+		Spec    string `json:"com.redhat.apb.spec"`
+		Runtime string `json:"com.redhat.apb.runtime"`
 	}
 
 	type config struct {
@@ -135,6 +137,18 @@ func imageToSpec(log *logging.Logger, req *http.Request, image string) (*apb.Spe
 	if err = yaml.Unmarshal(decodedSpecYaml, spec); err != nil {
 		log.Errorf("Something went wrong loading decoded spec yaml, %s", err)
 		return nil, err
+	}
+
+	runtime := conf.Config.Label.Runtime
+	if runtime == "" {
+		log.Infof("No runtime label found, assuming 1")
+		spec.Runtime = 1
+	} else {
+		spec.Runtime, err = strconv.Atoi(runtime)
+		if err != nil {
+			log.Errorf("Unable to parse APB runtime version - %v", err)
+			return nil, err
+		}
 	}
 
 	spec.Image = image

--- a/pkg/registries/registry.go
+++ b/pkg/registries/registry.go
@@ -296,7 +296,22 @@ func validateSpecs(log *logging.Logger, inSpecs []*apb.Spec) []*apb.Spec {
 func validateSpecFormat(spec *apb.Spec) (bool, string) {
 	// Specs must have compatible version
 	if !isCompatibleVersion(spec.Version, version.MinAPBVersion, version.MaxAPBVersion) {
-		return false, fmt.Sprintf("Specs must be at least version %s", version.MinAPBVersion)
+		return false, fmt.Sprintf(
+			"APB Spec version [%v] out of bounds %v <= %v",
+			spec.Version,
+			version.MinAPBVersion,
+			version.MaxAPBVersion,
+		)
+	}
+
+	// Specs must have compatible runtime version
+	if !isCompatibleRuntime(spec.Runtime, version.MinRuntimeVersion, version.MaxRuntimeVersion) {
+		return false, fmt.Sprintf(
+			"APB Runtime version [%v] out of bounds %v <= %v",
+			spec.Runtime,
+			version.MinRuntimeVersion,
+			version.MaxRuntimeVersion,
+		)
 	}
 
 	// Specs must have at least one plan
@@ -339,4 +354,8 @@ func isCompatibleVersion(specVersion string, minVersion string, maxVersion strin
 		return true
 	}
 	return false
+}
+
+func isCompatibleRuntime(specRuntime int, minVersion int, maxVersion int) bool {
+	return specRuntime >= minVersion && specRuntime <= maxVersion
 }

--- a/pkg/registries/registry_test.go
+++ b/pkg/registries/registry_test.go
@@ -29,8 +29,10 @@ import (
 var SpecTags = []string{"latest", "old-release"}
 
 const SpecID = "ab094014-b740-495e-b178-946d5aa97ebf"
-const SpecBadVersion = "1.0"
-const SpecVersion = "2.0"
+const SpecBadVersion = "2.0"
+const SpecVersion = "1.0"
+const SpecRuntime = 1
+const SpecBadRuntime = 0
 const SpecName = "etherpad-apb"
 const SpecImage = "fusor/etherpad-apb"
 const SpecBindable = false
@@ -93,6 +95,7 @@ var p = apb.Plan{
 
 var s = apb.Spec{
 	Version:     SpecVersion,
+	Runtime:     SpecRuntime,
 	ID:          SpecID,
 	Description: SpecDescription,
 	FQName:      SpecName,
@@ -105,6 +108,7 @@ var s = apb.Spec{
 
 var noPlansSpec = apb.Spec{
 	Version:     SpecVersion,
+	Runtime:     SpecRuntime,
 	ID:          SpecID,
 	Description: SpecDescription,
 	FQName:      SpecName,
@@ -115,6 +119,7 @@ var noPlansSpec = apb.Spec{
 }
 
 var noVersionSpec = apb.Spec{
+	Runtime:     SpecRuntime,
 	ID:          SpecID,
 	Description: SpecDescription,
 	FQName:      SpecName,
@@ -127,6 +132,20 @@ var noVersionSpec = apb.Spec{
 
 var badVersionSpec = apb.Spec{
 	Version:     SpecBadVersion,
+	Runtime:     SpecRuntime,
+	ID:          SpecID,
+	Description: SpecDescription,
+	FQName:      SpecName,
+	Image:       SpecImage,
+	Tags:        SpecTags,
+	Bindable:    SpecBindable,
+	Async:       SpecAsync,
+	Plans:       []apb.Plan{p},
+}
+
+var badRuntimeSpec = apb.Spec{
+	Version:     SpecVersion,
+	Runtime:     SpecBadRuntime,
 	ID:          SpecID,
 	Description: SpecDescription,
 	FQName:      SpecName,
@@ -217,7 +236,24 @@ func setUpBadVersion() Registry {
 	a = &TestingAdapter{
 		Name:   "testing",
 		Images: []string{"image1-apb", "image2"},
-		Specs:  []*apb.Spec{&noVersionSpec},
+		Specs:  []*apb.Spec{&badVersionSpec},
+		Called: map[string]bool{},
+	}
+	filter := Filter{}
+	c := Config{}
+	log := &logging.Logger{}
+	r = Registry{config: c,
+		adapter: a,
+		log:     log,
+		filter:  filter}
+	return r
+}
+
+func setUpBadRuntime() Registry {
+	a = &TestingAdapter{
+		Name:   "testing",
+		Images: []string{"image1-apb", "image2"},
+		Specs:  []*apb.Spec{&badRuntimeSpec},
 		Called: map[string]bool{},
 	}
 	filter := Filter{}
@@ -267,6 +303,17 @@ func TestRegistryLoadSpecsNoVersion(t *testing.T) {
 
 func TestRegistryLoadSpecsBadVersion(t *testing.T) {
 	r := setUpBadVersion()
+	specs, _, err := r.LoadSpecs()
+	if err != nil {
+		ft.AssertTrue(t, false)
+	}
+	ft.AssertTrue(t, a.Called["GetImageNames"])
+	ft.AssertTrue(t, a.Called["FetchSpecs"])
+	ft.AssertEqual(t, len(specs), 0)
+}
+
+func TestRegistryLoadSpecsBadRuntime(t *testing.T) {
+	r := setUpBadRuntime()
 	specs, _, err := r.LoadSpecs()
 	if err != nil {
 		ft.AssertTrue(t, false)

--- a/pkg/registries/registry_test.go
+++ b/pkg/registries/registry_test.go
@@ -29,7 +29,8 @@ import (
 var SpecTags = []string{"latest", "old-release"}
 
 const SpecID = "ab094014-b740-495e-b178-946d5aa97ebf"
-const SpecVersion = "1.0"
+const SpecBadVersion = "1.0"
+const SpecVersion = "2.0"
 const SpecName = "etherpad-apb"
 const SpecImage = "fusor/etherpad-apb"
 const SpecBindable = false
@@ -124,6 +125,18 @@ var noVersionSpec = apb.Spec{
 	Plans:       []apb.Plan{p},
 }
 
+var badVersionSpec = apb.Spec{
+	Version:     SpecBadVersion,
+	ID:          SpecID,
+	Description: SpecDescription,
+	FQName:      SpecName,
+	Image:       SpecImage,
+	Tags:        SpecTags,
+	Bindable:    SpecBindable,
+	Async:       SpecAsync,
+	Plans:       []apb.Plan{p},
+}
+
 type TestingAdapter struct {
 	Name   string
 	Images []string
@@ -200,6 +213,23 @@ func setUpNoVersion() Registry {
 	return r
 }
 
+func setUpBadVersion() Registry {
+	a = &TestingAdapter{
+		Name:   "testing",
+		Images: []string{"image1-apb", "image2"},
+		Specs:  []*apb.Spec{&noVersionSpec},
+		Called: map[string]bool{},
+	}
+	filter := Filter{}
+	c := Config{}
+	log := &logging.Logger{}
+	r = Registry{config: c,
+		adapter: a,
+		log:     log,
+		filter:  filter}
+	return r
+}
+
 func TestRegistryLoadSpecsNoError(t *testing.T) {
 	r := setUp()
 	specs, numImages, err := r.LoadSpecs()
@@ -226,6 +256,17 @@ func TestRegistryLoadSpecsNoPlans(t *testing.T) {
 
 func TestRegistryLoadSpecsNoVersion(t *testing.T) {
 	r := setUpNoVersion()
+	specs, _, err := r.LoadSpecs()
+	if err != nil {
+		ft.AssertTrue(t, false)
+	}
+	ft.AssertTrue(t, a.Called["GetImageNames"])
+	ft.AssertTrue(t, a.Called["FetchSpecs"])
+	ft.AssertEqual(t, len(specs), 0)
+}
+
+func TestRegistryLoadSpecsBadVersion(t *testing.T) {
+	r := setUpBadVersion()
 	specs, _, err := r.LoadSpecs()
 	if err != nil {
 		ft.AssertTrue(t, false)

--- a/pkg/version/apbruntimeversion.go
+++ b/pkg/version/apbruntimeversion.go
@@ -17,11 +17,11 @@
 package version
 
 // These constants describe the minimum and maximum
-// accepted APB spec versions. They are used to filter
+// accepted APB runtime versions. They are used to filter
 // acceptible APBs.
 
-// MinAPBVersion constant to describe minimum supported spec version
-const MinAPBVersion = "1.0"
+// MinRuntimeVersion constant to describe minimum supported runtime version
+const MinRuntimeVersion = 1
 
-// MaxAPBVersion contant to describe maximum supported spec version
-const MaxAPBVersion = "1.0"
+// MaxRuntimeVersion contant to describe maximum supported runtime version
+const MaxRuntimeVersion = 2

--- a/pkg/version/apbversion.go
+++ b/pkg/version/apbversion.go
@@ -21,7 +21,7 @@ package version
 // acceptible APBs.
 
 // MinAPBVersion constant to describe minimum supported spec version
-const MinAPBVersion = "1.0"
+const MinAPBVersion = "2.0"
 
 // MaxAPBVersion contant to describe maximum supported spec version
-const MaxAPBVersion = "1.0"
+const MaxAPBVersion = "2.0"

--- a/scripts/broker-ci/setup-broker.sh
+++ b/scripts/broker-ci/setup-broker.sh
@@ -44,6 +44,8 @@ BOOTSTRAP_ON_STARTUP="true"
 BEARER_TOKEN_FILE=""
 CA_FILE=""
 
+TAG="canary"
+
 # Always, IfNotPresent, Never
 IMAGE_PULL_POLICY="Always"
 EOF

--- a/scripts/openshift/deploy.sh
+++ b/scripts/openshift/deploy.sh
@@ -23,6 +23,7 @@ BROKER_CLIENT_CERT_PATH="/var/run/asb-etcd-auth/client.crt"
 BROKER_CLIENT_KEY_PATH="/var/run/asb-etcd-auth/client.key"
 ENABLE_BASIC_AUTH=false
 BROKER_CA_CERT=$(oc get secret --no-headers=true -n kube-service-catalog | grep -m 1 service-catalog-apiserver-token | oc get secret $(awk '{ print $1 }') -n kube-service-catalog -o yaml | grep service-ca.crt | awk '{ print $2 }' | cat)
+TAG="${TAG:-latest}"
 
 #Create Certs for etcd
 mkdir -p /tmp/etcd-cert
@@ -64,7 +65,8 @@ VARS="-p BROKER_IMAGE=${BROKER_IMAGE} \
   -p BROKER_CLIENT_KEY_PATH=${BROKER_CLIENT_KEY_PATH} \
   -p ETCD_TRUSTED_CA=${ETCD_CA_CERT} \
   -p BROKER_CLIENT_CERT=${ETCD_BROKER_CLIENT_CERT} \
-  -p BROKER_CLIENT_KEY=${ETCD_BROKER_CLIENT_KEY}"
+  -p BROKER_CLIENT_KEY=${ETCD_BROKER_CLIENT_KEY} \
+  -p TAG=${TAG}"
 
 # cleanup old deployment
 asb::delete_project ${PROJECT}


### PR DESCRIPTION
This change makes it so the broker can handle secrets that are created
by APBs when using the `asb_encode_binding` module.

- Update the broker so that it can handle secrets generated by the APB
  when `asb_encode_binding` module is used from the asb-modules.
- Update `executor::ExecuteApb` to wait for pod to complete, since the
  pod is no longer kept alive for credential extraction.
- Clean up some of the log messages and code format related to apb
  actions.

Fixes #544 
Fixes #553 
Implements the proposal #550 

Depends on the following PRs:
- [ansible-asb-modules#8](ansibleplaybookbundle/ansible-asb-modules#8) This is how the secret gets generated.
- [apb-base#7](ansibleplaybookbundle/apb-base#7) Remove scripts related to extracting credentials from the containers filesystem.
- [ansible-playbook-bundle#163](ansibleplaybookbundle/ansible-playbook-bundle#163) Bump the APB versions so freshly built APBs will pass version validation checks.