### PR TITLE
Identify the cluster in the NewRuntime call

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -201,6 +201,10 @@ func CreateApp() App {
 
 	app.log.Debug("Connecting Dao")
 	app.dao, err = dao.NewDao(app.config.Dao, app.log.Logger)
+	if err != nil {
+		app.log.Error(err.Error())
+		os.Exit(1)
+	}
 
 	app.log.Debug("Connecting Registry")
 	for _, r := range app.config.Registry {

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -17,13 +17,16 @@
 package runtime
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/openshift/ansible-service-broker/pkg/clients"
 	"github.com/openshift/ansible-service-broker/pkg/metrics"
 
 	logging "github.com/op/go-logging"
+	kapierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubeversiontypes "k8s.io/apimachinery/pkg/version"
 	apicorev1 "k8s.io/kubernetes/pkg/api/v1"
 	rbac "k8s.io/kubernetes/pkg/apis/rbac/v1beta1"
 )
@@ -52,7 +55,35 @@ type kubernetes struct{}
 
 // NewRuntime - Initialize provider variable
 func NewRuntime(log *logging.Logger) {
-	Provider = &provider{log: log}
+	k8scli, err := clients.Kubernetes(log)
+	if err != nil {
+		log.Error(err.Error())
+		panic(err.Error())
+	}
+
+	// Identify which cluster we're using
+	restclient := k8scli.Client.CoreV1().RESTClient()
+	body, err := restclient.Get().AbsPath("/version/openshift").Do().Raw()
+
+	var cluster coe
+	switch {
+	case err == nil:
+		var kubeServerInfo kubeversiontypes.Info
+		err = json.Unmarshal(body, &kubeServerInfo)
+		if err != nil && len(body) > 0 {
+			log.Error(err.Error())
+			panic(err.Error())
+		}
+		log.Info("OpenShift version: %v", kubeServerInfo)
+		cluster = openshift{}
+	case kapierrors.IsNotFound(err) || kapierrors.IsUnauthorized(err) || kapierrors.IsForbidden(err):
+		cluster = kubernetes{}
+	default:
+		log.Error(err.Error())
+		panic(err.Error())
+	}
+
+	Provider = &provider{log: log, coe: cluster}
 }
 
 // CreateSandbox - Translate the broker CreateSandbox call into cluster resource calls

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -75,15 +75,23 @@ func NewRuntime(log *logging.Logger) {
 			panic(err.Error())
 		}
 		log.Info("OpenShift version: %v", kubeServerInfo)
-		cluster = openshift{}
+		cluster = newOpenshift()
 	case kapierrors.IsNotFound(err) || kapierrors.IsUnauthorized(err) || kapierrors.IsForbidden(err):
-		cluster = kubernetes{}
+		cluster = newKubernetes()
 	default:
 		log.Error(err.Error())
 		panic(err.Error())
 	}
 
 	Provider = &provider{log: log, coe: cluster}
+}
+
+func newOpenshift() coe {
+	return openshift{}
+}
+
+func newKubernetes() coe {
+	return kubernetes{}
 }
 
 // CreateSandbox - Translate the broker CreateSandbox call into cluster resource calls

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -2,6 +2,11 @@ package runtime
 
 type fakeProvider struct{}
 
+func (f fakeProvider) ValidateRuntime() error {
+	//TODO: Write tests for ValidateRuntime using the fake kubernetes client
+	return nil
+}
+
 func (f fakeProvider) CreateSandbox(podName string, namespace string, targets []string, apbRole string) (string, error) {
 	//TODO: Write tests for CreateSandbox using the fake kubernetes client
 	return "", nil


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
Contact the openshift version endpoint to verfiy what cluster
the broker is running on.  If the openshift endpoint isn't present, the
broker is running on kubernetes.

Changes proposed in this pull request
 - Identify which cluster the broker is running on
