### PR TITLE
Remove the different job msg types to avoid duplication of code

### DIFF
--- a/pkg/broker/deprovision_job.go
+++ b/pkg/broker/deprovision_job.go
@@ -17,8 +17,6 @@
 package broker
 
 import (
-	"encoding/json"
-
 	"github.com/openshift/ansible-service-broker/pkg/apb"
 	"github.com/openshift/ansible-service-broker/pkg/dao"
 	"github.com/openshift/ansible-service-broker/pkg/metrics"
@@ -29,21 +27,6 @@ type DeprovisionJob struct {
 	serviceInstance  *apb.ServiceInstance
 	skipApbExecution bool
 	dao              *dao.Dao
-}
-
-// DeprovisionMsg - Message returned for a deprovison job.
-type DeprovisionMsg struct {
-	InstanceUUID string `json:"instance_uuid"`
-	PodName      string `json:"podname"`
-	JobToken     string `json:"job_token"`
-	SpecID       string `json:"spec_id"`
-	Error        string `json:"error"`
-}
-
-// Render - render the message
-func (m DeprovisionMsg) Render() string {
-	render, _ := json.Marshal(m)
-	return string(render)
 }
 
 // NewDeprovisionJob - Create a deprovision job.
@@ -63,7 +46,7 @@ func (p *DeprovisionJob) Run(token string, msgBuffer chan<- WorkMsg) {
 
 	if p.skipApbExecution {
 		log.Debug("skipping deprovision and sending complete msg to channel")
-		msgBuffer <- DeprovisionMsg{InstanceUUID: p.serviceInstance.ID.String(), PodName: "",
+		msgBuffer <- JobMsg{InstanceUUID: p.serviceInstance.ID.String(), PodName: "",
 			JobToken: token, SpecID: p.serviceInstance.Spec.ID, Error: ""}
 		return
 	}
@@ -72,12 +55,12 @@ func (p *DeprovisionJob) Run(token string, msgBuffer chan<- WorkMsg) {
 	if err != nil {
 		log.Error("broker::Deprovision error occurred.")
 		log.Errorf("%s", err.Error())
-		msgBuffer <- DeprovisionMsg{InstanceUUID: p.serviceInstance.ID.String(), PodName: podName,
+		msgBuffer <- JobMsg{InstanceUUID: p.serviceInstance.ID.String(), PodName: podName,
 			JobToken: token, SpecID: p.serviceInstance.Spec.ID, Error: err.Error()}
 		return
 	}
 
 	log.Debug("sending deprovision complete msg to channel")
-	msgBuffer <- DeprovisionMsg{InstanceUUID: p.serviceInstance.ID.String(), PodName: podName,
+	msgBuffer <- JobMsg{InstanceUUID: p.serviceInstance.ID.String(), PodName: podName,
 		JobToken: token, SpecID: p.serviceInstance.Spec.ID, Error: ""}
 }

--- a/pkg/broker/deprovision_subscriber.go
+++ b/pkg/broker/deprovision_subscriber.go
@@ -43,7 +43,7 @@ func (d *DeprovisionWorkSubscriber) Subscribe(msgBuffer <-chan WorkMsg) {
 		log.Info("Listening for deprovision messages")
 		for {
 			msg := <-msgBuffer
-			var dmsg *DeprovisionMsg
+			var dmsg *JobMsg
 			metrics.DeprovisionJobFinished()
 
 			log.Debug("Processed deprovision message from buffer")
@@ -89,7 +89,7 @@ func (d *DeprovisionWorkSubscriber) Subscribe(msgBuffer <-chan WorkMsg) {
 	}()
 }
 
-func setFailedDeprovisionJob(dao *dao.Dao, dmsg *DeprovisionMsg) {
+func setFailedDeprovisionJob(dao *dao.Dao, dmsg *JobMsg) {
 	dao.SetState(dmsg.InstanceUUID, apb.JobState{
 		Token:   dmsg.JobToken,
 		State:   apb.StateFailed,

--- a/pkg/broker/provision_job.go
+++ b/pkg/broker/provision_job.go
@@ -28,22 +28,6 @@ type ProvisionJob struct {
 	serviceInstance *apb.ServiceInstance
 }
 
-// ProvisionMsg - Message to be returned from the provision job
-type ProvisionMsg struct {
-	InstanceUUID string `json:"instance_uuid"`
-	JobToken     string `json:"job_token"`
-	SpecID       string `json:"spec_id"`
-	PodName      string `json:"podname"`
-	Msg          string `json:"msg"`
-	Error        string `json:"error"`
-}
-
-// Render - Display the provision message.
-func (m ProvisionMsg) Render() string {
-	render, _ := json.Marshal(m)
-	return string(render)
-}
-
 // NewProvisionJob - Create a new provision job.
 func NewProvisionJob(serviceInstance *apb.ServiceInstance) *ProvisionJob {
 	return &ProvisionJob{
@@ -63,7 +47,7 @@ func (p *ProvisionJob) Run(token string, msgBuffer chan<- WorkMsg) {
 		// send error message
 		// can't have an error type in a struct you want marshalled
 		// https://github.com/golang/go/issues/5161
-		msgBuffer <- ProvisionMsg{InstanceUUID: p.serviceInstance.ID.String(),
+		msgBuffer <- JobMsg{InstanceUUID: p.serviceInstance.ID.String(),
 			JobToken: token, SpecID: p.serviceInstance.Spec.ID, PodName: "", Msg: "", Error: err.Error()}
 		return
 	}
@@ -71,11 +55,11 @@ func (p *ProvisionJob) Run(token string, msgBuffer chan<- WorkMsg) {
 	// send creds
 	jsonmsg, err := json.Marshal(extCreds)
 	if err != nil {
-		msgBuffer <- ProvisionMsg{InstanceUUID: p.serviceInstance.ID.String(),
+		msgBuffer <- JobMsg{InstanceUUID: p.serviceInstance.ID.String(),
 			JobToken: token, SpecID: p.serviceInstance.Spec.ID, PodName: "", Msg: "", Error: err.Error()}
 		return
 	}
 
-	msgBuffer <- ProvisionMsg{InstanceUUID: p.serviceInstance.ID.String(),
+	msgBuffer <- JobMsg{InstanceUUID: p.serviceInstance.ID.String(),
 		JobToken: token, SpecID: p.serviceInstance.Spec.ID, PodName: podName, Msg: string(jsonmsg), Error: ""}
 }

--- a/pkg/broker/provision_subscriber.go
+++ b/pkg/broker/provision_subscriber.go
@@ -43,7 +43,7 @@ func (p *ProvisionWorkSubscriber) Subscribe(msgBuffer <-chan WorkMsg) {
 		log.Info("Listening for provision messages")
 		for {
 			msg := <-msgBuffer
-			var pmsg *ProvisionMsg
+			var pmsg *JobMsg
 			var extCreds *apb.ExtractedCredentials
 			metrics.ProvisionJobFinished()
 

--- a/pkg/broker/types.go
+++ b/pkg/broker/types.go
@@ -17,6 +17,8 @@
 package broker
 
 import (
+	"encoding/json"
+
 	schema "github.com/lestrrat/go-jsschema"
 	"github.com/openshift/ansible-service-broker/pkg/apb"
 	"github.com/pborman/uuid"
@@ -240,4 +242,20 @@ type UserInfo struct {
 	UID      string              `json:"uid"`
 	Groups   []string            `json:"groups,omitempty"`
 	Extra    map[string][]string `json:"extra,omitempty"`
+}
+
+// JobMsg - Message to be returned from the various jobs
+type JobMsg struct {
+	InstanceUUID string `json:"instance_uuid"`
+	JobToken     string `json:"job_token"`
+	SpecID       string `json:"spec_id"`
+	PodName      string `json:"podname"`
+	Error        string `json:"error"`
+	Msg          string `json:"msg"`
+}
+
+// Render - Display the job message.
+func (jm JobMsg) Render() string {
+	render, _ := json.Marshal(jm)
+	return string(render)
 }

--- a/pkg/broker/update_job.go
+++ b/pkg/broker/update_job.go
@@ -28,22 +28,6 @@ type UpdateJob struct {
 	serviceInstance *apb.ServiceInstance
 }
 
-// UpdateMsg - Message to be returned from the update job
-type UpdateMsg struct {
-	InstanceUUID string `json:"instance_uuid"`
-	JobToken     string `json:"job_token"`
-	SpecID       string `json:"spec_id"`
-	PodName      string `json:"podname"`
-	Msg          string `json:"msg"`
-	Error        string `json:"error"`
-}
-
-// Render - Display the update message.
-func (m UpdateMsg) Render() string {
-	render, _ := json.Marshal(m)
-	return string(render)
-}
-
 // NewUpdateJob - Create a new update job.
 func NewUpdateJob(serviceInstance *apb.ServiceInstance) *UpdateJob {
 	return &UpdateJob{
@@ -63,7 +47,7 @@ func (u *UpdateJob) Run(token string, msgBuffer chan<- WorkMsg) {
 		// send error message
 		// can't have an error type in a struct you want marshalled
 		// https://github.com/golang/go/issues/5161
-		msgBuffer <- UpdateMsg{InstanceUUID: u.serviceInstance.ID.String(),
+		msgBuffer <- JobMsg{InstanceUUID: u.serviceInstance.ID.String(),
 			JobToken: token, SpecID: u.serviceInstance.Spec.ID, PodName: "", Msg: "", Error: err.Error()}
 		return
 	}
@@ -71,11 +55,11 @@ func (u *UpdateJob) Run(token string, msgBuffer chan<- WorkMsg) {
 	// send creds
 	jsonmsg, err := json.Marshal(extCreds)
 	if err != nil {
-		msgBuffer <- UpdateMsg{InstanceUUID: u.serviceInstance.ID.String(),
+		msgBuffer <- JobMsg{InstanceUUID: u.serviceInstance.ID.String(),
 			JobToken: token, SpecID: u.serviceInstance.Spec.ID, PodName: "", Msg: "", Error: err.Error()}
 		return
 	}
 
-	msgBuffer <- UpdateMsg{InstanceUUID: u.serviceInstance.ID.String(),
+	msgBuffer <- JobMsg{InstanceUUID: u.serviceInstance.ID.String(),
 		JobToken: token, SpecID: u.serviceInstance.Spec.ID, PodName: podName, Msg: string(jsonmsg), Error: ""}
 }

--- a/pkg/broker/update_subscriber.go
+++ b/pkg/broker/update_subscriber.go
@@ -43,7 +43,7 @@ func (u *UpdateWorkSubscriber) Subscribe(msgBuffer <-chan WorkMsg) {
 		log.Info("Listening for provision messages")
 		for {
 			msg := <-msgBuffer
-			var umsg *UpdateMsg
+			var umsg *JobMsg
 			var extCreds *apb.ExtractedCredentials
 			metrics.UpdateJobFinished()
 


### PR DESCRIPTION
**Describe what this PR does and why we need it**:

There were 3 different JobMsg types being used however they were all essentially the same barring one field and all consumers of the type were using the interface: WorkMsg 

Changes proposed in this pull request
 - remove the provisionmsg, deprovisionmsg and updatemsg type and replace them with a single jobmsg type

