### PR TITLE
Make prep-local explicit and update docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,9 +103,6 @@ cd $GOPATH/src/github.com/openshift/ansible-service-broker
 make build
 ```
 
-Now you can [run your broker locally](#run-your-broker-locally) with `make run` or
-[package your broker using docker](#package-your-broker-using-docker) with `make build-image`.
-
 ## Package Your Broker Using Docker
 
 As stated above, you can also package your built Ansible Service Broker binary
@@ -164,9 +161,13 @@ cp scripts/my_local_dev_vars.example scripts/my_local_dev_vars
 Now you can modify `scripts/my_local_dev_vars` with things like your `DOCKERHUB_USERNAME`
 or use an insecure broker with `BROKER_INSECURE="true"`.
 
+It is possible to use an etcd instance running locally on your host instead
+of in-cluster. Simply set LOCAL_ETCD="true" in the my_local_dev_vars file,
+and the broker will point to an etcd at `localhost:2379`.
+
 **Prepare Local Environment**
 
-Running `make prepare-local-env` will do several things on your behalf:
+Running `make prep-local` will do several things on your behalf:
 
 * Remove the running `ansible-service-broker` from the cluster, leaving only
   `etcd` running in the namespace.
@@ -206,6 +207,11 @@ registry:
     pass: changeme
     org: example
 ```
+
+**NOTE**: It is important to explicitly run `make prep-local` every time a new
+cluster has been setup, like reseting a catasb cluster, for example. The reason
+is that the cluster's token/certs will have changed, so you will meed to `prep-local`
+again to extract them to your local filesystem.
 
 **Start the Broker**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -162,7 +162,7 @@ Now you can modify `scripts/my_local_dev_vars` with things like your `DOCKERHUB_
 or use an insecure broker with `BROKER_INSECURE="true"`.
 
 It is possible to use an etcd instance running locally on your host instead
-of in-cluster. Simply set LOCAL_ETCD="true" in the my_local_dev_vars file,
+of in-cluster. Simply set `LOCAL_ETCD="true"` in the my_local_dev_vars file,
 and the broker will point to an etcd at `localhost:2379`.
 
 **Prepare Local Environment**
@@ -209,8 +209,8 @@ registry:
 ```
 
 **NOTE**: It is important to explicitly run `make prep-local` every time a new
-cluster has been setup, like reseting a catasb cluster, for example. The reason
-is that the cluster's token/certs will have changed, so you will meed to `prep-local`
+cluster has been setup, like resetting a catasb cluster, for example. The reason
+is that the cluster's token/certs will have changed, so you will need to `prep-local`
 again to extract them to your local filesystem.
 
 **Start the Broker**

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ run: broker
 # /var/run/secrets/kubernetes.io/serviceaccount
 # Resetting a catasb cluster WILL generate new certs, so you will have to
 # run prep-local again to export the new certs.
-prep-local:
+prep-local: ## Prepares the local dev environment
 	@./scripts/prep_local_devel_env.sh
 
 build-image: ## Build a docker image with the broker binary
@@ -110,4 +110,4 @@ help: ## Show this help screen
 	@grep -E '^[ a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
 		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
-.PHONY: run build-image release-image release push clean deploy ci cleanup-ci lint build vendor fmt fmtcheck test vet help test-cover-html
+.PHONY: run build-image release-image release push clean deploy ci cleanup-ci lint build vendor fmt fmtcheck test vet help test-cover-html prep-local

--- a/Makefile
+++ b/Makefile
@@ -52,14 +52,16 @@ vet: ## Run go vet
 
 check: fmtcheck vet lint build test ## Pre-flight checks before creating PR
 
-run: broker | $(KUBERNETES_FILES) ## Run the broker locally, configure via etc/generated_local_development.yaml
+run: broker
 	@./scripts/run_local.sh ${BROKER_CONFIG}
 
-$(KUBERNETES_FILES):
+# NOTE: Must be explicitly run if you expect to be doing local development
+# Basically brings down the broker pod and extracts token/cert files to
+# /var/run/secrets/kubernetes.io/serviceaccount
+# Resetting a catasb cluster WILL generate new certs, so you will have to
+# run prep-local again to export the new certs.
+prep-local:
 	@./scripts/prep_local_devel_env.sh
-
-prepare-local-env: $(KUBERNETES_FILES) ## Prepare the local environment for running the broker locally
-	@echo > /dev/null
 
 build-image: ## Build a docker image with the broker binary
 	env GOOS=linux go build -i -ldflags="-s -s" -o ${BUILD_DIR}/broker ./cmd/broker


### PR DESCRIPTION
**Describe what this PR does and why we need it**:

I was continually running into unexpected behavior while resetting my catasb. Turns out the certs / tokens were getting regenerated in the cluster but were not being exported on my `make run`s because the files already existed.

I believe local developers should have an explicit "prep-local" target designed to setup a local environment with exported credentials, and a separate "make run" that is as thin as possible to facilitate rapid development iteration and testing.
