### PR TITLE
The config should only use type as a key when name does not exist.

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -261,8 +261,7 @@ func createSubMapFromArray(val []interface{}) map[string]interface{} {
 				if n, ok := name.(string); ok {
 					subMap[n] = value
 				}
-			}
-			if t, ok := s["type"]; ok {
+			} else if t, ok := s["type"]; ok {
 				if tp, ok := t.(string); ok {
 					subMap[tp] = value
 				}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -192,3 +192,11 @@ func TestConfigGetSubMap(t *testing.T) {
 	ft.AssertTrue(t, testInvalidSubMap.Empty())
 	ft.AssertTrue(t, testNoNameArray.Empty())
 }
+
+func TestConfigGetMap(t *testing.T) {
+	testMap := config.GetSubConfig("registry").ToMap()
+	_, ok := testMap["dh"]
+	ft.AssertTrue(t, ok)
+	_, ok = testMap["dockerhub"]
+	ft.AssertFalse(t, ok)
+}

--- a/pkg/registries/registry.go
+++ b/pkg/registries/registry.go
@@ -180,7 +180,6 @@ func (r Registry) RegistryName() string {
 
 // NewRegistry - Create a new registry from the registry config.
 func NewRegistry(con *config.Config) (Registry, error) {
-	log.Debugf("configu - %#v", con)
 	var adapter adapters.Adapter
 	configuration := Config{
 		URL:        con.GetString("url"),


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
This fixes a bug in the configuration package that caused multiple registries to be initialized.
Changes proposed in this pull request
 - make it so that you don't use both keys of name and type, but rather name then type.
- remove debug statement that should be removed.

**Which issue this PR fixes (This will close that issue when PR gets merged)**
fixes #605 
