### PR TITLE
Rebase k8s templates to pickup etcd name change

### DIFF
--- a/scripts/prep_local_devel_env.sh
+++ b/scripts/prep_local_devel_env.sh
@@ -28,6 +28,7 @@ if [ -n "${KUBERNETES}" ]; then
 	echo "ERROR: Kubernetes uses port 6443, not ${KUBERNETES_SERVICE_PORT}"
 	exit 1
     fi
+    AUTO_ESCALATE=true
     source "${SCRIPT_DIR}/kubernetes/resources.sh"
 else
     echo "OpenShift Cluster"
@@ -237,4 +238,3 @@ broker:
   refresh_interval: "600s"
   auto_escalate: ${AUTO_ESCALATE:-false}
 EOF
-

--- a/templates/k8s-ansible-service-broker.yaml.j2
+++ b/templates/k8s-ansible-service-broker.yaml.j2
@@ -1,3 +1,6 @@
+#
+# TODO: SSL for etcd
+#
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -125,15 +128,18 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-   name: etcd
+   name: asb-etcd
    namespace: ansible-service-broker
+   labels:
+     app: etcd
+     service: asb-etcd
 spec:
   ports:
     - name: etcd-advertise
       port: 2379
   selector:
-    app: ansible-service-broker
-    service: etcd
+    app: etcd
+    service: asb-etcd
 
 ---
 apiVersion: v1
@@ -154,7 +160,7 @@ data:
         white_list:
           - ".*-apb$"
     dao:
-      etcd_host: etcd
+      etcd_host: asb-etcd
       etcd_port: 2379
     log:
       logfile: /var/log/ansible-service-broker/asb.log
@@ -187,11 +193,11 @@ data:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: etcd
+  name: asb-etcd
   namespace: ansible-service-broker
   labels:
-    app: ansible-service-broker
-    service: etcd
+    app: etcd
+    service: asb-etcd
 spec:
   strategy:
     type: Recreate
@@ -199,8 +205,8 @@ spec:
   template:
     metadata:
       labels:
-        app: ansible-service-broker
-        service: etcd
+        app: etcd
+        service: asb-etcd
     spec:
       restartPolicy: Always
       containers:

--- a/templates/k8s-local-dev-changes.yaml
+++ b/templates/k8s-local-dev-changes.yaml
@@ -18,25 +18,25 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-   name: etcd
+   name: asb-etcd
    namespace: ansible-service-broker
 spec:
   ports:
     - name: etcd-advertise
       port: 2379
   selector:
-    app: ansible-service-broker
-    service: etcd
+    app: etcd
+    service: asb-etcd
 
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: etcd
+  name: asb-etcd
   namespace: ansible-service-broker
   labels:
-    app: ansible-service-broker
-    service: etcd
+    app: etcd
+    service: asb-etcd
 spec:
   strategy:
     type: Recreate
@@ -44,8 +44,8 @@ spec:
   template:
     metadata:
       labels:
-        app: ansible-service-broker
-        service: etcd
+        app: etcd
+        service: asb-etcd
     spec:
       restartPolicy: Always
       containers:


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
After the etcd ssl work landed, the broker and etcd
pods were split and the etcd deployment name changed.
Realign the k8s templates with those changes.

Changes proposed in this pull request
 - Have k8s use the same resources names as the openshift templates

Partially-fixes: https://github.com/openshift/ansible-service-broker/issues/233
