### PR TITLE
Pull apb templates from their respective git repos

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,10 +1,10 @@
 # Travis CI
-provision: mediawiki123
-provision: postgresql
+provision: ansibleplaybookbundle/mediawiki123-apb
+provision: ansibleplaybookbundle/rhscl-postgresql-apb
 
-bind: postgresql
+bind: ansibleplaybookbundle/rhscl-postgresql-apb
 verify: rthallisey/service-broker-ci/verify-mediawiki-postgresql.sh
-unbind: postgresql | mediawiki123
+unbind: rhscl-postgresql-apb | mediawiki123-apb
 
-deprovision: mediawiki123
-deprovision: postgresql
+deprovision: ansibleplaybookbundle/mediawiki123-apb
+deprovision: ansibleplaybookbundle/rhscl-postgresql-apb


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
The new ci framework uses the git repos of APBs to carry templates
that will operate the APBs.  This patch will point CI at the templates
in the APB's git repos.

Also, keep the existing templates in tree for cli testing.

Changes proposed in this pull request
 - Point CI to the APB's git repos
