### PR TITLE
475 last operation description

### DIFF
--- a/pkg/apb/provision.go
+++ b/pkg/apb/provision.go
@@ -19,6 +19,7 @@ package apb
 // Provision - will run the abp with the provision action.
 func Provision(
 	instance *ServiceInstance,
+	stateUpdates chan<- JobState,
 ) (string, *ExtractedCredentials, error) {
 	log.Notice("============================================================")
 	log.Notice("                       PROVISIONING                         ")
@@ -33,5 +34,5 @@ func Provision(
 	// provision and update, save for passing through the method type. Provision
 	// provides a nice public interface, but the bulk of the work is passed to
 	// provisionOrUpdate as an implementation detail.
-	return provisionOrUpdate(executionMethodProvision, instance)
+	return provisionOrUpdate(executionMethodProvision, instance, stateUpdates)
 }

--- a/pkg/apb/provision_or_update.go
+++ b/pkg/apb/provision_or_update.go
@@ -36,7 +36,8 @@ const (
 
 // returns PodName, ExtractedCredentials, error
 func provisionOrUpdate(method executionMethod,
-	instance *ServiceInstance) (string, *ExtractedCredentials, error) {
+	instance *ServiceInstance,
+	stateUpdates chan<- JobState) (string, *ExtractedCredentials, error) {
 
 	// Explicitly error out if image field is missing from instance.Spec
 	// was introduced as a change to the apb instance.Spec to support integration
@@ -79,7 +80,8 @@ func provisionOrUpdate(method executionMethod,
 	}
 
 	if instance.Spec.Runtime >= 2 || !instance.Spec.Bindable {
-		err := watchPod(executionContext.PodName, executionContext.Namespace)
+		log.Debugf("watching pod for serviceinstance %#v", instance.Spec)
+		err := watchPod(executionContext.PodName, executionContext.Namespace, k8scli.Client.CoreV1().Pods(executionContext.Namespace), stateUpdates)
 		if err != nil {
 			log.Errorf("Provision or Update action failed - %v", err)
 			return executionContext.PodName, nil, err

--- a/pkg/apb/types.go
+++ b/pkg/apb/types.go
@@ -161,11 +161,12 @@ const (
 
 // JobState - The job state
 type JobState struct {
-	Token   string    `json:"token"`
-	State   State     `json:"state"`
-	Podname string    `json:"podname"`
-	Method  JobMethod `json:"method"`
-	Error   string    `json:"error"`
+	Token       string    `json:"token"`
+	State       State     `json:"state"`
+	Podname     string    `json:"podname"`
+	Method      JobMethod `json:"method"`
+	Error       string    `json:"error"`
+	Description string    `json:"description"`
 }
 
 // ClusterConfig - Configuration for the cluster.
@@ -380,10 +381,16 @@ type ExecutionContext struct {
 }
 
 // Provisioner defines a function that knows how to provision an apb
-type Provisioner func(si *ServiceInstance) (string, *ExtractedCredentials, error)
+type Provisioner func(si *ServiceInstance, statusUpdate chan<- JobState) (string, *ExtractedCredentials, error)
+
+// Deprovisioner defines a function that knows how to deprovision an apb
+type Deprovisioner func(si *ServiceInstance, statusUpdate chan<- JobState) (string, error)
+
+// Updater defines a function that knows how to update an apb
+type Updater func(si *ServiceInstance, statusUpdate chan<- JobState) (string, *ExtractedCredentials, error)
 
 // Binder defines a function that knows how to perform a binding
-type Binder func(si *ServiceInstance, params *Parameters) (string, *ExtractedCredentials, error)
+type Binder func(si *ServiceInstance, params *Parameters, statusUpdate chan<- JobState) (string, *ExtractedCredentials, error)
 
 // UnBinder defines a function that knows how to perform a unbinding
-type UnBinder func(si *ServiceInstance, params *Parameters) error
+type UnBinder func(si *ServiceInstance, params *Parameters, statusUpdate chan<- JobState) error

--- a/pkg/apb/update.go
+++ b/pkg/apb/update.go
@@ -17,7 +17,7 @@
 package apb
 
 // Update - will run the abp with the provision action.
-func Update(instance *ServiceInstance) (string, *ExtractedCredentials, error) {
+func Update(instance *ServiceInstance, statusUpdate chan<- JobState) (string, *ExtractedCredentials, error) {
 	log.Notice("============================================================")
 	log.Notice("                       UPDATING                             ")
 	log.Notice("============================================================")
@@ -31,5 +31,5 @@ func Update(instance *ServiceInstance) (string, *ExtractedCredentials, error) {
 	// provision and update, save for passing through the method type. Update
 	// provides a nice public interface, but the bulk of the work is passed to
 	// provisionOrUpdate as an implementation detail.
-	return provisionOrUpdate(executionMethodUpdate, instance)
+	return provisionOrUpdate(executionMethodUpdate, instance, statusUpdate)
 }

--- a/pkg/apb/watch_pod_test.go
+++ b/pkg/apb/watch_pod_test.go
@@ -1,0 +1,201 @@
+package apb
+
+import (
+	"testing"
+
+	"time"
+
+	"fmt"
+
+	core1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/kubernetes/typed/core/v1"
+	ktesting "k8s.io/client-go/testing"
+)
+
+func TestWatchPod(t *testing.T) {
+
+	podStateUpdater := func(watcher *watch.FakeWatcher, podUpdates []*core1.Pod) {
+		for _, podUpdate := range podUpdates {
+			watcher.Modify(podUpdate)
+		}
+	}
+
+	cases := []struct {
+		Name            string
+		PodClient       func() (v1.PodInterface, *watch.FakeWatcher)
+		UpdatePodStates func(watcher *watch.FakeWatcher)
+		ExpectError     bool
+		Validate        func(status []JobState) error
+	}{
+		{
+			Name: "should get error and state update when pod fails",
+			PodClient: func() (v1.PodInterface, *watch.FakeWatcher) {
+				kfake := &fake.Clientset{}
+				podWatch := watch.NewFake()
+				kfake.AddWatchReactor("pods", ktesting.DefaultWatchReactor(podWatch, nil))
+				return kfake.CoreV1().Pods("test"), podWatch
+			},
+			ExpectError: true,
+			UpdatePodStates: func(watcher *watch.FakeWatcher) {
+				podStates := []*core1.Pod{{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test",
+						Annotations: map[string]string{
+							"apb_last_operation": "lastop0",
+						},
+					},
+					Status: core1.PodStatus{
+						Phase: core1.PodRunning,
+					},
+				}, {
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test",
+						Annotations: map[string]string{
+							"apb_last_operation": "lastop1",
+						},
+					},
+					Status: core1.PodStatus{
+						Phase: core1.PodFailed,
+					},
+				}}
+				podStateUpdater(watcher, podStates)
+			},
+			Validate: func(status []JobState) error {
+				if len(status) != 2 {
+					return fmt.Errorf("expected 2 status updates")
+				}
+				for i, s := range status {
+					if s.Description != fmt.Sprintf("lastop%v", i) {
+						return fmt.Errorf("expected description to be lastop%v but got %v", i, s.Description)
+					}
+					if s.State != StateInProgress {
+						return fmt.Errorf("expected state to be %v but was %v", StateInProgress, s.State)
+					}
+				}
+				return nil
+			},
+		},
+		{
+			Name: "should get state updates when pod succeeds and no error",
+			PodClient: func() (v1.PodInterface, *watch.FakeWatcher) {
+				kfake := &fake.Clientset{}
+				podWatch := watch.NewFake()
+				kfake.AddWatchReactor("pods", ktesting.DefaultWatchReactor(podWatch, nil))
+				return kfake.CoreV1().Pods("test"), podWatch
+			},
+			UpdatePodStates: func(watcher *watch.FakeWatcher) {
+				podStates := []*core1.Pod{{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test",
+						Annotations: map[string]string{
+							"apb_last_operation": "lastop0",
+						},
+					},
+					Status: core1.PodStatus{
+						Phase: core1.PodRunning,
+					},
+				}, {
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test",
+						Annotations: map[string]string{
+							"apb_last_operation": "lastop1",
+						},
+					},
+					Status: core1.PodStatus{
+						Phase: core1.PodSucceeded,
+					},
+				}}
+				podStateUpdater(watcher, podStates)
+
+			},
+			Validate: func(status []JobState) error {
+				if len(status) != 2 {
+					return fmt.Errorf("expected 2 status updates")
+				}
+				for i, s := range status {
+					if s.Description != fmt.Sprintf("lastop%v", i) {
+						return fmt.Errorf("expected description to be lastop%v but got %v", i, s.Description)
+					}
+					if s.State != StateInProgress {
+						return fmt.Errorf("expected state to be %v but was %v", StateInProgress, s.State)
+					}
+				}
+				return nil
+			},
+		},
+		{
+			Name: "should get state updates error if pod unexpectedly deleted",
+			PodClient: func() (v1.PodInterface, *watch.FakeWatcher) {
+				kfake := &fake.Clientset{}
+				podWatch := watch.NewFake()
+				kfake.AddWatchReactor("pods", ktesting.DefaultWatchReactor(podWatch, nil))
+				return kfake.CoreV1().Pods("test"), podWatch
+			},
+			UpdatePodStates: func(watcher *watch.FakeWatcher) {
+				podStates := []*core1.Pod{{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test",
+						Annotations: map[string]string{
+							"apb_last_operation": "lastop0",
+						},
+					},
+					Status: core1.PodStatus{
+						Phase: core1.PodRunning,
+					},
+				}}
+				podStateUpdater(watcher, podStates)
+				watcher.Delete(podStates[0])
+			},
+			ExpectError: true,
+			Validate: func(status []JobState) error {
+				if len(status) != 2 {
+					return fmt.Errorf("expected 2 status updates")
+				}
+				for _, s := range status {
+					if s.Description != "lastop0" {
+						return fmt.Errorf("expected description to be lastop0 but got %v", s.Description)
+					}
+					if s.State != StateInProgress {
+						return fmt.Errorf("expected state to be %v but was %v", StateInProgress, s.State)
+					}
+				}
+				return nil
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			statusReceiver := make(chan JobState)
+			podClient, podWatch := tc.PodClient()
+			time.AfterFunc(100*time.Millisecond, func() {
+				close(statusReceiver)
+			})
+			var watchErr error
+			go func() {
+				watchErr = watchPod("test", "test", podClient, statusReceiver)
+			}()
+			go tc.UpdatePodStates(podWatch)
+			var state []JobState
+			for s := range statusReceiver {
+				state = append(state, s)
+			}
+			if nil != tc.Validate {
+				if err := tc.Validate(state); err != nil {
+					t.Fatal("unexpected errror validating job state", err)
+				}
+			}
+			if tc.ExpectError && watchErr == nil {
+				t.Fatal("expected a watch err but got none")
+			}
+
+			if !tc.ExpectError && watchErr != nil {
+				t.Fatal("did not expect a watch err but got one ", watchErr)
+			}
+
+		})
+	}
+}

--- a/pkg/broker/deprovision_job_test.go
+++ b/pkg/broker/deprovision_job_test.go
@@ -1,0 +1,147 @@
+//
+// Copyright (c) 2018 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Red Hat trademarks are not licensed under Apache License, Version 2.
+// No permission is granted to use or replicate Red Hat trademarks that
+// are incorporated in this software or its documentation.
+//
+
+package broker_test
+
+import (
+	"testing"
+
+	"time"
+
+	"fmt"
+
+	"github.com/openshift/ansible-service-broker/pkg/apb"
+	"github.com/openshift/ansible-service-broker/pkg/broker"
+	"github.com/pborman/uuid"
+)
+
+func commonJobMsgValidation(expectedFinalState apb.State, expectedMethod apb.JobMethod, msgs []broker.JobMsg) error {
+	if len(msgs) < 2 {
+		return fmt.Errorf("expected 2 msgs but only got %v", len(msgs))
+	}
+	for i, msg := range msgs {
+		if msg.State.Method != expectedMethod {
+			return fmt.Errorf("expected job msg method to be %v but it was %v", expectedMethod, msg.State.Method)
+		}
+		if i == 0 && msg.State.State != apb.StateInProgress {
+			return fmt.Errorf("expected job msg state to be %v but it was %v", apb.StateInProgress, msg.State.State)
+		}
+
+		if i == len(msgs)-1 && msg.State.State != expectedFinalState {
+			return fmt.Errorf("expected job msg state to be %v but it was %v", expectedFinalState, msg.State.State)
+		}
+	}
+	return nil
+}
+
+func TestDeprovisionJob_Run(t *testing.T) {
+	var uid = uuid.NewRandom()
+	var serviceInstance = &apb.ServiceInstance{
+		ID: uid,
+		Spec: &apb.Spec{
+			ID: "test",
+		},
+	}
+
+	cases := []struct {
+		Name             string
+		Deprovision      apb.Deprovisioner
+		SkipAPBExecution bool
+		Validate         func(msgs []broker.JobMsg) error
+	}{
+		{
+			Name: "expect a success msg when no error occurs",
+			Deprovision: func(si *apb.ServiceInstance, statusUpdate chan<- apb.JobState) (string, error) {
+				return "somepod", nil
+			},
+			Validate: func(msgs []broker.JobMsg) error {
+				return commonJobMsgValidation(apb.StateSucceeded, apb.JobMethodDeprovision, msgs)
+			},
+		},
+		{
+			Name: "expect a success msg when skip apb execution",
+			Deprovision: func(si *apb.ServiceInstance, statusUpdate chan<- apb.JobState) (string, error) {
+				return "", nil
+			},
+			SkipAPBExecution: true,
+			Validate: func(msgs []broker.JobMsg) error {
+				return commonJobMsgValidation(apb.StateSucceeded, apb.JobMethodDeprovision, msgs)
+			},
+		},
+		{
+			Name: "expect a generic failure msg when an unknown error occurs",
+			Deprovision: func(si *apb.ServiceInstance, statusUpdate chan<- apb.JobState) (string, error) {
+				return "", fmt.Errorf("some error")
+			},
+			Validate: func(msgs []broker.JobMsg) error {
+				if err := commonJobMsgValidation(apb.StateFailed, apb.JobMethodDeprovision, msgs); err != nil {
+					return err
+				}
+				last := msgs[len(msgs)-1]
+				if last.State.Description == "some error" {
+					return fmt.Errorf("expected a generic error but got %s", last.State.Description)
+				}
+				return nil
+			},
+		},
+		{
+			Name: "expect an in progress msg with last operation description",
+			Deprovision: func(si *apb.ServiceInstance, statusUpdate chan<- apb.JobState) (string, error) {
+				statusUpdate <- apb.JobState{State: apb.StateInProgress, Description: "doing something", Method: apb.JobMethodDeprovision, Podname: "somepod"}
+				return "", nil
+			},
+			Validate: func(msgs []broker.JobMsg) error {
+				if err := commonJobMsgValidation(apb.StateSucceeded, apb.JobMethodDeprovision, msgs); err != nil {
+					return err
+				}
+				foundMessage := false
+				for _, msg := range msgs {
+					if msg.State.State == apb.StateInProgress && msg.State.Description == "doing something" {
+						foundMessage = true
+					}
+				}
+				if !foundMessage {
+					return fmt.Errorf("expected to find a last operation description stating: doing something but found none")
+				}
+				return nil
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			deprovisionJob := broker.NewDeprovisionJob(serviceInstance, tc.SkipAPBExecution, tc.Deprovision)
+			receiver := make(chan broker.JobMsg, 2)
+			// give some time to allow msgs to be sent as we are not actually provisioning this should be plenty
+			time.AfterFunc(200*time.Millisecond, func() {
+				close(receiver)
+			})
+
+			go deprovisionJob.Run("", receiver)
+			var msgs []broker.JobMsg
+			for msg := range receiver {
+				msgs = append(msgs, msg)
+			}
+			if err := tc.Validate(msgs); err != nil {
+				t.Fatal("failed to validate the jobmsgs ", err)
+			}
+		})
+	}
+}

--- a/pkg/broker/deprovision_subscriber_test.go
+++ b/pkg/broker/deprovision_subscriber_test.go
@@ -1,0 +1,208 @@
+//
+// Copyright (c) 2018 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Red Hat trademarks are not licensed under Apache License, Version 2.
+// No permission is granted to use or replicate Red Hat trademarks that
+// are incorporated in this software or its documentation.
+//
+package broker_test
+
+import (
+	"testing"
+
+	"fmt"
+
+	"time"
+
+	"sync"
+
+	"github.com/openshift/ansible-service-broker/pkg/apb"
+	"github.com/openshift/ansible-service-broker/pkg/broker"
+	"github.com/openshift/ansible-service-broker/pkg/mock"
+)
+
+func TestDeprovisionWorkSubscriber_Subscribe(t *testing.T) {
+	instanceID := "id"
+	cases := []struct {
+		Name   string
+		JobMsg broker.JobMsg
+		DAO    func() (*mock.SubscriberDAO, map[string]int)
+	}{
+		{
+			Name: "should set state and credentials when job is successful",
+			JobMsg: broker.JobMsg{
+				InstanceUUID: instanceID,
+				State: apb.JobState{
+					State:  apb.StateSucceeded,
+					Method: apb.JobMethodProvision,
+				},
+				ExtractedCredentials: apb.ExtractedCredentials{
+					Credentials: map[string]interface{}{"user": "test", "pass": "test"},
+				},
+			},
+			DAO: func() (*mock.SubscriberDAO, map[string]int) {
+				dao := mock.NewSubscriberDAO()
+				dao.AssertOn["DeleteExtractedCredentials"] = func(args ...interface{}) error {
+					id := args[0].(string)
+					if id != "id" {
+						return fmt.Errorf("epected the id to be : id but was %s", id)
+					}
+					return nil
+				}
+				dao.AssertOn["DeleteServiceInstance"] = func(args ...interface{}) error {
+					id := args[0].(string)
+					if id != "id" {
+						return fmt.Errorf("epected the id to be : id but was %s", id)
+					}
+					return nil
+				}
+				dao.AssertOn["SetState"] = func(i ...interface{}) error {
+					state := i[1].(apb.JobState)
+					if state.State != apb.StateSucceeded {
+						return fmt.Errorf("expected to the state to be %v but was %v", apb.StateSucceeded, state.State)
+					}
+					return nil
+				}
+				expectedCalls := map[string]int{
+					"DeleteExtractedCredentials": 1,
+					"DeleteServiceInstance":      1,
+					"SetState":                   1,
+				}
+				return dao, expectedCalls
+			},
+		},
+		{
+			Name: "should set state to failed if clean up failed to delete serviceInstance",
+			JobMsg: broker.JobMsg{
+				InstanceUUID: instanceID,
+				State: apb.JobState{
+					State:  apb.StateSucceeded,
+					Method: apb.JobMethodProvision,
+				},
+				ExtractedCredentials: apb.ExtractedCredentials{
+					Credentials: map[string]interface{}{"user": "test", "pass": "test"},
+				},
+			},
+			DAO: func() (*mock.SubscriberDAO, map[string]int) {
+				dao := mock.NewSubscriberDAO()
+				dao.AssertOn["DeleteExtractedCredentials"] = func(args ...interface{}) error {
+					id := args[0].(string)
+					if id != "id" {
+						return fmt.Errorf("epected the id to be : id but was %s", id)
+					}
+					return nil
+				}
+				dao.AssertOn["DeleteServiceInstance"] = func(args ...interface{}) error {
+					id := args[0].(string)
+					if id != "id" {
+						return fmt.Errorf("epected the id to be : id but was %s", id)
+					}
+					return nil
+				}
+				var states []apb.JobState
+				dao.AssertOn["SetState"] = func(i ...interface{}) error {
+					state := i[1].(apb.JobState)
+					states = append(states, state)
+					if states[0].State != apb.StateSucceeded {
+						return fmt.Errorf("expected to the state to be %v but was %v", apb.StateSucceeded, states[0].State)
+					}
+					if len(states) == 2 && states[1].State != apb.StateFailed {
+						return fmt.Errorf("expected to the state to be %v but was %v", apb.StateFailed, states[1].State)
+					}
+					return nil
+				}
+				dao.Errs["DeleteServiceInstance"] = fmt.Errorf("not there")
+				expectedCalls := map[string]int{
+					"DeleteExtractedCredentials": 1,
+					"DeleteServiceInstance":      1,
+					"SetState":                   2,
+				}
+				return dao, expectedCalls
+			},
+		},
+		{
+			Name: "should set state to failed if clean up failed to delete extractedCredentials",
+			JobMsg: broker.JobMsg{
+				InstanceUUID: instanceID,
+				State: apb.JobState{
+					State:  apb.StateSucceeded,
+					Method: apb.JobMethodProvision,
+				},
+				ExtractedCredentials: apb.ExtractedCredentials{
+					Credentials: map[string]interface{}{"user": "test", "pass": "test"},
+				},
+			},
+			DAO: func() (*mock.SubscriberDAO, map[string]int) {
+				dao := mock.NewSubscriberDAO()
+				dao.AssertOn["DeleteExtractedCredentials"] = func(args ...interface{}) error {
+					id := args[0].(string)
+					if id != "id" {
+						return fmt.Errorf("epected the id to be : id but was %s", id)
+					}
+					return nil
+				}
+				dao.AssertOn["DeleteServiceInstance"] = func(args ...interface{}) error {
+
+					return fmt.Errorf("shouldn't have got to DeleteServiceInstance")
+
+				}
+				var states []apb.JobState
+				dao.AssertOn["SetState"] = func(i ...interface{}) error {
+					state := i[1].(apb.JobState)
+					states = append(states, state)
+					if states[0].State != apb.StateSucceeded {
+						return fmt.Errorf("expected to the state to be %v but was %v", apb.StateSucceeded, states[0].State)
+					}
+					if len(states) == 2 && states[1].State != apb.StateFailed {
+						return fmt.Errorf("expected to the state to be %v but was %v", apb.StateFailed, states[1].State)
+					}
+					return nil
+				}
+				dao.Errs["DeleteExtractedCredentials"] = fmt.Errorf("not there")
+				expectedCalls := map[string]int{
+					"DeleteExtractedCredentials": 1,
+					"DeleteServiceInstance":      0,
+					"SetState":                   2,
+				}
+				return dao, expectedCalls
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			dao, expectedCalls := tc.DAO()
+			sub := broker.NewDeprovisionWorkSubscriber(dao)
+			wait := sync.WaitGroup{}
+			wait.Add(1)
+			// this is a bit gross but hard to test the subscribe method as it has a constant for loop
+			// so we give it 100ms to process the message and then do our checks
+			sender := make(chan broker.JobMsg)
+			sub.Subscribe(sender)
+			time.AfterFunc(100*time.Millisecond, func() {
+				close(sender)
+				wait.Done()
+			})
+			sender <- tc.JobMsg
+			wait.Wait()
+			if len(dao.AssertErrors()) != 0 {
+				t.Fatal("unexpected error during data assertions ", dao.AssertErrors())
+			}
+			if err := dao.CheckCalls(expectedCalls); err != nil {
+				t.Fatal("unexpected error checking calls ", err)
+			}
+		})
+	}
+}

--- a/pkg/broker/provision_job.go
+++ b/pkg/broker/provision_job.go
@@ -27,6 +27,9 @@ type ProvisionJob struct {
 	provision       apb.Provisioner
 }
 
+// Provisioner defines a function that knows how to provision an apb
+type Provisioner func(si *apb.ServiceInstance) (string, *apb.ExtractedCredentials, error)
+
 // NewProvisionJob - Create a new provision job.
 func NewProvisionJob(serviceInstance *apb.ServiceInstance, provision apb.Provisioner) *ProvisionJob {
 	return &ProvisionJob{

--- a/pkg/broker/provision_job.go
+++ b/pkg/broker/provision_job.go
@@ -27,9 +27,6 @@ type ProvisionJob struct {
 	provision       apb.Provisioner
 }
 
-// Provisioner defines a function that knows how to provision an apb
-type Provisioner func(si *apb.ServiceInstance) (string, *apb.ExtractedCredentials, error)
-
 // NewProvisionJob - Create a new provision job.
 func NewProvisionJob(serviceInstance *apb.ServiceInstance, provision apb.Provisioner) *ProvisionJob {
 	return &ProvisionJob{
@@ -40,43 +37,66 @@ func NewProvisionJob(serviceInstance *apb.ServiceInstance, provision apb.Provisi
 
 // Run - run the provision job.
 func (p *ProvisionJob) Run(token string, msgBuffer chan<- JobMsg) {
+	// receives state updates during the provision action
+	stateUpdates := make(chan apb.JobState, 1)
 	metrics.ProvisionJobStarted()
-	defer metrics.ProvisionJobFinished()
 	jobMsg := JobMsg{
 		InstanceUUID: p.serviceInstance.ID.String(),
 		JobToken:     token,
 		SpecID:       p.serviceInstance.Spec.ID,
 		State: apb.JobState{
-			State:  apb.StateInProgress,
-			Method: apb.JobMethodProvision,
-			Token:  token,
+			State:       apb.StateInProgress,
+			Method:      apb.JobMethodProvision,
+			Token:       token,
+			Description: "provision job started",
 		},
 	}
-	msgBuffer <- jobMsg
-	podName, extCreds, err := p.provision(p.serviceInstance)
 
+	var (
+		err      error
+		errMsg   = "Error occurred during provision. Please contact administrator if it persists."
+		podName  string
+		extCreds *apb.ExtractedCredentials
+	)
+
+	go func() {
+		defer func() {
+			close(stateUpdates)
+			metrics.ProvisionJobFinished()
+		}()
+		msgBuffer <- jobMsg
+		podName, extCreds, err = p.provision(p.serviceInstance, stateUpdates)
+	}()
+	for stateUpdate := range stateUpdates {
+		stateUpdate.Token = token
+		stateUpdate.Method = apb.JobMethodProvision
+		msgBuffer <- JobMsg{InstanceUUID: p.serviceInstance.ID.String(), JobToken: token, State: stateUpdate, PodName: stateUpdate.Podname}
+	}
+	// Once our job is finished evaluate if there was an err and update the state accordingly
 	if err != nil {
 		log.Errorf("broker::Provision error occurred. %s", err.Error())
-		errMsg := "Error occurred during provision. Please contact administrator if it persists."
+
 		// Because we know the error we should return that error.
 		if err == apb.ErrorPodPullErr {
 			errMsg = err.Error()
 		}
+
+		jobMsg.State.State = apb.StateFailed
 		// send error message, can't have
 		// an error type in a struct you want marshalled
 		// https://github.com/golang/go/issues/5161
-		jobMsg.State.State = apb.StateFailed
-		jobMsg.State.Error = errMsg
+		jobMsg.State.Error = err.Error()
+		jobMsg.State.Description = errMsg
 		msgBuffer <- jobMsg
 		return
 	}
-
-	// send creds
 	jobMsg.State.State = apb.StateSucceeded
 	jobMsg.State.Podname = podName
+	// send creds
 	if nil != extCreds {
 		jobMsg.ExtractedCredentials = *extCreds
 	}
 	jobMsg.PodName = podName
+	jobMsg.State.Description = "provision job completed"
 	msgBuffer <- jobMsg
 }

--- a/pkg/broker/types.go
+++ b/pkg/broker/types.go
@@ -301,4 +301,7 @@ func (jm JobMsg) Render() string {
 type SubscriberDAO interface {
 	SetExtractedCredentials(id string, extCreds *apb.ExtractedCredentials) error
 	SetState(id string, state apb.JobState) (string, error)
+	GetServiceInstance(id string) (*apb.ServiceInstance, error)
+	DeleteExtractedCredentials(id string) error
+	DeleteServiceInstance(id string) error
 }

--- a/pkg/broker/unbinding_job_test.go
+++ b/pkg/broker/unbinding_job_test.go
@@ -30,7 +30,7 @@ func TestUnBindingJob_Run(t *testing.T) {
 	}{
 		{
 			Name: "expect a success msg",
-			UnBinder: func(si *apb.ServiceInstance, params *apb.Parameters) error {
+			UnBinder: func(si *apb.ServiceInstance, params *apb.Parameters, state chan<- apb.JobState) error {
 				return nil
 			},
 			Validate: func(msgs []broker.JobMsg) error {
@@ -40,7 +40,7 @@ func TestUnBindingJob_Run(t *testing.T) {
 		{
 			Name:          "expect a success msg when skipping apb execution",
 			SkipExecution: true,
-			UnBinder: func(si *apb.ServiceInstance, params *apb.Parameters) error {
+			UnBinder: func(si *apb.ServiceInstance, params *apb.Parameters, state chan<- apb.JobState) error {
 				return nil
 			},
 			Validate: func(msgs []broker.JobMsg) error {
@@ -49,7 +49,7 @@ func TestUnBindingJob_Run(t *testing.T) {
 		},
 		{
 			Name: "expect failure state and generic error when unknown error type",
-			UnBinder: func(si *apb.ServiceInstance, params *apb.Parameters) error {
+			UnBinder: func(si *apb.ServiceInstance, params *apb.Parameters, state chan<- apb.JobState) error {
 				return fmt.Errorf("should not see")
 			},
 			Validate: func(msgs []broker.JobMsg) error {
@@ -68,7 +68,7 @@ func TestUnBindingJob_Run(t *testing.T) {
 		},
 		{
 			Name: "expect failure state and full error when known error type",
-			UnBinder: func(si *apb.ServiceInstance, params *apb.Parameters) error {
+			UnBinder: func(si *apb.ServiceInstance, params *apb.Parameters, state chan<- apb.JobState) error {
 				return apb.ErrorPodPullErr
 			},
 			Validate: func(msgs []broker.JobMsg) error {

--- a/pkg/broker/update_job_test.go
+++ b/pkg/broker/update_job_test.go
@@ -1,0 +1,136 @@
+//
+// Copyright (c) 2018 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Red Hat trademarks are not licensed under Apache License, Version 2.
+// No permission is granted to use or replicate Red Hat trademarks that
+// are incorporated in this software or its documentation.
+//
+package broker_test
+
+import (
+	"testing"
+
+	"time"
+
+	"fmt"
+
+	"github.com/openshift/ansible-service-broker/pkg/apb"
+	"github.com/openshift/ansible-service-broker/pkg/broker"
+	"github.com/pborman/uuid"
+)
+
+func TestUpdateJob_Run(t *testing.T) {
+	var uid = uuid.NewRandom()
+	var serviceInstance = &apb.ServiceInstance{
+		ID: uid,
+		Spec: &apb.Spec{
+			ID: "test",
+		},
+	}
+	var commonMsgValidation = func(expectedFinalState apb.State, msgs []broker.JobMsg) error {
+		if len(msgs) < 2 {
+			return fmt.Errorf("expected 2 msgs but only got %v", len(msgs))
+		}
+		for i, msg := range msgs {
+			if msg.State.Method != apb.JobMethodUpdate {
+				return fmt.Errorf("expected job msg method to be %v but it was %v", apb.JobMethodUpdate, msg.State.Method)
+			}
+			if i == 0 && msg.State.State != apb.StateInProgress {
+				return fmt.Errorf("expected job msg state to be %v but it was %v", apb.StateInProgress, msg.State.State)
+			}
+
+			if i == len(msgs)-1 && msg.State.State != expectedFinalState {
+				return fmt.Errorf("expected job msg state to be %v but it was %v", expectedFinalState, msg.State.State)
+			}
+		}
+		return nil
+	}
+	cases := []struct {
+		Name     string
+		Update   apb.Updater
+		Validate func(msg []broker.JobMsg) error
+	}{
+		{
+			Name: "expect a success msg with extracted credentials when no error occurs",
+			Update: func(si *apb.ServiceInstance, statusUpdate chan<- apb.JobState) (string, *apb.ExtractedCredentials, error) {
+				return "podName", &apb.ExtractedCredentials{Credentials: map[string]interface{}{
+					"user": "test",
+					"pass": "test",
+				}}, nil
+			},
+			Validate: func(msgs []broker.JobMsg) error {
+				return commonMsgValidation(apb.StateSucceeded, msgs)
+			},
+		},
+		{
+			Name: "expect failure state and generic error when unknown error type",
+			Update: func(si *apb.ServiceInstance, statusUpdates chan<- apb.JobState) (string, *apb.ExtractedCredentials, error) {
+				return "", nil, fmt.Errorf("should not see")
+			},
+			Validate: func(msgs []broker.JobMsg) error {
+				if err := commonMsgValidation(apb.StateFailed, msgs); err != nil {
+					return err
+				}
+				finalMsg := msgs[len(msgs)-1]
+				if finalMsg.State.Error == "" {
+					return fmt.Errorf("expected an error in the job state but got none")
+				}
+				if finalMsg.State.Description == "should not see" {
+					return fmt.Errorf("expected not to see the error msg %s it should have been replaced with a generic error ", finalMsg.State.Error)
+				}
+				return nil
+			},
+		},
+		{
+			Name: "expect failure state and full error when known error type",
+			Update: func(si *apb.ServiceInstance, statusUpdates chan<- apb.JobState) (string, *apb.ExtractedCredentials, error) {
+				return "", nil, apb.ErrorPodPullErr
+			},
+			Validate: func(msgs []broker.JobMsg) error {
+				if err := commonMsgValidation(apb.StateFailed, msgs); err != nil {
+					return err
+				}
+				finalMsg := msgs[len(msgs)-1]
+				if finalMsg.State.Error == "" {
+					return fmt.Errorf("expected an error in the job state but got none")
+				}
+				if finalMsg.State.Error != apb.ErrorPodPullErr.Error() {
+					return fmt.Errorf("expected to see the error failed %s but got %s ", apb.ErrorPodPullErr, finalMsg.State.Error)
+				}
+				return nil
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			update := broker.NewUpdateJob(serviceInstance, tc.Update)
+			receiver := make(chan broker.JobMsg)
+			// give some time to allow msgs to be sent as we are not actually provisioning this should be plenty
+			time.AfterFunc(200*time.Millisecond, func() {
+				close(receiver)
+			})
+			go update.Run("", receiver)
+			var msgs []broker.JobMsg
+			for msg := range receiver {
+				msgs = append(msgs, msg)
+			}
+			if err := tc.Validate(msgs); err != nil {
+				t.Fatal("failed to validate the jobmsg ", err)
+			}
+
+		})
+	}
+}

--- a/pkg/broker/update_subscriber.go
+++ b/pkg/broker/update_subscriber.go
@@ -18,16 +18,15 @@ package broker
 
 import (
 	"github.com/openshift/ansible-service-broker/pkg/apb"
-	"github.com/openshift/ansible-service-broker/pkg/dao"
 )
 
 // UpdateWorkSubscriber - Lissten for provision messages
 type UpdateWorkSubscriber struct {
-	dao dao.Dao
+	dao SubscriberDAO
 }
 
 // NewUpdateWorkSubscriber - Create a new work subscriber.
-func NewUpdateWorkSubscriber(dao dao.Dao) *UpdateWorkSubscriber {
+func NewUpdateWorkSubscriber(dao SubscriberDAO) *UpdateWorkSubscriber {
 	return &UpdateWorkSubscriber{dao: dao}
 }
 

--- a/pkg/broker/work_engine_test.go
+++ b/pkg/broker/work_engine_test.go
@@ -101,7 +101,7 @@ func TestStartNewJob(t *testing.T) {
 	worker := &mockWorker{wg: &wg}
 	work = worker
 
-	token, err := engine.StartNewJob("testtoken", work, ProvisionTopic)
+	token, err := engine.StartNewAsyncJob("testtoken", work, ProvisionTopic)
 	ft.AssertNil(t, err)
 	ft.AssertEqual(t, "testtoken", token, "token doesn't match")
 

--- a/pkg/mock/dao.go
+++ b/pkg/mock/dao.go
@@ -1,0 +1,112 @@
+package mock
+
+import (
+	"fmt"
+
+	"github.com/openshift/ansible-service-broker/pkg/apb"
+)
+
+// SubscriberDAO is mock DAO
+type SubscriberDAO struct {
+	calls     map[string]int
+	Errs      map[string]error
+	assertErr []error
+	AssertOn  map[string]func(...interface{}) error
+	Object    map[string]interface{}
+}
+
+// SetExtractedCredentials sets extracted credentials
+func (mp *SubscriberDAO) SetExtractedCredentials(id string, extCreds *apb.ExtractedCredentials) error {
+	assert := mp.AssertOn["SetExtractedCredentials"]
+	if nil != assert {
+		if err := assert(id, extCreds); err != nil {
+			mp.assertErr = append(mp.assertErr, err)
+			return err
+		}
+	}
+	mp.calls["SetExtractedCredentials"]++
+	return mp.Errs["SetExtractedCredentials"]
+
+}
+
+// SetState sets the JobState
+func (mp *SubscriberDAO) SetState(id string, state apb.JobState) (string, error) {
+	assert := mp.AssertOn["SetState"]
+	if nil != assert {
+		if err := assert(id, state); err != nil {
+			mp.assertErr = append(mp.assertErr, err)
+			return id, err
+		}
+	}
+	mp.calls["SetState"]++
+	return id, mp.Errs["SetState"]
+
+}
+
+// DeleteExtractedCredentials deletes extracted credentials
+func (mp *SubscriberDAO) DeleteExtractedCredentials(id string) error {
+	assert := mp.AssertOn["DeleteExtractedCredentials"]
+	if nil != assert {
+		if err := assert(id); err != nil {
+			mp.assertErr = append(mp.assertErr, err)
+			return err
+		}
+	}
+	mp.calls["DeleteExtractedCredentials"]++
+	return mp.Errs["DeleteExtractedCredentials"]
+}
+
+// DeleteServiceInstance deletes the serviceInstance
+func (mp *SubscriberDAO) DeleteServiceInstance(id string) error {
+	assert := mp.AssertOn["DeleteServiceInstance"]
+	if nil != assert {
+		if err := assert(id); err != nil {
+			mp.assertErr = append(mp.assertErr, err)
+			return err
+		}
+	}
+	mp.calls["DeleteServiceInstance"]++
+	return mp.Errs["DeleteServiceInstance"]
+}
+
+// GetServiceInstance gets a serviceInstance by id
+func (mp *SubscriberDAO) GetServiceInstance(id string) (*apb.ServiceInstance, error) {
+	assert := mp.AssertOn["GetServiceInstance"]
+	if nil != assert {
+		if err := assert(id); err != nil {
+			mp.assertErr = append(mp.assertErr, err)
+			return nil, err
+		}
+	}
+	mp.calls["GetServiceInstance"]++
+	retOb := mp.Object["GetServiceInstance"]
+	if nil == retOb {
+		return nil, mp.Errs["GetServiceInstance"]
+	}
+	return retOb.(*apb.ServiceInstance), mp.Errs["GetServiceInstance"]
+}
+
+// CheckCalls will check the calls made match the expected calls
+func (mp *SubscriberDAO) CheckCalls(calls map[string]int) error {
+	for k, v := range calls {
+		if mp.calls[k] != v {
+			return fmt.Errorf("expected %d calls to %s but got %d ", v, k, mp.calls[k])
+		}
+	}
+	return nil
+}
+
+// AssertErrors returns any assert errors
+func (mp *SubscriberDAO) AssertErrors() []error {
+	return mp.assertErr
+}
+
+// NewSubscriberDAO returns mock SubscriberDAO
+func NewSubscriberDAO() *SubscriberDAO {
+	return &SubscriberDAO{
+		Errs:     map[string]error{},
+		calls:    map[string]int{},
+		AssertOn: map[string]func(...interface{}) error{},
+		Object:   map[string]interface{}{},
+	}
+}


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
broker implementation for issue 475 last operation description
**Note**
This pr is based on top of the previous PR https://github.com/openshift/ansible-service-broker/pull/610 so probably better to review once that one is closed out. 
Changes proposed in this pull request
 - Add new channel that sends JobState changes asynchronously to allow the state to be updated ready for the last operation polling endpoint to read.
 - Add sets of tests for various places that have been changed.
 - change the watch pod to use the watch API
- Add StartSyncJob to unify the broker Job API

**Does this PR depend on another PR (Use this to track when PRs should be merged)**
~~depends-on https://github.com/openshift/ansible-service-broker/pull/610~~
depends-on https://github.com/openshift/ansible-service-broker/pull/671

**Which issue this PR fixes (This will close that issue when PR gets merged)**
fixes #475
