### PR TITLE
Use the global var instance to save client objects

### DIFF
--- a/pkg/apb/executor.go
+++ b/pkg/apb/executor.go
@@ -69,10 +69,7 @@ func ExecuteApb(
 	}
 
 	secrets := GetSecrets(spec)
-	k8scli, err := clients.Kubernetes()
-	if err != nil {
-		return executionContext, err
-	}
+	k8scli := clients.Kubernetes()
 
 	labels := map[string]string{
 		"apb-fqname": spec.FQName,

--- a/pkg/apb/provision_or_update.go
+++ b/pkg/apb/provision_or_update.go
@@ -52,15 +52,11 @@ func provisionOrUpdate(
 		return "", nil, errors.New("No image field found on instance.Spec")
 	}
 
-	k8scli, err := clients.Kubernetes()
-	if err != nil {
-		log.Error("Something went wrong getting kubernetes client")
-		return "", nil, err
-	}
+	k8scli := clients.Kubernetes()
 
 	ns := instance.Context.Namespace
 	log.Info("Checking if namespace %s exists.", ns)
-	_, err = k8scli.Client.CoreV1().Namespaces().Get(ns, metav1.GetOptions{})
+	_, err := k8scli.Client.CoreV1().Namespaces().Get(ns, metav1.GetOptions{})
 	if err != nil {
 		return "", nil, fmt.Errorf("Project %s does not exist", ns)
 	}

--- a/pkg/apb/secrets.go
+++ b/pkg/apb/secrets.go
@@ -167,10 +167,7 @@ func paramInSecret(param ParameterDescriptor, secretKeys []string) bool {
 }
 
 func getSecretKeys(secretName, namespace string) ([]string, error) {
-	k8scli, err := clients.Kubernetes()
-	if err != nil {
-		return nil, err
-	}
+	k8scli := clients.Kubernetes()
 
 	secretData, err := k8scli.Client.CoreV1().Secrets(namespace).Get(secretName, meta_v1.GetOptions{})
 	if err != nil {

--- a/pkg/apb/svc_acct.go
+++ b/pkg/apb/svc_acct.go
@@ -227,12 +227,8 @@ func (s *ServiceAccountManager) DestroyApbSandbox(executionContext ExecutionCont
 		s.log.Info("Requested destruction of APB sandbox with empty handle, skipping.")
 		return
 	}
-	k8scli, err := clients.Kubernetes()
-	if err != nil {
-		s.log.Error("Something went wrong getting kubernetes client")
-		s.log.Errorf("%s", err.Error())
-		return
-	}
+	k8scli := clients.Kubernetes()
+
 	pod, err := k8scli.Client.CoreV1().Pods(executionContext.Namespace).Get(executionContext.PodName, metav1.GetOptions{})
 	if err != nil {
 		s.log.Errorf("Unable to retrieve pod - %v", err)

--- a/pkg/app/config.go
+++ b/pkg/app/config.go
@@ -128,10 +128,7 @@ func readFile(fileName string) (string, string, error) {
 }
 
 func readSecret(secretName string, namespace string) (string, string, error) {
-	k8s, err := clients.Kubernetes()
-	if err != nil {
-		return "", "", err
-	}
+	k8s := clients.Kubernetes()
 
 	data, err := k8s.GetSecretData(secretName, namespace)
 	if err != nil {

--- a/pkg/clients/clients.go
+++ b/pkg/clients/clients.go
@@ -17,8 +17,6 @@
 package clients
 
 import (
-	"sync"
-
 	etcd "github.com/coreos/etcd/client"
 )
 
@@ -26,10 +24,4 @@ var instances struct {
 	Etcd       etcd.Client
 	Kubernetes *KubernetesClient
 	Openshift  *OpenshiftClient
-}
-
-var once struct {
-	Etcd       sync.Once
-	Kubernetes sync.Once
-	Openshift  sync.Once
 }

--- a/pkg/clients/etcd_test.go
+++ b/pkg/clients/etcd_test.go
@@ -8,9 +8,9 @@ import (
 	"net/url"
 	"os"
 	"strings"
-	"sync"
 	"testing"
 
+	etcd "github.com/coreos/etcd/client"
 	"github.com/coreos/etcd/version"
 	logging "github.com/op/go-logging"
 )
@@ -82,20 +82,23 @@ func TestEtcd(t *testing.T) {
 			}()
 
 			log := logging.MustGetLogger("test")
+			var err error
+			var cl etcd.Client
 			if tc.ResetRun {
-				once.Etcd = sync.Once{}
+				cl, err = NewEtcd(tc.Config, log)
 			}
+			cl = Etcd()
 			if tc.NilOutExistingClient {
 				instances.Etcd = nil
 			}
-			cl, err := Etcd(tc.Config, log)
+
 			if !tc.ShouldError && err != nil {
 				t.Fatalf("failed to get etcd client - %v client - %v", err, cl)
 			} else if tc.ShouldError && err != nil {
 				t.Logf("Should error and retrieved error - %v", err)
 				return
 			} else if tc.ShouldError && err == nil {
-				t.Fatalf("failed to get error - %v", err)
+				t.Fatalf("failed to get error - %v", err.Error())
 			}
 			t.Logf("client - %v", cl.Endpoints())
 			if tc.Config.EtcdCaFile != "" {

--- a/pkg/clients/kubernetes.go
+++ b/pkg/clients/kubernetes.go
@@ -17,8 +17,6 @@
 package clients
 
 import (
-	"errors"
-
 	logging "github.com/op/go-logging"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -35,21 +33,9 @@ type KubernetesClient struct {
 	log          *logging.Logger
 }
 
-// Kubernetes - Create a new kubernetes client if needed, returns reference
-func Kubernetes() (*KubernetesClient, error) {
-	once.Kubernetes.Do(func() {
-		var log *logging.Logger
-		client, err := newKubernetes(log)
-		if err != nil {
-			log.Error(err.Error())
-			panic(err.Error())
-		}
-		instances.Kubernetes = client
-	})
-	if instances.Kubernetes == nil {
-		return nil, errors.New("Kubernetes client instance is nil")
-	}
-	return instances.Kubernetes, nil
+// Kubernetes - Get a Kubernetes client
+func Kubernetes() *KubernetesClient {
+	return instances.Kubernetes
 }
 
 // GetSecretData - Returns the data inside of a given secret
@@ -62,21 +48,6 @@ func (k KubernetesClient) GetSecretData(secretName, namespace string) (map[strin
 	k.log.Debugf("Found secret with name %v\n", secretName)
 
 	return secretData.Data, nil
-}
-
-func createOnce(log *logging.Logger) {
-	errMsg := "Something went wrong while initializing kubernetes client!\n"
-	k8s, err := newKubernetes(log)
-	if err != nil {
-		log.Error(errMsg)
-		// NOTE: Looking to leverage panic recovery to gracefully handle this
-		// with things like retries or better intelligence, but the environment
-		// is probably in a unrecoverable state as far as the broker is concerned,
-		// and demands the attention of an operator.
-		panic(err.Error())
-	}
-
-	instances.Kubernetes = k8s
 }
 
 func createClientConfigFromFile(configPath string) (*rest.Config, error) {
@@ -92,7 +63,8 @@ func createClientConfigFromFile(configPath string) (*rest.Config, error) {
 	return config, nil
 }
 
-func newKubernetes(log *logging.Logger) (*KubernetesClient, error) {
+// NewKubernetes - Create the initial Kubernetes client
+func NewKubernetes(log *logging.Logger) (*KubernetesClient, error) {
 	// NOTE: Both the external and internal client object are using the same
 	// clientset library. Internal clientset normally uses a different
 	// library
@@ -119,5 +91,6 @@ func newKubernetes(log *logging.Logger) (*KubernetesClient, error) {
 		ClientConfig: clientConfig,
 		log:          log,
 	}
+	instances.Kubernetes = k
 	return k, err
 }

--- a/pkg/clients/openshift.go
+++ b/pkg/clients/openshift.go
@@ -19,7 +19,6 @@ package clients
 import (
 	b64 "encoding/base64"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strings"
 	"unsafe"
@@ -237,28 +236,13 @@ func autoConvertV1PolicyRulesToAuthorizationPolicyRules(in []PolicyRule) ([]auth
 
 /* End of v1 openshift rest calls that are need. */
 
-// Openshift - Create a new openshift client if needed, returns reference
-func Openshift(log *logging.Logger) (*OpenshiftClient, error) {
-	errMsg := "Something went wrong while initializing openshift client!\n"
-	once.Openshift.Do(func() {
-		client, err := newOpenshift(log)
-		if err != nil {
-			log.Error(errMsg)
-			// NOTE: Looking to leverage panic recovery to gracefully handle this
-			// with things like retries or better intelligence, but the environment
-			// is probably in a unrecoverable state as far as the broker is concerned,
-			// and demands the attention of an operator.
-			panic(err.Error())
-		}
-		instances.Openshift = client
-	})
-	if instances.Openshift == nil {
-		return nil, errors.New("OpenShift client instance is nil")
-	}
-	return instances.Openshift, nil
+// Openshift - Get an openshift client
+func Openshift() *OpenshiftClient {
+	return instances.Openshift
 }
 
-func newOpenshift(log *logging.Logger) (*OpenshiftClient, error) {
+// NewOpenshift - Create an openshift client
+func NewOpenshift(log *logging.Logger) (*OpenshiftClient, error) {
 	// NOTE: Both the external and internal client object are using the same
 	// clientset library. Internal clientset normally uses a different
 	// library
@@ -280,6 +264,7 @@ func newOpenshift(log *logging.Logger) (*OpenshiftClient, error) {
 		return nil, err
 	}
 
+	instances.Openshift = clientset
 	return clientset, err
 }
 

--- a/pkg/dao/dao.go
+++ b/pkg/dao/dao.go
@@ -61,10 +61,8 @@ func NewDao(config Config, log *logging.Logger) (*Dao, error) {
 		log:    log,
 	}
 
-	etcdClient, err := clients.Etcd(config.GetEtcdConfig(), log)
-	if err != nil {
-		return nil, err
-	}
+	etcdClient := clients.Etcd()
+
 	dao.client = etcdClient
 	dao.kapi = client.NewKeysAPI(dao.client)
 	return &dao, nil

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -555,10 +555,7 @@ func (h handler) unbind(w http.ResponseWriter, r *http.Request, params map[strin
 }
 
 func isNamespaceDeleted(name string, log *logging.Logger) (bool, error) {
-	k8scli, err := clients.Kubernetes()
-	if err != nil {
-		return false, err
-	}
+	k8scli := clients.Kubernetes()
 
 	namespace, err := k8scli.Client.CoreV1().Namespaces().Get(name, metav1.GetOptions{})
 	if err != nil {
@@ -698,10 +695,8 @@ func (h handler) printRequest(req *http.Request) {
 // the rules for the user in the namespace to determine if the user's roles
 // can cover the  all of the cluster role's rules.
 func (h handler) validateUser(userName, namespace string) (bool, int, error) {
-	openshiftClient, err := clients.Openshift(h.log)
-	if err != nil {
-		return false, http.StatusInternalServerError, fmt.Errorf("Unable to connect to the cluster")
-	}
+	openshiftClient := clients.Openshift()
+
 	// Retrieving the rules for the user in the namespace.
 	prs, err := openshiftClient.SubjectRulesReview(userName, namespace, h.log)
 	if err != nil {

--- a/pkg/registries/adapters/local_openshift_adapter.go
+++ b/pkg/registries/adapters/local_openshift_adapter.go
@@ -43,11 +43,7 @@ func (r LocalOpenShiftAdapter) GetImageNames() ([]string, error) {
 	r.Log.Debug("LocalOpenShiftAdapter::GetImageNames")
 	r.Log.Debug("BundleSpecLabel: %s", BundleSpecLabel)
 
-	openshiftClient, err := clients.Openshift(r.Log)
-	if err != nil {
-		r.Log.Errorf("Failed to instantiate OpenShift client")
-		return nil, err
-	}
+	openshiftClient := clients.Openshift()
 
 	images, err := openshiftClient.ListRegistryImages(r.Log)
 	if err != nil {
@@ -68,11 +64,7 @@ func (r LocalOpenShiftAdapter) FetchSpecs(imageNames []string) ([]*apb.Spec, err
 		return nil, err
 	}
 
-	openshiftClient, err := clients.Openshift(r.Log)
-	if err != nil {
-		r.Log.Errorf("Failed to instantiate OpenShift client.")
-		return nil, err
-	}
+	openshiftClient := clients.Openshift()
 
 	fqImages, err := openshiftClient.ConvertRegistryImagesToSpecs(r.Log, imageNames)
 	if err != nil {
@@ -131,10 +123,7 @@ func (r LocalOpenShiftAdapter) loadSpec(yamlSpec []byte) (*apb.Spec, error) {
 }
 
 func (r LocalOpenShiftAdapter) getServiceIP(service string, namespace string) (string, error) {
-	k8s, err := clients.Kubernetes()
-	if err != nil {
-		return "", err
-	}
+	k8s := clients.Kubernetes()
 
 	serviceData, err := k8s.Client.CoreV1().Services(namespace).Get(service, meta_v1.GetOptions{})
 	if err != nil {


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
Instead of using sync to make sure we initialize the clients once, use the ```initializeClients``` function to create the clients the first time and store them in the instances struct.

Changes proposed in this pull request
 - Global variable will save client objects
 - No need to pass around log to the clients pkg
