### PR TITLE
Remove WorkMsg interface to avoid unneeded marshalling and unmarshalling

### DIFF
--- a/pkg/broker/deprovision_job.go
+++ b/pkg/broker/deprovision_job.go
@@ -41,7 +41,7 @@ func NewDeprovisionJob(serviceInstance *apb.ServiceInstance,
 }
 
 // Run - will run the deprovision job.
-func (p *DeprovisionJob) Run(token string, msgBuffer chan<- WorkMsg) {
+func (p *DeprovisionJob) Run(token string, msgBuffer chan<- JobMsg) {
 	metrics.DeprovisionJobStarted()
 
 	if p.skipApbExecution {

--- a/pkg/broker/provision_job.go
+++ b/pkg/broker/provision_job.go
@@ -36,7 +36,7 @@ func NewProvisionJob(serviceInstance *apb.ServiceInstance) *ProvisionJob {
 }
 
 // Run - run the provision job.
-func (p *ProvisionJob) Run(token string, msgBuffer chan<- WorkMsg) {
+func (p *ProvisionJob) Run(token string, msgBuffer chan<- JobMsg) {
 	metrics.ProvisionJobStarted()
 	podName, extCreds, err := apb.Provision(p.serviceInstance)
 

--- a/pkg/broker/update_job.go
+++ b/pkg/broker/update_job.go
@@ -36,7 +36,7 @@ func NewUpdateJob(serviceInstance *apb.ServiceInstance) *UpdateJob {
 }
 
 // Run - run the update job.
-func (u *UpdateJob) Run(token string, msgBuffer chan<- WorkMsg) {
+func (u *UpdateJob) Run(token string, msgBuffer chan<- JobMsg) {
 	metrics.UpdateJobStarted()
 	podName, extCreds, err := apb.Update(u.serviceInstance)
 

--- a/pkg/broker/work_engine.go
+++ b/pkg/broker/work_engine.go
@@ -24,18 +24,18 @@ import (
 
 // Work - is the interface that wraps the basic run method.
 type Work interface {
-	Run(token string, msgBuffer chan<- WorkMsg)
+	Run(token string, msgBuffer chan<- JobMsg)
 }
 
 // WorkEngine - a new engine for doing work.
 type WorkEngine struct {
-	topics map[WorkTopic]chan WorkMsg
+	topics map[WorkTopic]chan JobMsg
 	bufsz  int
 }
 
 // NewWorkEngine - creates a new work engine
 func NewWorkEngine(bufferSize int) *WorkEngine {
-	return &WorkEngine{topics: make(map[WorkTopic]chan WorkMsg), bufsz: bufferSize}
+	return &WorkEngine{topics: make(map[WorkTopic]chan JobMsg), bufsz: bufferSize}
 }
 
 // StartNewJob - Starts a job in an new goroutine, reporting to a specific topic.
@@ -57,7 +57,7 @@ func (engine *WorkEngine) StartNewJob(
 
 	msgBuffer, topicExists := engine.topics[topic]
 	if !topicExists {
-		msgBuffer = make(chan WorkMsg, engine.bufsz)
+		msgBuffer = make(chan JobMsg, engine.bufsz)
 		engine.topics[topic] = msgBuffer
 	}
 
@@ -66,7 +66,7 @@ func (engine *WorkEngine) StartNewJob(
 }
 
 // AttachSubscriber - Attach a subscriber a specific messaging topic.
-// Will send the WorkMsg to the subscribers through the message buffer.
+// Will send the JobMsg to the subscribers through the message buffer.
 func (engine *WorkEngine) AttachSubscriber(
 	subscriber WorkSubscriber, topic WorkTopic,
 ) error {
@@ -76,7 +76,7 @@ func (engine *WorkEngine) AttachSubscriber(
 
 	msgBuffer, topicExists := engine.topics[topic]
 	if !topicExists {
-		msgBuffer = make(chan WorkMsg, engine.bufsz)
+		msgBuffer = make(chan JobMsg, engine.bufsz)
 		engine.topics[topic] = msgBuffer
 	}
 
@@ -85,6 +85,6 @@ func (engine *WorkEngine) AttachSubscriber(
 }
 
 // GetActiveTopics - Get list of topics
-func (engine *WorkEngine) GetActiveTopics() map[WorkTopic]chan WorkMsg {
+func (engine *WorkEngine) GetActiveTopics() map[WorkTopic]chan JobMsg {
 	return engine.topics
 }

--- a/pkg/broker/work_engine_test.go
+++ b/pkg/broker/work_engine_test.go
@@ -30,21 +30,13 @@ func init() {
 }
 
 type mockSubscriber struct {
-	buffer <-chan WorkMsg
+	buffer <-chan JobMsg
 	called bool
 }
 
-func (ms *mockSubscriber) Subscribe(buffer <-chan WorkMsg) {
+func (ms *mockSubscriber) Subscribe(buffer <-chan JobMsg) {
 	ms.buffer = buffer
 	ms.called = true
-}
-
-type mockMsg struct {
-	msg string
-}
-
-func (mm mockMsg) Render() string {
-	return mm.msg
 }
 
 type mockWorker struct {
@@ -52,9 +44,9 @@ type mockWorker struct {
 	wg     *sync.WaitGroup
 }
 
-func (mw *mockWorker) Run(token string, buffer chan<- WorkMsg) {
+func (mw *mockWorker) Run(token string, buffer chan<- JobMsg) {
 	mw.called = true
-	buffer <- mockMsg{msg: "hello"}
+	buffer <- JobMsg{Msg: "hello"}
 	mw.wg.Done()
 }
 

--- a/pkg/broker/work_subscriber.go
+++ b/pkg/broker/work_subscriber.go
@@ -18,10 +18,5 @@ package broker
 
 // WorkSubscriber - Interface tha wraps the Subscribe method
 type WorkSubscriber interface {
-	Subscribe(msgBuffer <-chan WorkMsg)
-}
-
-// WorkMsg - Interface that wraps the Render method
-type WorkMsg interface {
-	Render() string
+	Subscribe(msgBuffer <-chan JobMsg)
 }


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
Removes the WorkMsg interface as it only seems to be used to marshal msgs into strings and then the subscribers unmarshal back again. Now that we only have one JobMsg type, this seems unnecessary. This PR also adds missing err checks within the subscribers. 
Changes proposed in this pull request
 - Remove WorkMsg interface and replace with JobMsg concrete type
 - Add missing err checks within the subscribers
 - remove unneeded unmarshalling within the subscribers

