### PR TITLE
Give cluster client the log object

### DIFF
--- a/pkg/apb/executor.go
+++ b/pkg/apb/executor.go
@@ -69,7 +69,7 @@ func ExecuteApb(
 	}
 
 	secrets := GetSecrets(spec)
-	k8scli, err := clients.Kubernetes()
+	k8scli, err := clients.Kubernetes(log)
 	if err != nil {
 		return executionContext, err
 	}

--- a/pkg/apb/provision_or_update.go
+++ b/pkg/apb/provision_or_update.go
@@ -52,7 +52,7 @@ func provisionOrUpdate(
 		return "", nil, errors.New("No image field found on instance.Spec")
 	}
 
-	k8scli, err := clients.Kubernetes()
+	k8scli, err := clients.Kubernetes(log)
 	if err != nil {
 		log.Error("Something went wrong getting kubernetes client")
 		return "", nil, err

--- a/pkg/apb/secrets.go
+++ b/pkg/apb/secrets.go
@@ -167,7 +167,7 @@ func paramInSecret(param ParameterDescriptor, secretKeys []string) bool {
 }
 
 func getSecretKeys(secretName, namespace string) ([]string, error) {
-	k8scli, err := clients.Kubernetes()
+	k8scli, err := clients.Kubernetes(secrets.log)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/apb/svc_acct.go
+++ b/pkg/apb/svc_acct.go
@@ -227,7 +227,7 @@ func (s *ServiceAccountManager) DestroyApbSandbox(executionContext ExecutionCont
 		s.log.Info("Requested destruction of APB sandbox with empty handle, skipping.")
 		return
 	}
-	k8scli, err := clients.Kubernetes()
+	k8scli, err := clients.Kubernetes(s.log)
 	if err != nil {
 		s.log.Error("Something went wrong getting kubernetes client")
 		s.log.Errorf("%s", err.Error())

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -97,7 +97,7 @@ func apiServer(log *logging.Logger, config Config, args Args, providers []auth.P
 	}
 
 	if len(providers) == 0 {
-		k8s, err := clients.Kubernetes()
+		k8s, err := clients.Kubernetes(log)
 		if err != nil {
 			return nil, err
 		}
@@ -171,7 +171,7 @@ func CreateApp() App {
 	app.log.Debug("Connecting Dao")
 	app.dao, err = dao.NewDao(app.config.Dao, app.log.Logger)
 
-	k8scli, err := clients.Kubernetes()
+	k8scli, err := clients.Kubernetes(app.log.Logger)
 	if err != nil {
 		app.log.Error(err.Error())
 		os.Exit(1)
@@ -390,7 +390,7 @@ func initClients(log *logging.Logger, ec clients.EtcdConfig) error {
 	log.Info("Etcd Version [Server: %s, Cluster: %s]", version.Server, version.Cluster)
 
 	log.Debug("Connecting to Cluster")
-	_, err = clients.Kubernetes()
+	_, err = clients.Kubernetes(log)
 	if err != nil {
 		return err
 	}
@@ -399,7 +399,7 @@ func initClients(log *logging.Logger, ec clients.EtcdConfig) error {
 }
 
 func retrieveClusterRoleRules(clusterRole string, log *logging.Logger) ([]rbac.PolicyRule, error) {
-	k8scli, err := clients.Kubernetes()
+	k8scli, err := clients.Kubernetes(log)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/app/config.go
+++ b/pkg/app/config.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"strings"
 
+	logging "github.com/op/go-logging"
 	"github.com/openshift/ansible-service-broker/pkg/apb"
 	"github.com/openshift/ansible-service-broker/pkg/broker"
 	"github.com/openshift/ansible-service-broker/pkg/clients"
@@ -128,7 +129,8 @@ func readFile(fileName string) (string, string, error) {
 }
 
 func readSecret(secretName string, namespace string) (string, string, error) {
-	k8s, err := clients.Kubernetes()
+	var log *logging.Logger
+	k8s, err := clients.Kubernetes(log)
 	if err != nil {
 		return "", "", err
 	}

--- a/pkg/clients/kubernetes.go
+++ b/pkg/clients/kubernetes.go
@@ -36,9 +36,8 @@ type KubernetesClient struct {
 }
 
 // Kubernetes - Create a new kubernetes client if needed, returns reference
-func Kubernetes() (*KubernetesClient, error) {
+func Kubernetes(log *logging.Logger) (*KubernetesClient, error) {
 	once.Kubernetes.Do(func() {
-		var log *logging.Logger
 		client, err := newKubernetes(log)
 		if err != nil {
 			log.Error(err.Error())

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -555,7 +555,7 @@ func (h handler) unbind(w http.ResponseWriter, r *http.Request, params map[strin
 }
 
 func isNamespaceDeleted(name string, log *logging.Logger) (bool, error) {
-	k8scli, err := clients.Kubernetes()
+	k8scli, err := clients.Kubernetes(log)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/registries/adapters/local_openshift_adapter.go
+++ b/pkg/registries/adapters/local_openshift_adapter.go
@@ -131,7 +131,7 @@ func (r LocalOpenShiftAdapter) loadSpec(yamlSpec []byte) (*apb.Spec, error) {
 }
 
 func (r LocalOpenShiftAdapter) getServiceIP(service string, namespace string) (string, error) {
-	k8s, err := clients.Kubernetes()
+	k8s, err := clients.Kubernetes(r.Log)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Revert a portion of the k8s struct patch. We need to pass the log object in for each call.