### PR TITLE
Bug 1525817 - remove duplicate help output and return 0 exit code.

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -37,6 +37,7 @@ import (
 	authenticationclient "k8s.io/client-go/kubernetes/typed/authentication/v1beta1"
 	"k8s.io/kubernetes/pkg/apis/rbac"
 
+	"github.com/jessevdk/go-flags"
 	"github.com/openshift/ansible-service-broker/pkg/apb"
 	"github.com/openshift/ansible-service-broker/pkg/auth"
 	"github.com/openshift/ansible-service-broker/pkg/broker"
@@ -139,7 +140,11 @@ func CreateApp() App {
 
 	// Writing directly to stderr because log has not been bootstrapped
 	if app.args, err = CreateArgs(); err != nil {
-		os.Exit(1)
+		if flagsErr, ok := err.(*flags.Error); ok && flagsErr.Type == flags.ErrHelp {
+			os.Exit(0)
+		} else {
+			os.Exit(1)
+		}
 	}
 
 	if app.args.Version {

--- a/pkg/app/args.go
+++ b/pkg/app/args.go
@@ -17,12 +17,10 @@
 package app
 
 import (
-	"fmt"
-
 	flags "github.com/jessevdk/go-flags"
 )
 
-// Args - Command line arguments for the ansbile service broker.
+// Args - Command line arguments for the ansible service broker.
 type Args struct {
 	ConfigFile string `short:"c" long:"config" description:"Config File" default:"/etc/ansible-service-broker/config.yaml"`
 	Version    bool   `short:"v" long:"version" description:"Print version information"`
@@ -34,7 +32,6 @@ func CreateArgs() (Args, error) {
 
 	_, err := flags.Parse(&args)
 	if err != nil {
-		fmt.Printf("err - %v", err)
 		return args, err
 	}
 	return args, nil


### PR DESCRIPTION
`asbd --help` was showing help once and then again as an error.  All errors were printing twice.  I remove the extra println to remove the duplicate and return a 0 exit code if the command arg `--help` was used.

![screenshot from 2017-12-14 11-40-34](https://user-images.githubusercontent.com/1448375/34003748-10b03c74-e0c4-11e7-8e28-57b1966b9fd1.png)


