### PR TITLE
Use the router prefix for apb tool endpoints

### DIFF
--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -191,9 +191,9 @@ func NewHandler(b broker.Broker, brokerConfig *config.Config, prefix string,
 		createVarHandler(h.lastoperation)).Methods("GET")
 
 	if brokerConfig.GetBool("broker.dev_broker") {
-		h.router.HandleFunc("/apb/spec", createVarHandler(h.apbAddSpec)).Methods("POST")
-		h.router.HandleFunc("/apb/spec/{spec_id}", createVarHandler(h.apbRemoveSpec)).Methods("DELETE")
-		h.router.HandleFunc("/apb/spec", createVarHandler(h.apbRemoveSpecs)).Methods("DELETE")
+		s.HandleFunc("/v2/apb", createVarHandler(h.apbAddSpec)).Methods("POST")
+		s.HandleFunc("/v2/apb/{spec_id}", createVarHandler(h.apbRemoveSpec)).Methods("DELETE")
+		s.HandleFunc("/v2/apb", createVarHandler(h.apbRemoveSpecs)).Methods("DELETE")
 	}
 
 	return handlers.LoggingHandler(os.Stdout, userInfoHandler(authHandler(h, providers)))


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
Switch to using the same routing prefix for the apb tool endpoints. The apb tool has all the information needed to use these endpoints.  

**Which issue this PR fixes (This will close that issue when PR gets merged)**
partially: https://github.com/ansibleplaybookbundle/ansible-playbook-bundle/issues/180

