### PR TITLE
Bug 1472226 - Add additional field validations for JSON Schema.

### DIFF
--- a/pkg/apb/types.go
+++ b/pkg/apb/types.go
@@ -32,6 +32,9 @@ type Parameters map[string]interface{}
 // SpecManifest - Spec ID to Spec manifest
 type SpecManifest map[string]*Spec
 
+// NilableNumber - Number that could be nil (e.g. when omitted from json/yaml)
+type NilableNumber float64
+
 // ParameterDescriptor - a parameter to be used by the service catalog to get data.
 type ParameterDescriptor struct {
 	Name        string      `json:"name"`
@@ -47,11 +50,11 @@ type ParameterDescriptor struct {
 	Pattern             string `json:"pattern,omitempty"`
 
 	// number validators
-	MultipleOf       float64     `json:"multipleOf,omitempty" yaml:"multiple_of,omitempty"`
-	Maximum          interface{} `json:"maximum,omitempty"`
-	ExclusiveMaximum interface{} `json:"exclusiveMaximum,omitempty" yaml:"exclusive_maximum,omitempty"`
-	Minimum          interface{} `json:"minimum,omitempty"`
-	ExclusiveMinimum interface{} `json:"exclusiveMinimum,omitempty" yaml:"exclusive_minimum,omitempty"`
+	MultipleOf       float64        `json:"multipleOf,omitempty" yaml:"multiple_of,omitempty"`
+	Maximum          *NilableNumber `json:"maximum,omitempty"`
+	ExclusiveMaximum *NilableNumber `json:"exclusiveMaximum,omitempty" yaml:"exclusive_maximum,omitempty"`
+	Minimum          *NilableNumber `json:"minimum,omitempty"`
+	ExclusiveMinimum *NilableNumber `json:"exclusiveMinimum,omitempty" yaml:"exclusive_minimum,omitempty"`
 
 	Enum         []string `json:"enum,omitempty"`
 	Required     bool     `json:"required"`
@@ -216,10 +219,10 @@ func SpecLogDump(spec *Spec) {
 			log.Debug("  MinLength: %d", param.MinLength)
 			log.Debug("  Pattern: %s", param.Pattern)
 			log.Debug("  MultipleOf: %d", param.MultipleOf)
-			log.Debug("  Minimum: %d", param.Minimum)
-			log.Debug("  Maximum: %d", param.Maximum)
-			log.Debug("  ExclusiveMinimum: %d", param.ExclusiveMinimum)
-			log.Debug("  ExclusiveMaximum: %d", param.ExclusiveMaximum)
+			log.Debug("  Minimum: %#v", param.Minimum)
+			log.Debug("  Maximum: %#v", param.Maximum)
+			log.Debug("  ExclusiveMinimum: %#v", param.ExclusiveMinimum)
+			log.Debug("  ExclusiveMaximum: %#v", param.ExclusiveMaximum)
 			log.Debug("  Required: %s", param.Required)
 			log.Debug("  Enum: %v", param.Enum)
 		}

--- a/pkg/apb/types.go
+++ b/pkg/apb/types.go
@@ -34,18 +34,30 @@ type SpecManifest map[string]*Spec
 
 // ParameterDescriptor - a parameter to be used by the service catalog to get data.
 type ParameterDescriptor struct {
-	Name         string      `json:"name"`
-	Title        string      `json:"title"`
-	Type         string      `json:"type"`
-	Description  string      `json:"description,omitempty"`
-	Default      interface{} `json:"default,omitempty"`
-	Maxlength    int         `json:"maxlength,omitempty"`
-	Pattern      string      `json:"pattern,omitempty"`
-	Enum         []string    `json:"enum,omitempty"`
-	Required     bool        `json:"required"`
-	Updatable    bool        `json:"updatable"`
-	DisplayType  string      `json:"display_type,omitempty" yaml:"display_type,omitempty"`
-	DisplayGroup string      `json:"display_group,omitempty" yaml:"display_group,omitempty"`
+	Name        string      `json:"name"`
+	Title       string      `json:"title"`
+	Type        string      `json:"type"`
+	Description string      `json:"description,omitempty"`
+	Default     interface{} `json:"default,omitempty"`
+
+	// string validators
+	DeprecatedMaxlength int    `json:"maxlength,omitempty" yaml:"maxlength,omitempty"` // backwards compatibility
+	MaxLength           int    `json:"maxLength,omitempty" yaml:"max_length,omitempty"`
+	MinLength           int    `json:"minLength,omitempty" yaml:"min_length,omitempty"`
+	Pattern             string `json:"pattern,omitempty"`
+
+	// number validators
+	MultipleOf       float64     `json:"multipleOf,omitempty" yaml:"multiple_of,omitempty"`
+	Maximum          interface{} `json:"maximum,omitempty"`
+	ExclusiveMaximum interface{} `json:"exclusiveMaximum,omitempty" yaml:"exclusive_maximum,omitempty"`
+	Minimum          interface{} `json:"minimum,omitempty"`
+	ExclusiveMinimum interface{} `json:"exclusiveMinimum,omitempty" yaml:"exclusive_minimum,omitempty"`
+
+	Enum         []string `json:"enum,omitempty"`
+	Required     bool     `json:"required"`
+	Updatable    bool     `json:"updatable"`
+	DisplayType  string   `json:"displayType,omitempty" yaml:"display_type,omitempty"`
+	DisplayGroup string   `json:"displayGroup,omitempty" yaml:"display_group,omitempty"`
 }
 
 // Plan - Plan object describing an APB deployment plan and associated parameters
@@ -199,9 +211,16 @@ func SpecLogDump(spec *Spec) {
 			log.Debug("  Type: %s", param.Type)
 			log.Debug("  Description: %s", param.Description)
 			log.Debug("  Default: %#v", param.Default)
-			log.Debug("  Maxlength: %d", param.Maxlength)
+			log.Debug("  DeprecatedMaxlength: %d", param.DeprecatedMaxlength)
+			log.Debug("  MaxLength: %d", param.MaxLength)
+			log.Debug("  MinLength: %d", param.MinLength)
 			log.Debug("  Pattern: %s", param.Pattern)
-			log.Debug("  Pattern: %s", param.Required)
+			log.Debug("  MultipleOf: %d", param.MultipleOf)
+			log.Debug("  Minimum: %d", param.Minimum)
+			log.Debug("  Maximum: %d", param.Maximum)
+			log.Debug("  ExclusiveMinimum: %d", param.ExclusiveMinimum)
+			log.Debug("  ExclusiveMaximum: %d", param.ExclusiveMaximum)
+			log.Debug("  Required: %s", param.Required)
 			log.Debug("  Enum: %v", param.Enum)
 		}
 	}

--- a/pkg/apb/types_test.go
+++ b/pkg/apb/types_test.go
@@ -235,7 +235,7 @@ func TestEncodedParameters(t *testing.T) {
 	ft.AssertEqual(t, sitelang.Type, "string")
 	ft.AssertEqual(t, sitelang.Description, "")
 	ft.AssertEqual(t, sitelang.Default, "en")
-	ft.AssertEqual(t, sitelang.Maxlength, 0)
+	ft.AssertEqual(t, sitelang.DeprecatedMaxlength, 0)
 	ft.AssertEqual(t, sitelang.Pattern, "")
 	ft.AssertEqual(t, len(sitelang.Enum), 0)
 }

--- a/pkg/broker/util.go
+++ b/pkg/broker/util.go
@@ -344,21 +344,21 @@ func setNumberValidators(pd apb.ParameterDescriptor, prop *schema.Schema) {
 
 	// since 0 is a valid value for maximum, minimum, exclusiveMaximum, and exclusiveMinimum,
 	// we have to allow for empty.
-	if max, ok := pd.Maximum.(float64); ok {
-		prop.Maximum = schema.Number{Val: max, Initialized: true}
+	if pd.Maximum != nil {
+		prop.Maximum = schema.Number{Val: float64(*pd.Maximum), Initialized: true}
 	}
-	if min, ok := pd.Minimum.(float64); ok {
-		prop.Minimum = schema.Number{Val: min, Initialized: true}
+	if pd.Minimum != nil {
+		prop.Minimum = schema.Number{Val: float64(*pd.Minimum), Initialized: true}
 	}
 
 	// JSON Schema defines exclusiveMaximum and exclusiveMinimum as numbers separate from maximum and minimum
 	// but go-jsschema defines ExclusiveMaximum and ExclusiveMinimum as bool and reuses Maximum and Minimum
-	if exMax, ok := pd.ExclusiveMaximum.(float64); ok {
-		prop.Maximum = schema.Number{Val: exMax, Initialized: true}
+	if pd.ExclusiveMaximum != nil {
+		prop.Maximum = schema.Number{Val: float64(*pd.ExclusiveMaximum), Initialized: true}
 		prop.ExclusiveMaximum = schema.Bool{Val: true, Default: false, Initialized: true}
 	}
-	if exMin, ok := pd.ExclusiveMinimum.(float64); ok {
-		prop.Minimum = schema.Number{Val: exMin, Initialized: true}
+	if pd.ExclusiveMinimum != nil {
+		prop.Minimum = schema.Number{Val: float64(*pd.ExclusiveMinimum), Initialized: true}
 		prop.ExclusiveMinimum = schema.Bool{Val: true, Default: false, Initialized: true}
 	}
 }

--- a/pkg/broker/util.go
+++ b/pkg/broker/util.go
@@ -200,7 +200,7 @@ func getType(paramType string) (schema.PrimitiveTypes, error) {
 	switch strings.ToLower(paramType) {
 	case "string", "enum":
 		return []schema.PrimitiveType{schema.StringType}, nil
-	case "int":
+	case "int", "integer":
 		return []schema.PrimitiveType{schema.IntegerType}, nil
 	case "object":
 		return []schema.PrimitiveType{schema.ObjectType}, nil
@@ -274,7 +274,6 @@ func parametersToSchema(plan apb.Plan) (Schema, error) {
 func extractProperties(params []apb.ParameterDescriptor) (map[string]*schema.Schema, error) {
 	properties := make(map[string]*schema.Schema)
 
-	var patternRegex *regexp.Regexp
 	for _, pd := range params {
 		k := pd.Name
 
@@ -290,33 +289,87 @@ func extractProperties(params []apb.ParameterDescriptor) (map[string]*schema.Sch
 			Type:        t,
 		}
 
-		// we can NOT set values on the Schema object if we want to be
-		// omitempty. Setting maxlength to 0 is NOT the same as omitting it.
-		// 0 is a worthless value for Maxlength so we will not set it
-		if pd.Maxlength > 0 {
-			properties[k].MaxLength = schema.Integer{Val: pd.Maxlength, Initialized: true}
-		}
-
-		// do not set the regexp if it does not compile
-		if pd.Pattern != "" {
-			patternRegex, err = regexp.Compile(pd.Pattern)
-			properties[k].Pattern = patternRegex
-
-			if err != nil {
-				fmt.Printf("Invalid pattern: %s", err.Error())
-			}
-		}
-
-		// setup enums
-		if len(pd.Enum) > 0 {
-			properties[k].Enum = make([]interface{}, len(pd.Enum))
-			for i, v := range pd.Enum {
-				properties[k].Enum[i] = v
-			}
-		}
+		setStringValidators(pd, properties[k])
+		setNumberValidators(pd, properties[k])
+		setEnum(pd, properties[k])
 	}
 
 	return properties, nil
+}
+
+func setStringValidators(pd apb.ParameterDescriptor, prop *schema.Schema) {
+	if prop.Type[0] != schema.StringType {
+		return
+	}
+
+	// we can NOT set values on the Schema object if we want to be
+	// omitempty. Setting maxlength to 0 is NOT the same as omitting it.
+	// 0 is a worthless value for DeprecatedMaxlength so we will not set it
+
+	// maxlength
+	if pd.DeprecatedMaxlength > 0 {
+		prop.MaxLength = schema.Integer{Val: pd.DeprecatedMaxlength, Initialized: true}
+	}
+
+	// max_length overrides maxlength
+	if pd.MaxLength > 0 {
+		prop.MaxLength = schema.Integer{Val: pd.MaxLength, Initialized: true}
+	}
+	// min_length
+	if pd.MinLength > 0 {
+		prop.MinLength = schema.Integer{Val: pd.MinLength, Initialized: true}
+	}
+
+	// do not set the regexp if it does not compile
+	if pd.Pattern != "" {
+		patternRegex, err := regexp.Compile(pd.Pattern)
+		prop.Pattern = patternRegex
+
+		if err != nil {
+			fmt.Printf("Invalid pattern: %s", err.Error())
+		}
+	}
+}
+
+func setNumberValidators(pd apb.ParameterDescriptor, prop *schema.Schema) {
+	if prop.Type[0] != schema.NumberType && prop.Type[0] != schema.IntegerType {
+		return
+	}
+
+	// since 0 is not useful as a value for multipleOf,
+	// we can use it as a float64 and not worry about nil
+	if pd.MultipleOf > 0 {
+		prop.MultipleOf = schema.Number{Val: pd.MultipleOf, Initialized: true}
+	}
+
+	// since 0 is a valid value for maximum, minimum, exclusiveMaximum, and exclusiveMinimum,
+	// we have to allow for empty.
+	if max, ok := pd.Maximum.(float64); ok {
+		prop.Maximum = schema.Number{Val: max, Initialized: true}
+	}
+	if min, ok := pd.Minimum.(float64); ok {
+		prop.Minimum = schema.Number{Val: min, Initialized: true}
+	}
+
+	// JSON Schema defines exclusiveMaximum and exclusiveMinimum as numbers separate from maximum and minimum
+	// but go-jsschema defines ExclusiveMaximum and ExclusiveMinimum as bool and reuses Maximum and Minimum
+	if exMax, ok := pd.ExclusiveMaximum.(float64); ok {
+		prop.Maximum = schema.Number{Val: exMax, Initialized: true}
+		prop.ExclusiveMaximum = schema.Bool{Val: true, Default: false, Initialized: true}
+	}
+	if exMin, ok := pd.ExclusiveMinimum.(float64); ok {
+		prop.Minimum = schema.Number{Val: exMin, Initialized: true}
+		prop.ExclusiveMinimum = schema.Bool{Val: true, Default: false, Initialized: true}
+	}
+}
+
+func setEnum(pd apb.ParameterDescriptor, prop *schema.Schema) {
+	if len(pd.Enum) > 0 {
+		prop.Enum = make([]interface{}, len(pd.Enum))
+		for i, v := range pd.Enum {
+			prop.Enum[i] = v
+		}
+	}
 }
 
 func extractRequired(params []apb.ParameterDescriptor) []string {
@@ -330,7 +383,6 @@ func extractRequired(params []apb.ParameterDescriptor) []string {
 }
 
 func extractUpdatable(params []apb.ParameterDescriptor) (map[string]*schema.Schema, error) {
-	var patternRegex *regexp.Regexp
 	upd := make(map[string]*schema.Schema)
 	for _, v := range params {
 		t, err := getType(v.Type)
@@ -346,30 +398,9 @@ func extractUpdatable(params []apb.ParameterDescriptor) (map[string]*schema.Sche
 				Type:        t,
 			}
 
-			// we can NOT set values on the Schema object if we want to be
-			// omitempty. Setting maxlength to 0 is NOT the same as omitting it.
-			// 0 is a worthless value for Maxlength so we will not set it
-			if v.Maxlength > 0 {
-				upd[k].MaxLength = schema.Integer{Val: v.Maxlength, Initialized: true}
-			}
-
-			// do not set the regexp if it does not compile
-			if v.Pattern != "" {
-				patternRegex, err = regexp.Compile(v.Pattern)
-				upd[k].Pattern = patternRegex
-
-				if err != nil {
-					fmt.Printf("Invalid pattern: %s", err.Error())
-				}
-			}
-
-			// setup enums
-			if len(v.Enum) > 0 {
-				upd[k].Enum = make([]interface{}, len(v.Enum))
-				for i, v := range v.Enum {
-					upd[k].Enum[i] = v
-				}
-			}
+			setStringValidators(v, upd[k])
+			setNumberValidators(v, upd[k])
+			setEnum(v, upd[k])
 		}
 	}
 	return upd, nil

--- a/pkg/registries/registry_test.go
+++ b/pkg/registries/registry_test.go
@@ -65,11 +65,11 @@ var expectedPlanParameters = []apb.ParameterDescriptor{
 		Description: "A random alphanumeric string if left blank",
 		Title:       "PostgreSQL Password"},
 	apb.ParameterDescriptor{
-		Name:      "postgresql_user",
-		Default:   "admin",
-		Title:     "PostgreSQL User",
-		Type:      "string",
-		Maxlength: 63},
+		Name:                "postgresql_user",
+		Default:             "admin",
+		Title:               "PostgreSQL User",
+		Type:                "string",
+		DeprecatedMaxlength: 63},
 	apb.ParameterDescriptor{
 		Name:    "postgresql_version",
 		Default: 9.5,


### PR DESCRIPTION
Updated apb spec to allow for more validations from JSON Schema. 
https://datatracker.ietf.org/doc/draft-handrews-json-schema-validation/

Validations follow JSON schema keywords, and uses snake_case instead of camelCase for consistency when writing APBs

Added apb_field (JSON schema field):
- max_length (maxLength)
- min_length (minLength)
- multiple_of (multipleOf)
- minimum (minimum)
- maximum (maximum)
- exclusive_minimum (exclusiveMinimum)
- exclusive_maximum (exclusiveMaximum)

Allow maxlength to be used for backwards compatibility as DeprecatedMaxlength.
Allowed `type: integer` since it's used in JSON schema