### PR TITLE
Create a Kubernetes Client struct

### DIFF
--- a/pkg/apb/provision_or_update.go
+++ b/pkg/apb/provision_or_update.go
@@ -52,7 +52,7 @@ func provisionOrUpdate(
 		return "", nil, errors.New("No image field found on instance.Spec")
 	}
 
-	k8scli, err := clients.Kubernetes(log)
+	k8scli, err := clients.Kubernetes()
 	if err != nil {
 		log.Error("Something went wrong getting kubernetes client")
 		return "", nil, err
@@ -60,7 +60,7 @@ func provisionOrUpdate(
 
 	ns := instance.Context.Namespace
 	log.Info("Checking if namespace %s exists.", ns)
-	_, err = k8scli.CoreV1().Namespaces().Get(ns, metav1.GetOptions{})
+	_, err = k8scli.Client.CoreV1().Namespaces().Get(ns, metav1.GetOptions{})
 	if err != nil {
 		return "", nil, fmt.Errorf("Project %s does not exist", ns)
 	}

--- a/pkg/apb/secrets.go
+++ b/pkg/apb/secrets.go
@@ -167,12 +167,12 @@ func paramInSecret(param ParameterDescriptor, secretKeys []string) bool {
 }
 
 func getSecretKeys(secretName, namespace string) ([]string, error) {
-	k8scli, err := clients.Kubernetes(secrets.log)
+	k8scli, err := clients.Kubernetes()
 	if err != nil {
 		return nil, err
 	}
 
-	secretData, err := k8scli.CoreV1().Secrets(namespace).Get(secretName, meta_v1.GetOptions{})
+	secretData, err := k8scli.Client.CoreV1().Secrets(namespace).Get(secretName, meta_v1.GetOptions{})
 	if err != nil {
 		secrets.log.Warningf("Unable to load secret '%s' from namespace '%s'", secretName, namespace)
 		return []string{}, nil

--- a/pkg/apb/svc_acct.go
+++ b/pkg/apb/svc_acct.go
@@ -227,20 +227,20 @@ func (s *ServiceAccountManager) DestroyApbSandbox(executionContext ExecutionCont
 		s.log.Info("Requested destruction of APB sandbox with empty handle, skipping.")
 		return
 	}
-	k8scli, err := clients.Kubernetes(s.log)
+	k8scli, err := clients.Kubernetes()
 	if err != nil {
 		s.log.Error("Something went wrong getting kubernetes client")
 		s.log.Errorf("%s", err.Error())
 		return
 	}
-	pod, err := k8scli.CoreV1().Pods(executionContext.Namespace).Get(executionContext.PodName, metav1.GetOptions{})
+	pod, err := k8scli.Client.CoreV1().Pods(executionContext.Namespace).Get(executionContext.PodName, metav1.GetOptions{})
 	if err != nil {
 		s.log.Errorf("Unable to retrieve pod - %v", err)
 	}
 	if shouldDeleteNamespace(clusterConfig, pod, err) {
 		if clusterConfig.Namespace != executionContext.Namespace {
 			s.log.Debug("Deleting namespace %s", executionContext.Namespace)
-			k8scli.CoreV1().Namespaces().Delete(executionContext.Namespace, &metav1.DeleteOptions{})
+			k8scli.Client.CoreV1().Namespaces().Delete(executionContext.Namespace, &metav1.DeleteOptions{})
 			// This is keeping track of namespaces.
 			metrics.SandboxDeleted()
 		} else {

--- a/pkg/app/config.go
+++ b/pkg/app/config.go
@@ -128,7 +128,12 @@ func readFile(fileName string) (string, string, error) {
 }
 
 func readSecret(secretName string, namespace string) (string, string, error) {
-	data, err := clients.GetSecretData(secretName, namespace)
+	k8s, err := clients.Kubernetes()
+	if err != nil {
+		return "", "", err
+	}
+
+	data, err := k8s.GetSecretData(secretName, namespace)
 	if err != nil {
 		return "", "", fmt.Errorf("Failed to find Dockerhub credentials in secret: %s", secretName)
 	}

--- a/pkg/clients/clients.go
+++ b/pkg/clients/clients.go
@@ -20,15 +20,12 @@ import (
 	"sync"
 
 	etcd "github.com/coreos/etcd/client"
-	"k8s.io/client-go/rest"
-	k8s "k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
 )
 
 var instances struct {
-	Etcd             etcd.Client
-	Kubernetes       *k8s.Clientset
-	KubernetesConfig *rest.Config
-	Openshift        *OpenshiftClient
+	Etcd       etcd.Client
+	Kubernetes *KubernetesClient
+	Openshift  *OpenshiftClient
 }
 
 var once struct {

--- a/pkg/clients/kubernetes.go
+++ b/pkg/clients/kubernetes.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
 )
 
+// KubernetesClient - Client to interact with Kubernetes API
 type KubernetesClient struct {
 	Client       *clientset.Clientset
 	ClientConfig *rest.Config

--- a/pkg/clients/kubernetes.go
+++ b/pkg/clients/kubernetes.go
@@ -28,45 +28,44 @@ import (
 	"k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
 )
 
+type KubernetesClient struct {
+	Client       *clientset.Clientset
+	ClientConfig *rest.Config
+	log          *logging.Logger
+}
+
 // Kubernetes - Create a new kubernetes client if needed, returns reference
-func Kubernetes(log *logging.Logger) (*clientset.Clientset, error) {
-	once.Kubernetes.Do(func() { createOnce(log) })
+func Kubernetes() (*KubernetesClient, error) {
+	once.Kubernetes.Do(func() {
+		var log *logging.Logger
+		client, err := newKubernetes(log)
+		if err != nil {
+			log.Error(err.Error())
+			panic(err.Error())
+		}
+		instances.Kubernetes = client
+	})
 	if instances.Kubernetes == nil {
 		return nil, errors.New("Kubernetes client instance is nil")
 	}
 	return instances.Kubernetes, nil
 }
 
-// KubernetesConfig - Retrieve or create a new kubernetes configuration.
-func KubernetesConfig(log *logging.Logger) (*rest.Config, error) {
-	once.Kubernetes.Do(func() { createOnce(log) })
-	if instances.KubernetesConfig == nil {
-		return nil, errors.New("Kubernetes client config instance is nil")
-	}
-	return instances.KubernetesConfig, nil
-}
-
 // GetSecretData - Returns the data inside of a given secret
-func GetSecretData(secretName, namespace string) (map[string][]byte, error) {
-	var log logging.Logger
-	k8scli, err := Kubernetes(&log)
+func (k KubernetesClient) GetSecretData(secretName, namespace string) (map[string][]byte, error) {
+	secretData, err := k.Client.CoreV1().Secrets(namespace).Get(secretName, meta_v1.GetOptions{})
 	if err != nil {
-		return nil, err
-	}
-
-	secretData, err := k8scli.CoreV1().Secrets(namespace).Get(secretName, meta_v1.GetOptions{})
-	if err != nil {
-		log.Errorf("Unable to load secret '%s' from namespace '%s'", secretName, namespace)
+		k.log.Errorf("Unable to load secret '%s' from namespace '%s'", secretName, namespace)
 		return make(map[string][]byte), nil
 	}
-	log.Debugf("Found secret with name %v\n", secretName)
+	k.log.Debugf("Found secret with name %v\n", secretName)
 
 	return secretData.Data, nil
 }
 
 func createOnce(log *logging.Logger) {
 	errMsg := "Something went wrong while initializing kubernetes client!\n"
-	client, clientConfig, err := newKubernetes(log)
+	k8s, err := newKubernetes(log)
 	if err != nil {
 		log.Error(errMsg)
 		// NOTE: Looking to leverage panic recovery to gracefully handle this
@@ -75,8 +74,8 @@ func createOnce(log *logging.Logger) {
 		// and demands the attention of an operator.
 		panic(err.Error())
 	}
-	instances.Kubernetes = client
-	instances.KubernetesConfig = clientConfig
+
+	instances.Kubernetes = k8s
 }
 
 func createClientConfigFromFile(configPath string) (*rest.Config, error) {
@@ -92,7 +91,7 @@ func createClientConfigFromFile(configPath string) (*rest.Config, error) {
 	return config, nil
 }
 
-func newKubernetes(log *logging.Logger) (*clientset.Clientset, *rest.Config, error) {
+func newKubernetes(log *logging.Logger) (*KubernetesClient, error) {
 	// NOTE: Both the external and internal client object are using the same
 	// clientset library. Internal clientset normally uses a different
 	// library
@@ -104,15 +103,20 @@ func newKubernetes(log *logging.Logger) (*clientset.Clientset, *rest.Config, err
 		clientConfig, err = createClientConfigFromFile(homedir.HomeDir() + "/.kube/config")
 		if err != nil {
 			log.Error("Failed to create LocalClientSet")
-			return nil, nil, err
+			return nil, err
 		}
 	}
 
 	clientset, err := clientset.NewForConfig(clientConfig)
 	if err != nil {
 		log.Error("Failed to create LocalClientSet")
-		return nil, nil, err
+		return nil, err
 	}
 
-	return clientset, clientConfig, err
+	k := &KubernetesClient{
+		Client:       clientset,
+		ClientConfig: clientConfig,
+		log:          log,
+	}
+	return k, err
 }

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -555,12 +555,12 @@ func (h handler) unbind(w http.ResponseWriter, r *http.Request, params map[strin
 }
 
 func isNamespaceDeleted(name string, log *logging.Logger) (bool, error) {
-	k8scli, err := clients.Kubernetes(log)
+	k8scli, err := clients.Kubernetes()
 	if err != nil {
 		return false, err
 	}
 
-	namespace, err := k8scli.CoreV1().Namespaces().Get(name, metav1.GetOptions{})
+	namespace, err := k8scli.Client.CoreV1().Namespaces().Get(name, metav1.GetOptions{})
 	if err != nil {
 		return false, err
 	}

--- a/pkg/registries/adapters/local_openshift_adapter.go
+++ b/pkg/registries/adapters/local_openshift_adapter.go
@@ -131,12 +131,12 @@ func (r LocalOpenShiftAdapter) loadSpec(yamlSpec []byte) (*apb.Spec, error) {
 }
 
 func (r LocalOpenShiftAdapter) getServiceIP(service string, namespace string) (string, error) {
-	k8scli, err := clients.Kubernetes(r.Log)
+	k8s, err := clients.Kubernetes()
 	if err != nil {
 		return "", err
 	}
 
-	serviceData, err := k8scli.CoreV1().Services(namespace).Get(service, meta_v1.GetOptions{})
+	serviceData, err := k8s.Client.CoreV1().Services(namespace).Get(service, meta_v1.GetOptions{})
 	if err != nil {
 		r.Log.Warningf("Unable to load service '%s' from namespace '%s'", service, namespace)
 		return "", err


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
In the Clients pkg, each of the clients should have a Class to
reference.  This creates the Kubernetes class reference so we
can build specific Kubernetes functions into the client class.

Changes proposed in this pull request
 -  Add a Kubernetes class to the client pkg
 