### PR TITLE
Few fixes to the local deploy templates

### DIFF
--- a/scripts/broker-ci/cleanup-ci.sh
+++ b/scripts/broker-ci/cleanup-ci.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-oc delete -f ./scripts/broker-ci/bind-mediawiki-postgresql.yaml
+oc delete -f ./templates/postgresql-mediawiki123-bind.yaml
 ./scripts/broker-ci/wait-for-resource.sh delete ServiceBinding mediawiki-postgresql-binding
-oc delete -f ./scripts/broker-ci/mediawiki123.yaml
-oc delete -f ./scripts/broker-ci/postgresql.yaml
+oc delete -f ./templates/mediawiki123.yaml
+oc delete -f ./templates/postgresql.yaml
 oc delete dc postgresql mediawiki123 -n default
 ./scripts/broker-ci/wait-for-resource.sh delete pod postgresql
 ./scripts/broker-ci/wait-for-resource.sh delete pod mediawiki

--- a/scripts/prep_local_devel_env.sh
+++ b/scripts/prep_local_devel_env.sh
@@ -167,10 +167,9 @@ done
 
 TERMINATION="reencrypt"
 
-kubectl delete deployment asb -n ${ASB_PROJECT}
-kubectl delete deployment asb-etcd -n ${ASB_PROJECT}
+cluster::deployments delete asb -n ${ASB_PROJECT}
+cluster::deployments delete asb-etcd -n ${ASB_PROJECT}
 kubectl delete endpoints asb -n ${ASB_PROJECT}
-kubectl delete service asb  -n ${ASB_PROJECT}
 cluster::routes delete asb-etcd -n ${ASB_PROJECT}
 kubectl delete service asb-etcd -n ${ASB_PROJECT}
 

--- a/templates/deploy-local-dev-changes.yaml
+++ b/templates/deploy-local-dev-changes.yaml
@@ -13,62 +13,54 @@ objects:
 - apiVersion: v1
   kind: Service
   metadata:
-    name: etcd
-    labels:
-      app: ansible-service-broker
-      service: etcd
+    name: asb-etcd
+    namespace: ansible-service-broker
   spec:
     ports:
       - name: etcd-advertise
         port: 2379
     selector:
-      app: ansible-service-broker
-      service: etcd
+      app: etcd
+      service: asb-etcd
 
-- apiVersion: extensions/v1beta1
-  kind: Deployment
+- apiVersion: v1
+  kind: DeploymentConfig
   metadata:
-    name: etcd
+    name: asb-etcd
+    namespace: ansible-service-broker
     labels:
-      app: ansible-service-broker
-      service: etcd
+      app: etcd
+      service: asb-etcd
   spec:
-    replicas: 1
-    selector:
-      matchLabels:
-        app: ansible-service-broker
-        service: etcd
     strategy:
-      rollingUpdate:
-        maxSurge: 1
-        maxUnavailable: 1
-      type: RollingUpdate
+      type: Recreate
+    replicas: 1
     template:
       metadata:
         labels:
-          app: ansible-service-broker
-          service: etcd
+          app: etcd
+          service: asb-etcd
       spec:
+        restartPolicy: Always
         containers:
-        - image: ${ETCD_IMAGE}
-          name: etcd
-          imagePullPolicy: IfNotPresent
-          terminationMessagePath: /tmp/termination-log
-          workingDir: /etcd
-          args:
-            - ${ETCD_PATH}
-            - --data-dir=/data
-            - --listen-client-urls=http://0.0.0.0:2379
-            - --advertise-client-urls=http://0.0.0.0:2379
-          ports:
-          - containerPort: 2379
-            protocol: TCP
-          env:
-          - name: ETCDCTL_API
-            value: "3"
-          volumeMounts:
-            - mountPath: /data
-              name: etcd
+          - image: "quay.io/coreos/etcd:latest"
+            name: main
+            imagePullPolicy: IfNotPresent
+            workingDir: /etcd
+            args:
+              - /usr/local/bin/etcd
+              - --data-dir=/data
+              - --listen-client-urls=http://0.0.0.0:2379
+              - --advertise-client-urls=http://0.0.0.0:2379
+            ports:
+            - containerPort: 2379
+              protocol: TCP
+            env:
+            - name: ETCDCTL_API
+              value: "3"
+            volumeMounts:
+              - mountPath: /data
+                name: etcd
         volumes:
           - name: etcd
             persistentVolumeClaim:
@@ -84,7 +76,7 @@ objects:
   spec:
     to:
       kind: Service
-      name: etcd
+      name: asb-etcd
     port:
       targetPort: ${ETCD_TARGET_PORT}
 
@@ -108,44 +100,22 @@ objects:
   kind: Endpoints
   metadata:
     labels:
-      app: ansible-service-broker
-      service: asb
+      app: etcd
+      service: asb-etcd
     name: asb
   subsets:
   - addresses:
     - ip: ${BROKER_IP_ADDR}
     ports:
-    - name: port-${BROKER_PORT}
-      port: ${BROKER_PORT}
+    - name: port-1338
+      port: 1338
       protocol: TCP
-
-- apiVersion: v1
-  kind: Service
-  metadata:
-    labels:
-      app: ansible-service-broker
-      service: asb
-    name: asb
-  spec:
-    ports:
-    -
-      name: port-${BROKER_PORT}
-      port: ${BROKER_PORT}
-      protocol: TCP
-      #targetPort: ${BROKER_PORT}
-      nodePort: 0
-  selector: {}
 
 parameters:
 - description: Name of the etcd target port to connect to
   displayname: ETCD_TARGET_PORT
   name: ETCD_TARGET_PORT
   value: etcd-advertise
-
-- description: Brokers port
-  displayname: BROKER_PORT
-  name: BROKER_PORT
-  value: "1338"
 
 - description: Brokers IP Address
   displayname: BROKER_IP_ADDR

--- a/templates/k8s-local-dev-changes.yaml
+++ b/templates/k8s-local-dev-changes.yaml
@@ -1,23 +1,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-   name: asb
-   namespace: ansible-service-broker
-   labels:
-     app: ansible-service-broker
-     service: asb
-spec:
-  ports:
-    - name: port-1338
-      port: 1338
-      targetPort: 1338
-      protocol: TCP
-  selector: {}
-
----
-apiVersion: v1
-kind: Service
-metadata:
    name: asb-etcd
    namespace: ansible-service-broker
 spec:


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
A bunch of fixes when running locally.

Changes proposed in this pull request
 - Deleting the asb service causes issues. The service-ca (asb-tls) gets deleting causing later prep_local_dev_env runs to fail and the catalog fails to connect to the broker.
 - Use the proper path when deleting ci resources
 - Use a deployment config for asb-etcd
 - Point the asb-etcd resources at the etcd app and service
 - Remove the BROKER_PORT variable since it was causing an issue with template rendering and isn't needed


**Does this PR depend on another PR (Use this to track when PRs should be merged)**
depends-on <PR>

**Which issue this PR fixes (This will close that issue when PR gets merged)**
fixes <issue_number>
