### PR TITLE
Bug 1536629 - send job state and credentials from job

### DIFF
--- a/pkg/apb/types.go
+++ b/pkg/apb/types.go
@@ -329,3 +329,6 @@ type ExecutionContext struct {
 	Targets        []string
 	ProxyConfig    *ProxyConfig
 }
+
+// Provisioner defines a function that knows how to provision an apb
+type Provisioner func(si *ServiceInstance) (string, *ExtractedCredentials, error)

--- a/pkg/apb/types.go
+++ b/pkg/apb/types.go
@@ -332,3 +332,9 @@ type ExecutionContext struct {
 
 // Provisioner defines a function that knows how to provision an apb
 type Provisioner func(si *ServiceInstance) (string, *ExtractedCredentials, error)
+
+// Binder defines a function that knows how to perform a binding
+type Binder func(si *ServiceInstance, params *Parameters) (string, *ExtractedCredentials, error)
+
+// UnBinder defines a function that knows how to perform a unbinding
+type UnBinder func(si *ServiceInstance, params *Parameters) error

--- a/pkg/broker/binding_job_test.go
+++ b/pkg/broker/binding_job_test.go
@@ -1,0 +1,124 @@
+package broker_test
+
+import (
+	"testing"
+
+	"time"
+
+	"fmt"
+
+	"github.com/openshift/ansible-service-broker/pkg/apb"
+	"github.com/openshift/ansible-service-broker/pkg/broker"
+	"github.com/pborman/uuid"
+)
+
+func TestBindingJob_Run(t *testing.T) {
+	instanceID := uuid.NewRandom()
+	bindingID := uuid.NewRandom()
+	serviceInstance := &apb.ServiceInstance{
+		ID: instanceID,
+		Spec: &apb.Spec{
+			ID: "test",
+		},
+	}
+	cases := []struct {
+		Name       string
+		Binder     apb.Binder
+		BindParams *apb.Parameters
+		Validate   func(msg broker.JobMsg) error
+	}{
+		{
+			Name: "expect a success msg with extracted credentials",
+			Binder: func(si *apb.ServiceInstance, params *apb.Parameters) (string, *apb.ExtractedCredentials, error) {
+				return "podName", &apb.ExtractedCredentials{Credentials: map[string]interface{}{
+					"user": "test",
+					"pass": "test",
+				}}, nil
+			},
+			Validate: func(msg broker.JobMsg) error {
+				if msg.State.State != apb.StateSucceeded {
+					return fmt.Errorf("expected the state to be %v but got %v", apb.StateSucceeded, msg.State.State)
+				}
+				if msg.State.Method != apb.JobMethodBind {
+					return fmt.Errorf("expected job method to be %v but it was %v", apb.JobMethodBind, msg.State.Method)
+				}
+				if msg.PodName == "" {
+					return fmt.Errorf("expected the podName to be set but it was empty")
+				}
+				credentials := msg.ExtractedCredentials.Credentials
+
+				if _, ok := credentials["user"]; !ok {
+					return fmt.Errorf("expected a user key in the credentials but it was missing")
+				}
+				if _, ok := credentials["pass"]; !ok {
+					return fmt.Errorf("expected a pass key in the credentials but it was missing")
+				}
+				return nil
+			},
+		},
+		{
+			Name: "expect failure state and generic error when unknown error type",
+			Binder: func(si *apb.ServiceInstance, params *apb.Parameters) (string, *apb.ExtractedCredentials, error) {
+				return "", nil, fmt.Errorf("should not see")
+			},
+			Validate: func(msg broker.JobMsg) error {
+				if msg.State.State != apb.StateFailed {
+					return fmt.Errorf("expected the Job to be in state %v but was in %v ", apb.StateFailed, msg.State.State)
+				}
+				if msg.State.Method != apb.JobMethodBind {
+					return fmt.Errorf("expected job method to be %v but it was %v", apb.JobMethodBind, msg.State.Method)
+				}
+				if msg.State.Error == "" {
+					return fmt.Errorf("expected an error in the job state but got none")
+				}
+				if msg.State.Error == "should not see" {
+					return fmt.Errorf("expected not to see the error msg %s it should have been replaced with a generic error ", msg.State.Error)
+				}
+				return nil
+			},
+		},
+		{
+			Name: "expect failure state and full error when known error type",
+			Binder: func(si *apb.ServiceInstance, params *apb.Parameters) (string, *apb.ExtractedCredentials, error) {
+				return "", nil, apb.ErrorPodPullErr
+			},
+			Validate: func(msg broker.JobMsg) error {
+				if msg.State.State != apb.StateFailed {
+					return fmt.Errorf("expected the Job to be in state %v but was in %v ", apb.StateFailed, msg.State.State)
+				}
+				if msg.State.Method != apb.JobMethodBind {
+					return fmt.Errorf("expected job method to be %v but it was %v", apb.JobMethodBind, msg.State.Method)
+				}
+				if msg.State.Error == "" {
+					return fmt.Errorf("expected an error in the job state but got none")
+				}
+				if msg.State.Error != apb.ErrorPodPullErr.Error() {
+					return fmt.Errorf("expected to see the error msg %s but got %s ", apb.ErrorPodPullErr, msg.State.Error)
+				}
+				return nil
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			bindingJob := broker.NewBindingJob(serviceInstance, bindingID, tc.BindParams, tc.Binder)
+			receiver := make(chan broker.JobMsg)
+			timedOut := false
+			time.AfterFunc(1*time.Second, func() {
+				close(receiver)
+				timedOut = true
+			})
+			go bindingJob.Run("", receiver)
+
+			msg := <-receiver
+			if timedOut {
+				t.Fatal("timed out waiting for a msg from the Job")
+			}
+			if err := tc.Validate(msg); err != nil {
+				t.Fatal("failed to validate the jobmsg ", err)
+			}
+
+		})
+	}
+}

--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -372,7 +372,7 @@ func (a AnsibleBroker) Recover() (string, error) {
 			var job Work
 			var topic WorkTopic
 			if rs.State.Method == apb.JobMethodProvision {
-				job = NewProvisionJob(instance)
+				job = NewProvisionJob(instance, apb.Provision)
 				topic = ProvisionTopic
 			} else if rs.State.Method == apb.JobMethodUpdate {
 				job = NewUpdateJob(instance)
@@ -647,7 +647,7 @@ func (a AnsibleBroker) Provision(instanceUUID uuid.UUID, req *ProvisionRequest, 
 	if async {
 		log.Info("ASYNC provisioning in progress")
 		// asyncronously provision and return the token for the lastoperation
-		pjob := NewProvisionJob(serviceInstance)
+		pjob := NewProvisionJob(serviceInstance, apb.Provision)
 
 		token, err = a.engine.StartNewJob("", pjob, ProvisionTopic)
 		if err != nil {

--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -931,7 +931,7 @@ func (a AnsibleBroker) Bind(instance apb.ServiceInstance, bindingUUID uuid.UUID,
 		// asynchronous mode, requires that the launch apb config
 		// entry is on, and that async comes in from the catalog
 		log.Info("ASYNC binding in progress")
-		bindjob := NewBindingJob(&instance, bindingUUID, &params)
+		bindjob := NewBindingJob(&instance, bindingUUID, &params, apb.Bind)
 
 		token, err = a.engine.StartNewJob("", bindjob, BindingTopic)
 		if err != nil {
@@ -1052,7 +1052,7 @@ func (a AnsibleBroker) Unbind(
 		// asynchronous mode, required that the launch apb config
 		// entry is on, and that async comes in from the catalog
 		log.Info("ASYNC unbinding in progress")
-		unbindjob := NewUnbindingJob(&serviceInstance, &bindInstance, &params, skipApbExecution)
+		unbindjob := NewUnbindingJob(&serviceInstance, &bindInstance, &params, apb.Unbind, skipApbExecution)
 		token, jerr = a.engine.StartNewJob("", unbindjob, UnbindingTopic)
 		if jerr != nil {
 			log.Error("Failed to start new job for async unbind\n%s", jerr.Error())

--- a/pkg/broker/deprovision_job.go
+++ b/pkg/broker/deprovision_job.go
@@ -43,42 +43,44 @@ func NewDeprovisionJob(serviceInstance *apb.ServiceInstance,
 // Run - will run the deprovision job.
 func (p *DeprovisionJob) Run(token string, msgBuffer chan<- JobMsg) {
 	metrics.DeprovisionJobStarted()
+	defer metrics.DeprovisionJobFinished()
+	jobMsg := JobMsg{
+		InstanceUUID: p.serviceInstance.ID.String(),
+		JobToken:     token,
+		SpecID:       p.serviceInstance.Spec.ID,
+		State: apb.JobState{
+			State:  apb.StateInProgress,
+			Method: apb.JobMethodDeprovision,
+			Token:  token,
+		},
+	}
 
 	if p.skipApbExecution {
 		log.Debug("skipping deprovision and sending complete msg to channel")
-		msgBuffer <- JobMsg{InstanceUUID: p.serviceInstance.ID.String(), PodName: "",
-			JobToken: token, SpecID: p.serviceInstance.Spec.ID, Error: ""}
+		jobMsg.State.State = apb.StateSucceeded
+		msgBuffer <- jobMsg
 		return
 	}
 
 	podName, err := apb.Deprovision(p.serviceInstance)
 	if err != nil {
-		log.Error("broker::Deprovision error occurred.")
-		log.Errorf("%s", err.Error())
+		log.Errorf("broker::Deprovision error occurred. %v", err)
+		errMsg := "Error occurred during deprovision. Please contact administrator if it persists."
 		// Because we know the error we should return that error.
 		if err == apb.ErrorPodPullErr {
-			// send error message, can't have
-			// an error type in a struct you want marshalled
-			// https://github.com/golang/go/issues/5161
-			msgBuffer <- JobMsg{InstanceUUID: p.serviceInstance.ID.String(),
-				JobToken: token,
-				SpecID:   p.serviceInstance.Spec.ID,
-				PodName:  "",
-				Msg:      "",
-				Error:    err.Error()}
-			return
+			errMsg = err.Error()
 		}
-		//Unkown error defaulting to generic message.
-		msgBuffer <- JobMsg{InstanceUUID: p.serviceInstance.ID.String(),
-			JobToken: token,
-			SpecID:   p.serviceInstance.Spec.ID,
-			PodName:  "",
-			Msg:      "",
-			Error:    "Error occured during deprovision. Please contact administrator if it presists."}
+		// send error message, can't have
+		// an error type in a struct you want marshalled
+		// https://github.com/golang/go/issues/5161
+		jobMsg.State.State = apb.StateFailed
+		jobMsg.State.Error = errMsg
+		msgBuffer <- jobMsg
 		return
 	}
 
 	log.Debug("sending deprovision complete msg to channel")
-	msgBuffer <- JobMsg{InstanceUUID: p.serviceInstance.ID.String(), PodName: podName,
-		JobToken: token, SpecID: p.serviceInstance.Spec.ID, Error: ""}
+	jobMsg.State.State = apb.StateSucceeded
+	jobMsg.PodName = podName
+	msgBuffer <- jobMsg
 }

--- a/pkg/broker/deprovision_subscriber.go
+++ b/pkg/broker/deprovision_subscriber.go
@@ -19,7 +19,6 @@ package broker
 import (
 	"github.com/openshift/ansible-service-broker/pkg/apb"
 	"github.com/openshift/ansible-service-broker/pkg/dao"
-	"github.com/openshift/ansible-service-broker/pkg/metrics"
 )
 
 // DeprovisionWorkSubscriber - Lissten for provision messages
@@ -36,18 +35,14 @@ func NewDeprovisionWorkSubscriber(dao *dao.Dao) *DeprovisionWorkSubscriber {
 // Subscribe - will start the work subscriber listenning on the message buffer for deprovision messages.
 func (d *DeprovisionWorkSubscriber) Subscribe(msgBuffer <-chan JobMsg) {
 	d.msgBuffer = msgBuffer
-
 	go func() {
 		log.Info("Listening for deprovision messages")
-		for {
-			msg := <-msgBuffer
-			metrics.DeprovisionJobFinished()
-			log.Debug("Processed deprovision message from buffer")
-
-			if msg.Error != "" {
-				// Job failed, mark failure
-				log.Errorf("Deprovision job reporting error: %s", msg.Error)
-				setFailedDeprovisionJob(d.dao, msg)
+		for msg := range msgBuffer {
+			log.Debug("received deprovision message from buffer")
+			if msg.State.State != apb.StateSucceeded {
+				if err := d.dao.SetState(msg.InstanceUUID, msg.State); err != nil {
+					log.Errorf("failed to set state after deprovision %v", err)
+				}
 				continue
 			}
 
@@ -60,40 +55,22 @@ func (d *DeprovisionWorkSubscriber) Subscribe(msgBuffer <-chan JobMsg) {
 				setFailedDeprovisionJob(d.dao, msg)
 				continue
 			}
-
-			// Job is not reporting error, cleanup after deprovision
-			err = cleanupDeprovision(instance, d.dao)
-			if err != nil {
-				log.Error("Failed cleaning up deprovision after job, error: %s", err.Error())
+			if err := cleanupDeprovision(instance, d.dao); err != nil {
+				log.Errorf("Failed cleaning up deprovision after job, error: %v", err)
 				// Cleanup is reporting something has gone wrong. Deprovision overall
 				// has not completed. Mark the job as failed.
 				setFailedDeprovisionJob(d.dao, msg)
 				continue
-			}
-
-			// No errors reported, deprovision action successfully performed and
-			// broker has successfully cleaned up. Mark depro success
-			if err := d.dao.SetState(msg.InstanceUUID, apb.JobState{
-				Token:   msg.JobToken,
-				State:   apb.StateSucceeded,
-				Podname: msg.PodName,
-				Method:  apb.JobMethodDeprovision,
-			}); err != nil {
-				log.Errorf("failed to set state after deprovision %#v", err)
 			}
 		}
 	}()
 }
 
 func setFailedDeprovisionJob(dao *dao.Dao, dmsg JobMsg) {
-	if err := dao.SetState(dmsg.InstanceUUID, apb.JobState{
-		Token:   dmsg.JobToken,
-		State:   apb.StateFailed,
-		Podname: dmsg.PodName,
-		Method:  apb.JobMethodDeprovision,
-		Error:   dmsg.Error,
-	}); err != nil {
-		log.Errorf("failed to set state after deprovision %#v", err)
+	// have to set the state here manually as the logic that triggers this is in the subscriber
+	dmsg.State.State = apb.StateFailed
+	if err := dao.SetState(dmsg.InstanceUUID, dmsg.State); err != nil {
+		log.Errorf("failed to set state after deprovision %v", err)
 	}
 }
 
@@ -102,12 +79,12 @@ func cleanupDeprovision(instance *apb.ServiceInstance, dao *dao.Dao) error {
 	id := instance.ID.String()
 
 	if err = dao.DeleteExtractedCredentials(id); err != nil {
-		log.Error("failed to delete extracted credentials - %#v", err)
+		log.Error("failed to delete extracted credentials - %v", err)
 		return err
 	}
 
 	if err = dao.DeleteServiceInstance(id); err != nil {
-		log.Error("failed to delete service instance - %#v", err)
+		log.Error("failed to delete service instance - %v", err)
 		return err
 	}
 

--- a/pkg/broker/deprovision_subscriber.go
+++ b/pkg/broker/deprovision_subscriber.go
@@ -39,10 +39,9 @@ func (d *DeprovisionWorkSubscriber) Subscribe(msgBuffer <-chan JobMsg) {
 		log.Info("Listening for deprovision messages")
 		for msg := range msgBuffer {
 			log.Debug("received deprovision message from buffer")
-			if msg.State.State != apb.StateSucceeded {
-				if err := d.dao.SetState(msg.InstanceUUID, msg.State); err != nil {
-					log.Errorf("failed to set state after deprovision %v", err)
-				}
+
+			if err := d.dao.SetState(msg.InstanceUUID, msg.State); err != nil {
+				log.Errorf("failed to set state after deprovision %v", err)
 				continue
 			}
 

--- a/pkg/broker/provision_job_test.go
+++ b/pkg/broker/provision_job_test.go
@@ -1,0 +1,121 @@
+package broker_test
+
+import (
+	"testing"
+
+	"time"
+
+	"fmt"
+
+	"github.com/openshift/ansible-service-broker/pkg/apb"
+	"github.com/openshift/ansible-service-broker/pkg/broker"
+	"github.com/pborman/uuid"
+)
+
+func TestProvisionJob_Run(t *testing.T) {
+	var uid = uuid.NewRandom()
+	var serviceInstance = &apb.ServiceInstance{
+		ID: uid,
+		Spec: &apb.Spec{
+			ID: "test",
+		},
+	}
+	cases := []struct {
+		Name      string
+		Provision apb.Provisioner
+		Validate  func(msg broker.JobMsg) error
+	}{
+		{
+			Name: "expect a success msg with extracted credentials",
+			Provision: func(si *apb.ServiceInstance) (string, *apb.ExtractedCredentials, error) {
+				return "podName", &apb.ExtractedCredentials{Credentials: map[string]interface{}{
+					"user": "test",
+					"pass": "test",
+				}}, nil
+			},
+			Validate: func(msg broker.JobMsg) error {
+				if msg.State.State != apb.StateSucceeded {
+					return fmt.Errorf("expected the state to be %v but got %v", apb.StateSucceeded, msg.State.State)
+				}
+				if msg.State.Method != apb.JobMethodProvision {
+					return fmt.Errorf("expected job method to be %v but it was %v", apb.JobMethodProvision, msg.State.Method)
+				}
+				if msg.PodName == "" {
+					return fmt.Errorf("expected the podName to be set but it was empty")
+				}
+				credentials := msg.ExtractedCredentials.Credentials
+
+				if _, ok := credentials["user"]; !ok {
+					return fmt.Errorf("expected a user key in the credentials but it was missing")
+				}
+				if _, ok := credentials["pass"]; !ok {
+					return fmt.Errorf("expected a pass key in the credentials but it was missing")
+				}
+				return nil
+			},
+		},
+		{
+			Name: "expect failure state and generic error when unknown error type",
+			Provision: func(si *apb.ServiceInstance) (string, *apb.ExtractedCredentials, error) {
+				return "", nil, fmt.Errorf("should not see")
+			},
+			Validate: func(msg broker.JobMsg) error {
+				if msg.State.State != apb.StateFailed {
+					return fmt.Errorf("expected the Job to be in state %v but was in %v ", apb.StateFailed, msg.State.State)
+				}
+				if msg.State.Method != apb.JobMethodProvision {
+					return fmt.Errorf("expected job method to be %v but it was %v", apb.JobMethodProvision, msg.State.Method)
+				}
+				if msg.State.Error == "" {
+					return fmt.Errorf("expected an error in the job state but got none")
+				}
+				if msg.State.Error == "should not see" {
+					return fmt.Errorf("expected not to see the error msg %s it should have been replaced with a generic error ", msg.State.Error)
+				}
+				return nil
+			},
+		},
+		{
+			Name: "expect failure state and full error when known error type",
+			Provision: func(si *apb.ServiceInstance) (string, *apb.ExtractedCredentials, error) {
+				return "", nil, apb.ErrorPodPullErr
+			},
+			Validate: func(msg broker.JobMsg) error {
+				if msg.State.State != apb.StateFailed {
+					return fmt.Errorf("expected the Job to be in state %v but was in %v ", apb.StateFailed, msg.State.State)
+				}
+				if msg.State.Method != apb.JobMethodProvision {
+					return fmt.Errorf("expected job method to be %v but it was %v", apb.JobMethodProvision, msg.State.Method)
+				}
+				if msg.State.Error == "" {
+					return fmt.Errorf("expected an error in the job state but got none")
+				}
+				if msg.State.Error != apb.ErrorPodPullErr.Error() {
+					return fmt.Errorf("expected to see the error msg %s but got %s ", apb.ErrorPodPullErr, msg.State.Error)
+				}
+				return nil
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			provJob := broker.NewProvisionJob(serviceInstance, tc.Provision)
+			receiver := make(chan broker.JobMsg)
+			timedOut := false
+			time.AfterFunc(1*time.Second, func() {
+				close(receiver)
+				timedOut = true
+			})
+			go provJob.Run("", receiver)
+
+			msg := <-receiver
+			if timedOut {
+				t.Fatal("timed out waiting for a msg from the Job")
+			}
+			if err := tc.Validate(msg); err != nil {
+				t.Fatal("failed to validate the jobmsg ", err)
+			}
+		})
+	}
+}

--- a/pkg/broker/provision_subscriber.go
+++ b/pkg/broker/provision_subscriber.go
@@ -17,75 +17,34 @@
 package broker
 
 import (
-	"encoding/json"
-
 	"github.com/openshift/ansible-service-broker/pkg/apb"
-	"github.com/openshift/ansible-service-broker/pkg/dao"
-	"github.com/openshift/ansible-service-broker/pkg/metrics"
 )
 
-// ProvisionWorkSubscriber - Lissten for provision messages
+// ProvisionWorkSubscriber - Listen for provision messages
 type ProvisionWorkSubscriber struct {
-	dao       *dao.Dao
-	msgBuffer <-chan JobMsg
+	dao SubscriberDAO
 }
 
 // NewProvisionWorkSubscriber - Create a new work subscriber.
-func NewProvisionWorkSubscriber(dao *dao.Dao) *ProvisionWorkSubscriber {
+func NewProvisionWorkSubscriber(dao SubscriberDAO) *ProvisionWorkSubscriber {
 	return &ProvisionWorkSubscriber{dao: dao}
 }
 
-// Subscribe - will start the work subscriber listenning on the message buffer for provision messages.
+// Subscribe - will start the work subscriber listening on the message buffer for provision messages.
 func (p *ProvisionWorkSubscriber) Subscribe(msgBuffer <-chan JobMsg) {
-	p.msgBuffer = msgBuffer
-
 	go func() {
 		log.Info("Listening for provision messages")
-		for {
-			msg := <-msgBuffer
-			var extCreds *apb.ExtractedCredentials
-			metrics.ProvisionJobFinished()
+		for msg := range msgBuffer {
+			log.Debug("received provision message from buffer")
 
-			log.Debug("Processed provision message from buffer")
-
-			if msg.Error != "" {
-				log.Errorf("Provision job reporting error: %s", msg.Error)
-				if err := p.dao.SetState(msg.InstanceUUID, apb.JobState{
-					Token:   msg.JobToken,
-					State:   apb.StateFailed,
-					Podname: msg.PodName,
-					Method:  apb.JobMethodProvision,
-					Error:   msg.Error,
-				}); err != nil {
-					log.Errorf("failed to set state after provision %v", err)
-				}
-			} else if msg.Msg == "" {
-				// HACK: OMG this is horrible. We should probably pass in a
-				// state. Since we'll also be using this to get more granular
-				// updates one day.
-				if err := p.dao.SetState(msg.InstanceUUID, apb.JobState{
-					Token:   msg.JobToken,
-					State:   apb.StateInProgress,
-					Podname: msg.PodName,
-					Method:  apb.JobMethodProvision,
-				}); err != nil {
-					log.Errorf("failed to set state after provision %v", err)
-				}
-			} else {
-				if err := json.Unmarshal([]byte(msg.Msg), &extCreds); err != nil {
-					log.Errorf("failed to unmarshal extracted credentials after provision %v", err)
-				}
-				if err := p.dao.SetState(msg.InstanceUUID, apb.JobState{
-					Token:   msg.JobToken,
-					State:   apb.StateSucceeded,
-					Podname: msg.PodName,
-					Method:  apb.JobMethodProvision,
-				}); err != nil {
-					log.Errorf("failed to set state after provision %v", err)
-				}
-				if err := p.dao.SetExtractedCredentials(msg.InstanceUUID, extCreds); err != nil {
+			if msg.State.State == apb.StateSucceeded {
+				log.Debugf("job in state succeeded setting credentials")
+				if err := p.dao.SetExtractedCredentials(msg.InstanceUUID, &msg.ExtractedCredentials); err != nil {
 					log.Errorf("failed to set extracted credentials after provision %v", err)
 				}
+			}
+			if err := p.dao.SetState(msg.InstanceUUID, msg.State); err != nil {
+				log.Errorf("failed to set state after provision %v", err)
 			}
 		}
 	}()

--- a/pkg/broker/provision_subscriber_test.go
+++ b/pkg/broker/provision_subscriber_test.go
@@ -1,0 +1,200 @@
+package broker_test
+
+import (
+	"testing"
+
+	"fmt"
+
+	"time"
+
+	"sync"
+
+	"github.com/openshift/ansible-service-broker/pkg/apb"
+	"github.com/openshift/ansible-service-broker/pkg/broker"
+)
+
+func TestProvisionWorkSubscriber_Subscribe(t *testing.T) {
+	cases := []struct {
+		Name   string
+		JobMsg broker.JobMsg
+		DAO    func() (*mockProvisionSubscriberDAO, map[string]int)
+	}{
+		{
+			Name: "should set state and credentials when job is successful",
+			JobMsg: broker.JobMsg{
+				State: apb.JobState{
+					State:  apb.StateSucceeded,
+					Method: apb.JobMethodProvision,
+				},
+				ExtractedCredentials: apb.ExtractedCredentials{
+					Credentials: map[string]interface{}{"user": "test", "pass": "test"},
+				},
+			},
+			DAO: func() (*mockProvisionSubscriberDAO, map[string]int) {
+				dao := newProvisionSubscriberDAO()
+				dao.assertOn["SetExtractedCredentials"] = func(args ...interface{}) error {
+					cred := args[1]
+					if nil == cred {
+						return fmt.Errorf("expected credentials to passed")
+					}
+					creds := cred.(*apb.ExtractedCredentials)
+					if _, ok := creds.Credentials["user"]; !ok {
+						return fmt.Errorf("expected there to be a user field in the credentials")
+					}
+					if _, ok := creds.Credentials["pass"]; !ok {
+						return fmt.Errorf("expected there to be a pass field in the credentials")
+					}
+					return nil
+				}
+				dao.assertOn["SetState"] = func(args ...interface{}) error {
+					state := args[1].(apb.JobState)
+					if state.Method != apb.JobMethodProvision {
+						return fmt.Errorf("expected to have a provision job state")
+					}
+					if state.State != apb.StateSucceeded {
+						return fmt.Errorf("expected the job state to be %v but got %v", apb.StateSucceeded, state.State)
+					}
+					return nil
+
+				}
+				expectedCalls := map[string]int{
+					"SetExtractedCredentials": 1,
+					"SetState":                1,
+				}
+				return dao, expectedCalls
+			},
+		},
+		{
+			Name: "should set state but not credentials when failed",
+			JobMsg: broker.JobMsg{
+				State: apb.JobState{
+					State:  apb.StateFailed,
+					Method: apb.JobMethodProvision,
+				},
+			},
+			DAO: func() (*mockProvisionSubscriberDAO, map[string]int) {
+				dao := newProvisionSubscriberDAO()
+				dao.assertOn["SetState"] = func(args ...interface{}) error {
+					state := args[1].(apb.JobState)
+					if state.Method != apb.JobMethodProvision {
+						fmt.Println(state)
+						return fmt.Errorf("expected to have a provision job state but was %v", state.Method)
+					}
+					if state.State != apb.StateFailed {
+						return fmt.Errorf("expected the job state to be %v but got %v", apb.StateSucceeded, state.State)
+					}
+					return nil
+				}
+				expectedCalls := map[string]int{
+					"SetExtractedCredentials": 0,
+					"SetState":                1,
+				}
+				return dao, expectedCalls
+			},
+		},
+		{
+			Name: "should set state but not credentials when in progress",
+			JobMsg: broker.JobMsg{
+				State: apb.JobState{
+					State:  apb.StateInProgress,
+					Method: apb.JobMethodProvision,
+				},
+			},
+			DAO: func() (*mockProvisionSubscriberDAO, map[string]int) {
+				dao := newProvisionSubscriberDAO()
+				dao.assertOn["SetState"] = func(args ...interface{}) error {
+					state := args[1].(apb.JobState)
+					if state.Method != apb.JobMethodProvision {
+						return fmt.Errorf("expected to have a provision job state")
+					}
+					if state.State != apb.StateInProgress {
+						return fmt.Errorf("expected the job state to be %v but got %v", apb.StateSucceeded, state.State)
+					}
+					return nil
+				}
+				expectedCalls := map[string]int{
+					"SetExtractedCredentials": 0,
+					"SetState":                1,
+				}
+				return dao, expectedCalls
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			dao, expectedCalls := tc.DAO()
+			sub := broker.NewProvisionWorkSubscriber(dao)
+			wait := sync.WaitGroup{}
+			wait.Add(1)
+			// this is a bit gross but hard to test the subscribe method as it has a constant for loop
+			// so we give it 100ms to process the message and then do our checks
+			sender := make(chan broker.JobMsg)
+			sub.Subscribe(sender)
+			time.AfterFunc(100*time.Millisecond, func() {
+				close(sender)
+				wait.Done()
+			})
+			sender <- tc.JobMsg
+			wait.Wait()
+			if len(dao.AssertErrors()) != 0 {
+				t.Fatal("unexpected error during data assertions ", dao.AssertErrors())
+			}
+			if err := dao.CheckCalls(expectedCalls); err != nil {
+				t.Fatal("unexpected error checking calls ", err)
+			}
+		})
+	}
+}
+
+type mockProvisionSubscriberDAO struct {
+	calls     map[string]int
+	err       error
+	assertErr []error
+	assertOn  map[string]func(...interface{}) error
+}
+
+func (mp *mockProvisionSubscriberDAO) SetExtractedCredentials(id string, extCreds *apb.ExtractedCredentials) error {
+	assert := mp.assertOn["SetExtractedCredentials"]
+	if nil != assert {
+		if err := assert(id, extCreds); err != nil {
+			mp.assertErr = append(mp.assertErr, err)
+			return err
+		}
+	}
+	mp.calls["SetExtractedCredentials"]++
+	return mp.err
+
+}
+func (mp *mockProvisionSubscriberDAO) SetState(id string, state apb.JobState) error {
+	assert := mp.assertOn["SetState"]
+	if nil != assert {
+		if err := assert(id, state); err != nil {
+			mp.assertErr = append(mp.assertErr, err)
+			return err
+		}
+	}
+	mp.calls["SetState"]++
+	return mp.err
+
+}
+
+func (mp *mockProvisionSubscriberDAO) CheckCalls(calls map[string]int) error {
+	for k, v := range calls {
+		if mp.calls[k] != v {
+			return fmt.Errorf("expected %d calls to %s but got %d ", v, k, mp.calls[k])
+		}
+	}
+	return nil
+}
+
+func (mp *mockProvisionSubscriberDAO) AssertErrors() []error {
+	return mp.assertErr
+}
+
+func newProvisionSubscriberDAO() *mockProvisionSubscriberDAO {
+	return &mockProvisionSubscriberDAO{
+		calls:    map[string]int{},
+		assertOn: map[string]func(...interface{}) error{},
+	}
+}

--- a/pkg/broker/types.go
+++ b/pkg/broker/types.go
@@ -261,17 +261,25 @@ type UserInfo struct {
 
 // JobMsg - Message to be returned from the various jobs
 type JobMsg struct {
-	InstanceUUID string `json:"instance_uuid"`
-	JobToken     string `json:"job_token"`
-	SpecID       string `json:"spec_id"`
-	PodName      string `json:"podname"`
-	Error        string `json:"error"`
-	Msg          string `json:"msg"`
-	BindingUUID  string `json:"binding_uuid"`
+	InstanceUUID         string                   `json:"instance_uuid"`
+	JobToken             string                   `json:"job_token"`
+	SpecID               string                   `json:"spec_id"`
+	PodName              string                   `json:"podname"`
+	Msg                  string                   `json:"msg"`
+	State                apb.JobState             `json:"state"`
+	ExtractedCredentials apb.ExtractedCredentials `json:"extracted_credentials"`
+	BindingUUID          string                   `json:"binding_uuid"`
+	Error                string                   `json:"error"`
 }
 
 // Render - Display the job message.
 func (jm JobMsg) Render() string {
 	render, _ := json.Marshal(jm)
 	return string(render)
+}
+
+// SubscriberDAO defines the interface subscribers use when persisting state
+type SubscriberDAO interface {
+	SetExtractedCredentials(id string, extCreds *apb.ExtractedCredentials) error
+	SetState(id string, state apb.JobState) error
 }

--- a/pkg/broker/unbinding_job_test.go
+++ b/pkg/broker/unbinding_job_test.go
@@ -1,0 +1,127 @@
+package broker_test
+
+import (
+	"testing"
+
+	"time"
+
+	"fmt"
+
+	"github.com/openshift/ansible-service-broker/pkg/apb"
+	"github.com/openshift/ansible-service-broker/pkg/broker"
+	"github.com/pborman/uuid"
+)
+
+func TestUnBindingJob_Run(t *testing.T) {
+	instanceID := uuid.NewRandom()
+	bindingInst := &apb.BindInstance{ID: uuid.NewRandom()}
+	serviceInstance := &apb.ServiceInstance{
+		ID: instanceID,
+		Spec: &apb.Spec{
+			ID: "test",
+		},
+	}
+	cases := []struct {
+		Name          string
+		UnBinder      apb.UnBinder
+		UnBindParams  *apb.Parameters
+		SkipExecution bool
+		Validate      func(msg broker.JobMsg) error
+	}{
+		{
+			Name: "expect a success msg",
+			UnBinder: func(si *apb.ServiceInstance, params *apb.Parameters) error {
+				return nil
+			},
+			Validate: func(msg broker.JobMsg) error {
+				if msg.State.State != apb.StateSucceeded {
+					return fmt.Errorf("expected the state to be %v but got %v", apb.StateSucceeded, msg.State.State)
+				}
+				if msg.State.Method != apb.JobMethodUnbind {
+					return fmt.Errorf("expected job method to be %v but it was %v", apb.JobMethodUnbind, msg.State.Method)
+				}
+				return nil
+			},
+		},
+		{
+			Name:          "expect a success msg when skipping apb execution",
+			SkipExecution: true,
+			UnBinder: func(si *apb.ServiceInstance, params *apb.Parameters) error {
+				return nil
+			},
+			Validate: func(msg broker.JobMsg) error {
+				if msg.State.State != apb.StateSucceeded {
+					return fmt.Errorf("expected the state to be %v but got %v", apb.StateSucceeded, msg.State.State)
+				}
+				if msg.State.Method != apb.JobMethodUnbind {
+					return fmt.Errorf("expected job method to be %v but it was %v", apb.JobMethodUnbind, msg.State.Method)
+				}
+				return nil
+			},
+		},
+		{
+			Name: "expect failure state and generic error when unknown error type",
+			UnBinder: func(si *apb.ServiceInstance, params *apb.Parameters) error {
+				return fmt.Errorf("should not see")
+			},
+			Validate: func(msg broker.JobMsg) error {
+				if msg.State.State != apb.StateFailed {
+					return fmt.Errorf("expected the Job to be in state %v but was in %v ", apb.StateFailed, msg.State.State)
+				}
+				if msg.State.Method != apb.JobMethodUnbind {
+					return fmt.Errorf("expected job method to be %v but it was %v", apb.JobMethodUnbind, msg.State.Method)
+				}
+				if msg.State.Error == "" {
+					return fmt.Errorf("expected an error in the job state but got none")
+				}
+				if msg.State.Error == "should not see" {
+					return fmt.Errorf("expected not to see the error msg %s it should have been replaced with a generic error ", msg.State.Error)
+				}
+				return nil
+			},
+		},
+		{
+			Name: "expect failure state and full error when known error type",
+			UnBinder: func(si *apb.ServiceInstance, params *apb.Parameters) error {
+				return apb.ErrorPodPullErr
+			},
+			Validate: func(msg broker.JobMsg) error {
+				if msg.State.State != apb.StateFailed {
+					return fmt.Errorf("expected the Job to be in state %v but was in %v ", apb.StateFailed, msg.State.State)
+				}
+				if msg.State.Method != apb.JobMethodUnbind {
+					return fmt.Errorf("expected job method to be %v but it was %v", apb.JobMethodUnbind, msg.State.Method)
+				}
+				if msg.State.Error == "" {
+					return fmt.Errorf("expected an error in the job state but got none")
+				}
+				if msg.State.Error != apb.ErrorPodPullErr.Error() {
+					return fmt.Errorf("expected to see the error msg %s but got %s ", apb.ErrorPodPullErr, msg.State.Error)
+				}
+				return nil
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			unbindJob := broker.NewUnbindingJob(serviceInstance, bindingInst, tc.UnBindParams, tc.UnBinder, tc.SkipExecution)
+			receiver := make(chan broker.JobMsg)
+			timedOut := false
+			time.AfterFunc(1*time.Second, func() {
+				close(receiver)
+				timedOut = true
+			})
+			go unbindJob.Run("", receiver)
+
+			msg := <-receiver
+			if timedOut {
+				t.Fatal("timed out waiting for a msg from the Job")
+			}
+			if err := tc.Validate(msg); err != nil {
+				t.Fatal("failed to validate the jobmsg ", err)
+			}
+
+		})
+	}
+}

--- a/pkg/broker/update_subscriber.go
+++ b/pkg/broker/update_subscriber.go
@@ -17,17 +17,13 @@
 package broker
 
 import (
-	"encoding/json"
-
 	"github.com/openshift/ansible-service-broker/pkg/apb"
 	"github.com/openshift/ansible-service-broker/pkg/dao"
-	"github.com/openshift/ansible-service-broker/pkg/metrics"
 )
 
 // UpdateWorkSubscriber - Lissten for provision messages
 type UpdateWorkSubscriber struct {
-	dao       *dao.Dao
-	msgBuffer <-chan JobMsg
+	dao *dao.Dao
 }
 
 // NewUpdateWorkSubscriber - Create a new work subscriber.
@@ -37,55 +33,18 @@ func NewUpdateWorkSubscriber(dao *dao.Dao) *UpdateWorkSubscriber {
 
 // Subscribe - will start the work subscriber listenning on the message buffer for provision messages.
 func (u *UpdateWorkSubscriber) Subscribe(msgBuffer <-chan JobMsg) {
-	u.msgBuffer = msgBuffer
-
 	go func() {
-		log.Info("Listening for provision messages")
-		for {
-			msg := <-msgBuffer
-			var extCreds *apb.ExtractedCredentials
-			metrics.UpdateJobFinished()
+		log.Info("Listening for update messages")
+		for msg := range msgBuffer {
+			log.Debug("received update message from buffer")
 
-			log.Debug("Processed provision message from buffer")
-
-			if msg.Error != "" {
-				log.Errorf("Update job reporting error: %s", msg.Error)
-				if err := u.dao.SetState(msg.InstanceUUID, apb.JobState{
-					Token:   msg.JobToken,
-					State:   apb.StateFailed,
-					Podname: msg.PodName,
-					Method:  apb.JobMethodUpdate,
-					Error:   msg.Error,
-				}); err != nil {
-					log.Errorf("failed to set state after update job msg received %v ", err)
+			if msg.State.State == apb.StateSucceeded {
+				if err := u.dao.SetExtractedCredentials(msg.InstanceUUID, &msg.ExtractedCredentials); err != nil {
+					log.Errorf("failed to set extracted credentials after update %v", err)
 				}
-			} else if msg.Msg == "" {
-				// HACK: OMG this is horrible. We should probably pass in a
-				// state. Since we'll also be using this to get more granular
-				// updates one day.
-				if err := u.dao.SetState(msg.InstanceUUID, apb.JobState{
-					Token:   msg.JobToken,
-					State:   apb.StateInProgress,
-					Podname: msg.PodName,
-					Method:  apb.JobMethodUpdate,
-				}); err != nil {
-					log.Errorf("failed to set state after update job msg received %v ", err)
-				}
-			} else {
-				if err := json.Unmarshal([]byte(msg.Msg), &extCreds); err != nil {
-					log.Errorf("failed to unmarshal the extracted credentials from JobMsg after update %v", err)
-				}
-				if err := u.dao.SetState(msg.InstanceUUID, apb.JobState{
-					Token:   msg.JobToken,
-					State:   apb.StateSucceeded,
-					Podname: msg.PodName,
-					Method:  apb.JobMethodUpdate,
-				}); err != nil {
-					log.Errorf("failed to set state after update job msg received %v ", err)
-				}
-				if err := u.dao.SetExtractedCredentials(msg.InstanceUUID, extCreds); err != nil {
-					log.Errorf("failed to set extracted credentials after update job msg received %v ", err)
-				}
+			}
+			if err := u.dao.SetState(msg.InstanceUUID, msg.State); err != nil {
+				log.Errorf("failed to set state after update %v", err)
 			}
 		}
 	}()


### PR DESCRIPTION
**Note for Reviewer**
There are two commits here
1) making the changes required
2) adding a set of test for the provision subscriber and job. If happy with the approach here I will expand the tests to cover the other subscribers and jobs.  Making a number of changes like this, I felt a little disconcerted that I had no unit test to run so would love to add more to help protect against regressions in future changes.

These commits are independent of each other so if the new tests are not wanted I can remove.

I am currently trying this out in my local cluster but wanted to create the PR to let the integration tests run.

**Describe what this PR does and why we need it**:
The subscribers were deciding on the state of the Job, rather than the job informing the subscriber of the job state.  This pr follows on from issue https://github.com/openshift/ansible-service-broker/issues/608
Also the Job was Marshalling the extracted credentials and sending them as a string on the Msg field, then the subscriber would Unmarshal it and save it. Instead of doing this we just send the credentials through

Changes proposed in this pull request
 - simplify subscriber logic
 - send state from the individual job
 - send credentials directly via the Job rather than turning them into a JSON string and then back to credentials again in the subscriber (avoid unneeded marshalling and unmarshalling)
- Make an attempt at adding test cases for the ProvisionJob as an example for how it might be done and to get feedback on the approach 

**Which issue this PR fixes (This will close that issue when PR gets merged)**
fixes #608

  