### PR TITLE
Adding local openshift adapter

### DIFF
--- a/templates/deploy-ansible-service-broker.template.yaml
+++ b/templates/deploy-ansible-service-broker.template.yaml
@@ -298,6 +298,11 @@ objects:
           tag: "${TAG}"
           white_list:
             - ".*-apb$"
+        - type: local_openshift
+          name: localregistry
+          namespaces: ['openshift']
+          white_list:
+            - ".*-apb$"
       dao:
         etcd_host: asb-etcd.${NAMESPACE}.svc
         etcd_port: 2379


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
The PR adds the local openshift adapter to the template.

Problem is, with the `master` version of the `templates/deploy-ansible-service-broker.template.yaml`, and the `scripts/run_latest_build.sh` files, it is not possible to perform an `apb push` (with latest apb-tools).

The call succeeds, but the apb is not added.

On IRC @shawn-hurley told me that it's because I dont have the local openshift adapter. 

So I am adding it here

Changes proposed in this pull request
 - adding local openshift adapter to the template

**Does this PR depend on another PR (Use this to track when PRs should be merged)**
depends-on <PR>

nope

**Which issue this PR fixes (This will close that issue when PR gets merged)**
fixes <issue_number>
