### PR TITLE
fix incorrect check in if statement

### DIFF
--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -1251,7 +1251,7 @@ func (a AnsibleBroker) LastOperation(instanceUUID uuid.UUID, req *LastOperationR
 
 	state := StateToLastOperation(jobstate.State)
 	log.Debugf("state: %s", state)
-	if jobstate.Error == "" {
+	if jobstate.Error != "" {
 		log.Debugf("job state has an error. Assuming that any error here is human readable. err - %v", jobstate.Error)
 	}
 	return &LastOperationResponse{State: state, Description: jobstate.Error}, err


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
in last operation there was an incorrect if statement causes excess logging 
```
job state has an error. Assuming that any error here is human readable. err - 

```
Changes proposed in this pull request
 - fix the if statement so it only logs if there is an error
