### PR TITLE
Bug 1512042 - Allowing error messages to make it from apb to user.

### DIFF
--- a/pkg/apb/provision_or_update.go
+++ b/pkg/apb/provision_or_update.go
@@ -74,7 +74,7 @@ func provisionOrUpdate(method executionMethod,
 		clusterConfig.KeepNamespaceOnError,
 	)
 	if err != nil {
-		log.Errorf("Problem executing apb [%s] provision", executionContext.PodName)
+		log.Errorf("Problem executing apb [%s] provision - err: %v ", executionContext.PodName, err)
 		return executionContext.PodName, nil, err
 	}
 

--- a/pkg/apb/types.go
+++ b/pkg/apb/types.go
@@ -138,6 +138,7 @@ type JobState struct {
 	State   State     `json:"state"`
 	Podname string    `json:"podname"`
 	Method  JobMethod `json:"method"`
+	Error   string    `json:"error"`
 }
 
 // ClusterConfig - Configuration for the cluster.

--- a/pkg/apb/watch_pod.go
+++ b/pkg/apb/watch_pod.go
@@ -52,7 +52,7 @@ func watchPod(podName string, namespace string) error {
 
 		switch podStatus.Phase {
 		case apiv1.PodFailed:
-			if errorPullingImage(podStatus.Conditions) {
+			if errorPullingImage(podStatus.ContainerStatuses) {
 				return ErrorPodPullErr
 			}
 			return fmt.Errorf("Pod [ %s ] failed - %v", podName, podStatus.Message)
@@ -69,11 +69,22 @@ func watchPod(podName string, namespace string) error {
 	return fmt.Errorf("Timed out while watching pod %s for completion", podName)
 }
 
-func errorPullingImage(conds []apiv1.PodCondition) bool {
-	for _, cond := range conds {
-		if cond.Reason == "ErrImgPull" {
-			return true
-		}
+func errorPullingImage(conds []apiv1.ContainerStatus) bool {
+	if len(conds) < 1 {
+		log.Warningf("unable to get container status for APB pod")
+		return false
 	}
+	// We should expect only a single container for our APB pod.
+	// If this assumption changes then we may need to update this code.
+	// Basis for the image strings is here:
+	// https://github.com/kubernetes/kubernetes/blob/886e04f1fffbb04faf8a9f9ee141143b2684ae68/pkg/kubelet/images/types.go#L27
+	status := conds[0].State.Waiting
+
+	if status.Reason == "ErrImagePull" {
+		return true
+	} else if status.Reason == "ImagePullBackOff" {
+		return true
+	}
+
 	return false
 }

--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -454,13 +454,13 @@ func (a AnsibleBroker) Catalog() (*CatalogResponse, error) {
 		return nil, err
 	}
 
-	services = make([]Service, len(specs))
-	for i, spec := range specs {
+	services = []Service{}
+	for _, spec := range specs {
 		ser, err := SpecToService(spec)
 		if err != nil {
 			log.Errorf("not adding spec %v to list of services due to error transforming to service - %v", spec.FQName, err)
 		} else {
-			services[i] = ser
+			services = append(services, ser)
 		}
 	}
 
@@ -1251,7 +1251,10 @@ func (a AnsibleBroker) LastOperation(instanceUUID uuid.UUID, req *LastOperationR
 
 	state := StateToLastOperation(jobstate.State)
 	log.Debugf("state: %s", state)
-	return &LastOperationResponse{State: state, Description: ""}, err
+	if jobstate.Error == "" {
+		log.Debugf("job state has an error. Assuming that any error here is human readable. err - %v", jobstate.Error)
+	}
+	return &LastOperationResponse{State: state, Description: jobstate.Error}, err
 }
 
 // AddSpec - adding the spec to the catalog for local development

--- a/pkg/broker/deprovision_subscriber.go
+++ b/pkg/broker/deprovision_subscriber.go
@@ -91,6 +91,7 @@ func setFailedDeprovisionJob(dao *dao.Dao, dmsg JobMsg) {
 		State:   apb.StateFailed,
 		Podname: dmsg.PodName,
 		Method:  apb.JobMethodDeprovision,
+		Error:   dmsg.Error,
 	}); err != nil {
 		log.Errorf("failed to set state after deprovision %#v", err)
 	}

--- a/pkg/broker/provision_job.go
+++ b/pkg/broker/provision_job.go
@@ -44,11 +44,26 @@ func (p *ProvisionJob) Run(token string, msgBuffer chan<- JobMsg) {
 		log.Error("broker::Provision error occurred.")
 		log.Errorf("%s", err.Error())
 
-		// send error message
-		// can't have an error type in a struct you want marshalled
-		// https://github.com/golang/go/issues/5161
+		// Because we know the error we should return that error.
+		if err == apb.ErrorPodPullErr {
+			// send error message, can't have
+			// an error type in a struct you want marshalled
+			// https://github.com/golang/go/issues/5161
+			msgBuffer <- JobMsg{InstanceUUID: p.serviceInstance.ID.String(),
+				JobToken: token,
+				SpecID:   p.serviceInstance.Spec.ID,
+				PodName:  "",
+				Msg:      "",
+				Error:    err.Error()}
+			return
+		}
+		//Unkown error defaulting to generic message.
 		msgBuffer <- JobMsg{InstanceUUID: p.serviceInstance.ID.String(),
-			JobToken: token, SpecID: p.serviceInstance.Spec.ID, PodName: "", Msg: "", Error: err.Error()}
+			JobToken: token,
+			SpecID:   p.serviceInstance.Spec.ID,
+			PodName:  "",
+			Msg:      "",
+			Error:    "Error occured during provision. Please contact administrator if it presists."}
 		return
 	}
 

--- a/pkg/broker/provision_subscriber.go
+++ b/pkg/broker/provision_subscriber.go
@@ -55,6 +55,7 @@ func (p *ProvisionWorkSubscriber) Subscribe(msgBuffer <-chan JobMsg) {
 					State:   apb.StateFailed,
 					Podname: msg.PodName,
 					Method:  apb.JobMethodProvision,
+					Error:   msg.Error,
 				}); err != nil {
 					log.Errorf("failed to set state after provision %v", err)
 				}

--- a/pkg/broker/update_job.go
+++ b/pkg/broker/update_job.go
@@ -44,11 +44,26 @@ func (u *UpdateJob) Run(token string, msgBuffer chan<- JobMsg) {
 		log.Error("broker::Update error occurred.")
 		log.Errorf("%s", err.Error())
 
-		// send error message
-		// can't have an error type in a struct you want marshalled
-		// https://github.com/golang/go/issues/5161
+		// Because we know the error we should return that error.
+		if err == apb.ErrorPodPullErr {
+			// send error message, can't have
+			// an error type in a struct you want marshalled
+			// https://github.com/golang/go/issues/5161
+			msgBuffer <- JobMsg{InstanceUUID: u.serviceInstance.ID.String(),
+				JobToken: token,
+				SpecID:   u.serviceInstance.Spec.ID,
+				PodName:  "",
+				Msg:      "",
+				Error:    err.Error()}
+			return
+		}
+		//Unkown error defaulting to generic message.
 		msgBuffer <- JobMsg{InstanceUUID: u.serviceInstance.ID.String(),
-			JobToken: token, SpecID: u.serviceInstance.Spec.ID, PodName: "", Msg: "", Error: err.Error()}
+			JobToken: token,
+			SpecID:   u.serviceInstance.Spec.ID,
+			PodName:  "",
+			Msg:      "",
+			Error:    "Error occured during update. Please contact administrator if it presists."}
 		return
 	}
 

--- a/pkg/broker/update_subscriber.go
+++ b/pkg/broker/update_subscriber.go
@@ -55,6 +55,7 @@ func (u *UpdateWorkSubscriber) Subscribe(msgBuffer <-chan JobMsg) {
 					State:   apb.StateFailed,
 					Podname: msg.PodName,
 					Method:  apb.JobMethodUpdate,
+					Error:   msg.Error,
 				}); err != nil {
 					log.Errorf("failed to set state after update job msg received %v ", err)
 				}

--- a/pkg/registries/adapters/local_openshift_adapter.go
+++ b/pkg/registries/adapters/local_openshift_adapter.go
@@ -114,6 +114,13 @@ func (r LocalOpenShiftAdapter) FetchSpecs(imageNames []string) ([]*apb.Spec, err
 			namespace = nsList[1]
 		}
 		for _, ns := range r.Config.Namespaces {
+			// logging to warn users about the potential bug if
+			// the svc-acct does not have access to the namespace.
+			if ns != "openshift" {
+				r.Log.Warningf("You may not be able to load provision images from the namespace: %v.\n"+
+					"You should make sure that the namespace has given the permissions for the "+
+					"system:authenticated group.", ns)
+			}
 			if ns == namespace {
 				r.Log.Debugf("Image [%v] is in configured namespace [%v]. Adding to SpecList.", image.Name, ns)
 				specList = append(specList, spec)


### PR DESCRIPTION
* Make it so that job state holds errors from apb package
* Make it so de/provision/update/_job can get the error and handle correctly.
* make sure that the broker/handler handles the error and returns
* Warn when about permissions for specs that may not be pullable.

**Describe what this PR does and why we need it**:
Fixes bug 1512042 by adding more explicit warning logs and handing errors back to the user.


**Which issue this PR fixes (This will close that issue when PR gets merged)**
Bug 1512042
