### PR TITLE
Docker should use the systemd cgroup driver on systemd systems

### DIFF
--- a/scripts/broker-ci/setup-cluster.sh
+++ b/scripts/broker-ci/setup-cluster.sh
@@ -6,7 +6,10 @@ set -ex
 broker_travis_job=$1
 
 function cluster-setup () {
-    git clone https://github.com/fusor/catasb
+    git clone https://github.com/shawn-hurley/catasb
+    pushd catasb
+    git checkout fix-mac-cgroup
+    popd
 
     cat <<EOF > "catasb/config/my_vars.yml"
 ---


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
Ubuntu 16.04 has systemd and should use systemd as the docker cgroup driver.

Gate Testing.
