### PR TITLE
Bug 1526887 - Handle case when whitelist/blacklist set to ""

### DIFF
--- a/pkg/registries/filter.go
+++ b/pkg/registries/filter.go
@@ -17,7 +17,6 @@
 package registries
 
 import (
-	"fmt"
 	"regexp"
 	"sync"
 )
@@ -82,7 +81,6 @@ func compileRegexp(regexStrs []string) ([]*regexp.Regexp, []failedRegexp) {
 func (f *Filter) Run(totalList []string) ([]string, []string) {
 	filterMode := f.getFilterMode()
 	if filterMode == filterModeNone {
-		fmt.Printf("!!!!!!filter mode is none")
 		return nil, totalList
 	}
 

--- a/pkg/registries/filter.go
+++ b/pkg/registries/filter.go
@@ -62,7 +62,7 @@ func compileRegexp(regexStrs []string) ([]*regexp.Regexp, []failedRegexp) {
 
 	for _, str := range regexStrs {
 		if str == "" {
-			log.Debugf("ignoring empty string that was set as regex string")
+			log.Debugf("Ignoring empty whitelist or blacklist regex.")
 			continue
 		}
 		cr, err := regexp.Compile(str)

--- a/pkg/registries/filter.go
+++ b/pkg/registries/filter.go
@@ -62,6 +62,10 @@ func compileRegexp(regexStrs []string) ([]*regexp.Regexp, []failedRegexp) {
 	failedRegexps := []failedRegexp{}
 
 	for _, str := range regexStrs {
+		if str == "" {
+			log.Debugf("ignoring empty string that was set as regex string")
+			continue
+		}
 		cr, err := regexp.Compile(str)
 		if err != nil {
 			failedRegexps = append(failedRegexps, failedRegexp{str, err})
@@ -79,7 +83,7 @@ func (f *Filter) Run(totalList []string) ([]string, []string) {
 	filterMode := f.getFilterMode()
 	if filterMode == filterModeNone {
 		fmt.Printf("!!!!!!filter mode is none")
-		return nil, nil
+		return nil, totalList
 	}
 
 	whiteMatchSet, blackMatchSet := genMatchSets(

--- a/pkg/registries/filter_test.go
+++ b/pkg/registries/filter_test.go
@@ -223,3 +223,36 @@ func TestBlackAndWhitelistNoOverride(t *testing.T) {
 	ft.AssertTrue(t, testSetEq(expectedFilteredNames, filteredNames))
 	ft.AssertTrue(t, testSetEq(expectedTotal, testNames()))
 }
+
+func TestOnlyWhitelistWithEmptyString(t *testing.T) {
+	filter := Filter{whitelist: []string{""},
+		blacklist: []string{}}
+	filter.Init()
+
+	log.Debugf("filter regex: %#v", filter.whiteRegexp)
+	log.Debugf("filter regex: %#v", filter.blackRegexp)
+
+	expectedFilteredNames := []string{
+		"totally-not-malicious-apb",
+		"malicious-bar-apb",
+		"specific-blacklist-apb",
+		// Not explicitly whitelisted, so should be filtered
+		"baz-apb",
+		"foobar-apb",
+		"legitimate-postgresql-apb",
+		"legitimate-mediawiki-apb",
+		"foo-apb",
+		"bar-apb",
+		"rhscl-postgresql-apb",
+	}
+
+	validNames, filteredNames := filter.Run(testNames())
+
+	expectedTotal := expectedFilteredNames
+	log.Debugf("validNames: %#v", validNames)
+	log.Debugf("filteredNames: %#v", filteredNames)
+	log.Debugf("expectedTotal: %#v", expectedTotal)
+	ft.AssertTrue(t, testSetEq(nil, validNames))
+	ft.AssertTrue(t, testSetEq(expectedFilteredNames, filteredNames))
+	ft.AssertTrue(t, testSetEq(expectedTotal, testNames()))
+}


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
Handles case when the yaml looks like
```yaml
registry:
...
    white_list:
       - ""
....
```
Changes proposed in this pull request
 - Test case for the use case
 - If block to ignore regex strings that are zero value or `""`

**Which issue this PR fixes (This will close that issue when PR gets merged)**
Bug 1526887
