### PR TITLE
allows parameter types to be case-insensitive

### DIFF
--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -458,7 +458,7 @@ func (a AnsibleBroker) Catalog() (*CatalogResponse, error) {
 	for i, spec := range specs {
 		ser, err := SpecToService(spec)
 		if err != nil {
-			log.Errorf("not adding spec to list of services due to error transforming to service - %v", err)
+			log.Errorf("not adding spec %v to list of services due to error transforming to service - %v", spec.FQName, err)
 		} else {
 			services[i] = ser
 		}

--- a/pkg/broker/util.go
+++ b/pkg/broker/util.go
@@ -19,6 +19,7 @@ package broker
 import (
 	"fmt"
 	"regexp"
+	"strings"
 
 	"encoding/json"
 
@@ -196,7 +197,7 @@ func createUIFormItem(pd apb.ParameterDescriptor, paramIndex int) (interface{}, 
 
 // getType transforms an apb parameter type to a JSON Schema type
 func getType(paramType string) (schema.PrimitiveTypes, error) {
-	switch paramType {
+	switch strings.ToLower(paramType) {
 	case "string", "enum":
 		return []schema.PrimitiveType{schema.StringType}, nil
 	case "int":

--- a/pkg/broker/util_test.go
+++ b/pkg/broker/util_test.go
@@ -375,6 +375,8 @@ func TestGetType(t *testing.T) {
 		want     schema.PrimitiveType
 	}{
 		{"string", schema.StringType},
+		{"STRING", schema.StringType},
+		{"String", schema.StringType},
 		{"enum", schema.StringType},
 		{"int", schema.IntegerType},
 		{"object", schema.ObjectType},


### PR DESCRIPTION
The error message when failing to parse a spec is improved to include the name
of the spec.

fixes #592 