### PR TITLE
uses "exec" so bash process gets replaced instead of retained

### DIFF
--- a/build/entrypoint.sh
+++ b/build/entrypoint.sh
@@ -16,4 +16,4 @@ if [ ! -f "$BROKER_CONFIG" ] ; then
 fi
 echo "Using config file mounted to $BROKER_CONFIG"
 
-asbd -c $BROKER_CONFIG $FLAGS
+exec asbd -c $BROKER_CONFIG $FLAGS


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
Previously, a bash process would stay running all the time, and the broker
would be a child process of it. It is a best practice when building containers
to use "exec" to avoid such unneccessary parent processes.

**Changes proposed in this pull request**
 - use "exec" in the entrypoint script

Before this change, you can see the extra bash process sitting around as PID 1:

```
$ oc exec -it asb-2-7rd7b -- ps -awfux
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
ansible+    20  0.0  0.0  47456  3240 ?        Rs+  19:40   0:00 ps -awfux
ansible+     1  0.0  0.0  11652  2412 ?        Ss   18:32   0:00 bash /usr/bin/entrypoint.sh
ansible+     9  0.2  0.3 283316 46148 ?        Sl   18:32   0:10 asbd -c /etc/ansible-service-broker/config.yaml
```

After this change, no bash to be found:

```
$ oc exec -it asb-2-5mhvl -- ps -awfux
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
ansible+    16  0.0  0.0  47456  3228 ?        Rs+  21:06   0:00 ps -awfux
ansible+     1  0.8  0.2 322140 35408 ?        Ssl  21:05   0:00 asbd -c /etc/ansible-service-broker/config.yaml
```