### PR TITLE
fix potential nil pointer panic

### DIFF
--- a/pkg/apb/watch_pod.go
+++ b/pkg/apb/watch_pod.go
@@ -79,6 +79,9 @@ func errorPullingImage(conds []apiv1.ContainerStatus) bool {
 	// Basis for the image strings is here:
 	// https://github.com/kubernetes/kubernetes/blob/886e04f1fffbb04faf8a9f9ee141143b2684ae68/pkg/kubelet/images/types.go#L27
 	status := conds[0].State.Waiting
+	if status == nil {
+		return false
+	}
 
 	if status.Reason == "ErrImagePull" {
 		return true


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
This is minor fix for an issue that resulted in https://github.com/openshift/ansible-service-broker/issues/612, But is likely not the full resolution though.

Changes proposed in this pull request
 - containerStatus.State.Waiting is a pointer and so can be nil.

