### PR TITLE
Update copr link in Makefile comments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ release-image:
 	@echo "Remember you need to push your image before calling make deploy"
 	@echo "    make push"
 
-# https://copr.fedorainfracloud.org/coprs/g/ansible-service-broker/ansible-service-broker/
+# https://copr.fedorainfracloud.org/coprs/g/ansible-service-broker/ansible-service-broker-latest/
 release: release-image ## Builds docker container using latest rpm from Copr
 
 push:


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
Update a comment in the Makefile.

The non-suffixed repo is redundant and I want to remove it. Keeping it up to date doubles the number of builds we're doing and copr is already under a crushing load so we're not helping them or us to enjoy a stable service.