### PR TITLE
Adding ability to warn and filter out bad specs.

### DIFF
--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -516,7 +516,12 @@ func (a AnsibleBroker) Catalog() (*CatalogResponse, error) {
 
 	services = make([]Service, len(specs))
 	for i, spec := range specs {
-		services[i] = SpecToService(spec)
+		ser, err := SpecToService(spec)
+		if err != nil {
+			a.log.Debugf("no adding spec to list of services due to error transforming to service - %v", err)
+		} else {
+			services[i] = ser
+		}
 	}
 
 	return &CatalogResponse{services}, nil
@@ -1321,7 +1326,11 @@ func (a AnsibleBroker) AddSpec(spec apb.Spec) (*CatalogResponse, error) {
 		return nil, err
 	}
 	apb.AddSecretsFor(&spec)
-	service := SpecToService(&spec)
+	service, err := SpecToService(&spec)
+	if err != nil {
+		a.log.Debugf("spec was not added due to issue with transformation to serivce - %v", err)
+		return nil, err
+	}
 	metrics.SpecsLoaded(apbPushRegName, 1)
 	return &CatalogResponse{Services: []Service{service}}, nil
 }

--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -518,7 +518,7 @@ func (a AnsibleBroker) Catalog() (*CatalogResponse, error) {
 	for i, spec := range specs {
 		ser, err := SpecToService(spec)
 		if err != nil {
-			a.log.Debugf("no adding spec to list of services due to error transforming to service - %v", err)
+			a.log.Errorf("not adding spec to list of services due to error transforming to service - %v", err)
 		} else {
 			services[i] = ser
 		}

--- a/pkg/broker/util_test.go
+++ b/pkg/broker/util_test.go
@@ -113,7 +113,7 @@ var p = apb.Plan{
 
 func TestEnumIsCopied(t *testing.T) {
 
-	schemaObj := parametersToSchema(p)
+	schemaObj, _ := parametersToSchema(p)
 
 	emailParam := schemaObj.ServiceInstance.Create["parameters"].Properties["email_address"]
 	ft.AssertEqual(t, len(emailParam.Enum), 2, "enum mismatch")
@@ -124,7 +124,7 @@ func TestEnumIsCopied(t *testing.T) {
 
 func TestEnumIsCopiedForUpdate(t *testing.T) {
 
-	schemaObj := parametersToSchema(p)
+	schemaObj, _ := parametersToSchema(p)
 
 	emailParam := schemaObj.ServiceInstance.Update["parameters"].Properties["email_address"]
 	ft.AssertEqual(t, len(emailParam.Enum), 2, "enum mismatch")
@@ -162,7 +162,7 @@ func TestSpecToService(t *testing.T) {
 		Metadata:    descriptors,
 	}
 
-	svc := SpecToService(&spec)
+	svc, _ := SpecToService(&spec)
 
 	ft.AssertEqual(t, svc.Name, expectedsvc.Name, "name is not equal")
 	ft.AssertEqual(t, svc.Description, expectedsvc.Description, "description is not equal")
@@ -270,7 +270,7 @@ func TestParametersToSchema(t *testing.T) {
 	if err = yaml.Unmarshal(decodedyaml, spec); err != nil {
 		t.Fatal(err)
 	}
-	schemaObj := parametersToSchema(spec.Plans[0])
+	schemaObj, _ := parametersToSchema(spec.Plans[0])
 
 	found := false
 	for k, p := range schemaObj.ServiceInstance.Create["parameters"].Properties {
@@ -301,7 +301,7 @@ func TestUpdateParametersToSchema(t *testing.T) {
 	if err = yaml.Unmarshal(decodedyaml, spec); err != nil {
 		t.Fatal(err)
 	}
-	schemaObj := parametersToSchema(spec.Plans[0])
+	schemaObj, _ := parametersToSchema(spec.Plans[0])
 
 	found := false
 	for k, p := range schemaObj.ServiceInstance.Create["parameters"].Properties {
@@ -390,7 +390,13 @@ func TestGetType(t *testing.T) {
 	// test
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("%s in type %s", tc.want, tc.jsonType), func(t *testing.T) {
-			ft.AssertTrue(t, getType(tc.jsonType).Contains(tc.want), "test failed")
+			ty, err := getType(tc.jsonType)
+			if tc.jsonType == "biteme" && err == nil {
+				t.Fatalf("unknown schema types should return an error")
+			} else if tc.jsonType == "biteme" && err != nil {
+				return
+			}
+			ft.AssertTrue(t, ty.Contains(tc.want), "test failed")
 		})
 	}
 }


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
Will add debug messages when a type from an APB parameter is not defined, and remove from the services for catalog.
Changes proposed in this pull request
 - add error handling to SpecToService

**Which issue this PR fixes (This will close that issue when PR gets merged)**
fixes #388 
