### PR TITLE
Async bind feature

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -232,6 +232,13 @@ func CreateApp() App {
 		log.Errorf("Failed to attach subscriber to WorkEngine: %s", err.Error())
 		os.Exit(1)
 	}
+	err = app.engine.AttachSubscriber(
+		broker.NewBindingWorkSubscriber(app.dao),
+		broker.BindingTopic)
+	if err != nil {
+		log.Errorf("Failed to attach subscriber to WorkEngine: %s", err.Error())
+		os.Exit(1)
+	}
 	log.Debugf("Active work engine topics: %+v", app.engine.GetActiveTopics())
 
 	apb.InitializeSecretsCache(app.config.GetSubConfig("secrets"))

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -239,6 +239,13 @@ func CreateApp() App {
 		log.Errorf("Failed to attach subscriber to WorkEngine: %s", err.Error())
 		os.Exit(1)
 	}
+	err = app.engine.AttachSubscriber(
+		broker.NewUnbindingWorkSubscriber(app.dao),
+		broker.UnbindingTopic)
+	if err != nil {
+		log.Errorf("Failed to attach subscriber to WorkEngine: %s", err.Error())
+		os.Exit(1)
+	}
 	log.Debugf("Active work engine topics: %+v", app.engine.GetActiveTopics())
 
 	apb.InitializeSecretsCache(app.config.GetSubConfig("secrets"))

--- a/pkg/broker/binding_job.go
+++ b/pkg/broker/binding_job.go
@@ -30,6 +30,7 @@ import (
 // BindingJob - Job to provision
 type BindingJob struct {
 	serviceInstance *apb.ServiceInstance
+	params          *apb.Parameters
 }
 
 // BindingMsg - Message to be returned from the binding job
@@ -58,14 +59,14 @@ func NewBindingJob(serviceInstance *apb.ServiceInstance) *BindingJob {
 // Run - run the binding job.
 func (p *BindingJob) Run(token string, msgBuffer chan<- WorkMsg) {
 	metrics.BindingJobStarted()
-	var podName, extCreds string
+	var podName string
+	var extCreds *apb.ExtractedCredentials
 	var err error
 
-	// podName, extCreds, err := apb.Provision(p.serviceInstance)
+	podName, extCreds, err = apb.Bind(p.serviceInstance, p.params)
 
 	if err != nil {
-		log.Error("broker::Binding error occurred.")
-		log.Errorf("%s", err.Error())
+		log.Errorf("broker::Binding error occurred.\n%s", err.Error())
 
 		// send error message
 		// can't have an error type in a struct you want marshalled

--- a/pkg/broker/binding_job.go
+++ b/pkg/broker/binding_job.go
@@ -34,9 +34,10 @@ type BindingJob struct {
 }
 
 // NewBindingJob - Create a new binding job.
-func NewBindingJob(serviceInstance *apb.ServiceInstance) *BindingJob {
+func NewBindingJob(serviceInstance *apb.ServiceInstance, params *apb.Parameters) *BindingJob {
 	return &BindingJob{
 		serviceInstance: serviceInstance,
+		params:          params,
 	}
 }
 

--- a/pkg/broker/binding_job.go
+++ b/pkg/broker/binding_job.go
@@ -44,13 +44,10 @@ func NewBindingJob(serviceInstance *apb.ServiceInstance, params *apb.Parameters)
 // Run - run the binding job.
 func (p *BindingJob) Run(token string, msgBuffer chan<- JobMsg) {
 	metrics.BindingJobStarted()
-	var podName string
-	var extCreds *apb.ExtractedCredentials
-	var err error
 
 	log.Debug("BJ: binding job started, calling apb.Bind")
 
-	podName, extCreds, err = apb.Bind(p.serviceInstance, p.params)
+	podName, extCreds, err := apb.Bind(p.serviceInstance, p.params)
 
 	log.Debug("BJ: RETURNED from apb.Bind")
 

--- a/pkg/broker/binding_job.go
+++ b/pkg/broker/binding_job.go
@@ -1,0 +1,95 @@
+//
+// Copyright (c) 2017 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Red Hat trademarks are not licensed under Apache License, Version 2.
+// No permission is granted to use or replicate Red Hat trademarks that
+// are incorporated in this software or its documentation.
+//
+
+package broker
+
+import (
+	"encoding/json"
+
+	logging "github.com/op/go-logging"
+	"github.com/openshift/ansible-service-broker/pkg/apb"
+	"github.com/openshift/ansible-service-broker/pkg/metrics"
+)
+
+// BindingJob - Job to provision
+type BindingJob struct {
+	serviceInstance *apb.ServiceInstance
+	clusterConfig   apb.ClusterConfig
+	log             *logging.Logger
+}
+
+// BindingMsg - Message to be returned from the binding job
+type BindingMsg struct {
+	InstanceUUID string `json:"instance_uuid"`
+	JobToken     string `json:"job_token"`
+	SpecID       string `json:"spec_id"`
+	PodName      string `json:"podname"`
+	Msg          string `json:"msg"`
+	Error        string `json:"error"`
+}
+
+// Render - Display the binding message.
+func (m BindingMsg) Render() string {
+	render, _ := json.Marshal(m)
+	return string(render)
+}
+
+// NewBindingJob - Create a new binding job.
+func NewBindingJob(serviceInstance *apb.ServiceInstance, clusterConfig apb.ClusterConfig,
+	log *logging.Logger,
+) *BindingJob {
+	return &BindingJob{
+		serviceInstance: serviceInstance,
+		clusterConfig:   clusterConfig,
+		log:             log,
+	}
+}
+
+// Run - run the binding job.
+func (p *BindingJob) Run(token string, msgBuffer chan<- WorkMsg) {
+	metrics.BindingJobStarted()
+	var podName, extCreds string
+	var err error
+
+	// podName, extCreds, err := apb.Provision(p.serviceInstance, p.clusterConfig, p.log)
+
+	if err != nil {
+		p.log.Error("broker::Binding error occurred.")
+		p.log.Errorf("%s", err.Error())
+
+		// send error message
+		// can't have an error type in a struct you want marshalled
+		// https://github.com/golang/go/issues/5161
+		msgBuffer <- BindingMsg{InstanceUUID: p.serviceInstance.ID.String(),
+			JobToken: token, SpecID: p.serviceInstance.Spec.ID, PodName: "", Msg: "", Error: err.Error()}
+		return
+	}
+
+	// send creds
+	jsonmsg, err := json.Marshal(extCreds)
+	if err != nil {
+		msgBuffer <- BindingMsg{InstanceUUID: p.serviceInstance.ID.String(),
+			JobToken: token, SpecID: p.serviceInstance.Spec.ID, PodName: "", Msg: "", Error: err.Error()}
+		return
+	}
+
+	msgBuffer <- BindingMsg{InstanceUUID: p.serviceInstance.ID.String(),
+		JobToken: token, SpecID: p.serviceInstance.Spec.ID, PodName: podName, Msg: string(jsonmsg), Error: ""}
+}

--- a/pkg/broker/binding_job.go
+++ b/pkg/broker/binding_job.go
@@ -48,14 +48,14 @@ func NewBindingJob(serviceInstance *apb.ServiceInstance, bindingUUID uuid.UUID, 
 func (p *BindingJob) Run(token string, msgBuffer chan<- JobMsg) {
 	metrics.BindingJobStarted()
 
-	log.Debug("BJ: binding job started, calling apb.Bind")
+	log.Debug("bindjob: binding job started, calling apb.Bind")
 
 	podName, extCreds, err := apb.Bind(p.serviceInstance, p.params)
 
-	log.Debug("BJ: RETURNED from apb.Bind")
+	log.Debug("bindjob: returned from apb.Bind")
 
 	if err != nil {
-		log.Errorf("broker::Binding error occurred.\n%s", err.Error())
+		log.Errorf("bindjob::Binding error occurred.\n%s", err.Error())
 
 		// send error message
 		// can't have an error type in a struct you want marshalled
@@ -66,19 +66,16 @@ func (p *BindingJob) Run(token string, msgBuffer chan<- JobMsg) {
 		return
 	}
 
-	log.Debug("BJ: No error, going to marshal the credentials")
-
 	// send creds
 	jsonmsg, err := json.Marshal(extCreds)
 	if err != nil {
-		log.Debug("BJ: ERROR during marshal")
 		msgBuffer <- JobMsg{InstanceUUID: p.serviceInstance.ID.String(),
 			BindingUUID: p.bindingUUID.String(), JobToken: token,
 			SpecID: p.serviceInstance.Spec.ID, PodName: "", Msg: "", Error: err.Error()}
 		return
 	}
 
-	log.Debug("BJ: Looks like we're done")
+	log.Debug("bindjob: looks like we're done, sending credentials")
 	msgBuffer <- JobMsg{InstanceUUID: p.serviceInstance.ID.String(),
 		BindingUUID: p.bindingUUID.String(), JobToken: token,
 		SpecID: p.serviceInstance.Spec.ID, PodName: podName, Msg: string(jsonmsg), Error: ""}

--- a/pkg/broker/binding_job.go
+++ b/pkg/broker/binding_job.go
@@ -48,7 +48,11 @@ func (p *BindingJob) Run(token string, msgBuffer chan<- JobMsg) {
 	var extCreds *apb.ExtractedCredentials
 	var err error
 
+	log.Debug("BJ: binding job started, calling apb.Bind")
+
 	podName, extCreds, err = apb.Bind(p.serviceInstance, p.params)
+
+	log.Debug("BJ: RETURNED from apb.Bind")
 
 	if err != nil {
 		log.Errorf("broker::Binding error occurred.\n%s", err.Error())
@@ -61,14 +65,18 @@ func (p *BindingJob) Run(token string, msgBuffer chan<- JobMsg) {
 		return
 	}
 
+	log.Debug("BJ: No error, going to marshal the credentials")
+
 	// send creds
 	jsonmsg, err := json.Marshal(extCreds)
 	if err != nil {
+		log.Debug("BJ: ERROR during marshal")
 		msgBuffer <- JobMsg{InstanceUUID: p.serviceInstance.ID.String(),
 			JobToken: token, SpecID: p.serviceInstance.Spec.ID, PodName: "", Msg: "", Error: err.Error()}
 		return
 	}
 
+	log.Debug("BJ: Looks like we're done")
 	msgBuffer <- JobMsg{InstanceUUID: p.serviceInstance.ID.String(),
 		JobToken: token, SpecID: p.serviceInstance.Spec.ID, PodName: podName, Msg: string(jsonmsg), Error: ""}
 }

--- a/pkg/broker/binding_job.go
+++ b/pkg/broker/binding_job.go
@@ -33,22 +33,6 @@ type BindingJob struct {
 	params          *apb.Parameters
 }
 
-// BindingMsg - Message to be returned from the binding job
-type BindingMsg struct {
-	InstanceUUID string `json:"instance_uuid"`
-	JobToken     string `json:"job_token"`
-	SpecID       string `json:"spec_id"`
-	PodName      string `json:"podname"`
-	Msg          string `json:"msg"`
-	Error        string `json:"error"`
-}
-
-// Render - Display the binding message.
-func (m BindingMsg) Render() string {
-	render, _ := json.Marshal(m)
-	return string(render)
-}
-
 // NewBindingJob - Create a new binding job.
 func NewBindingJob(serviceInstance *apb.ServiceInstance) *BindingJob {
 	return &BindingJob{
@@ -57,7 +41,7 @@ func NewBindingJob(serviceInstance *apb.ServiceInstance) *BindingJob {
 }
 
 // Run - run the binding job.
-func (p *BindingJob) Run(token string, msgBuffer chan<- WorkMsg) {
+func (p *BindingJob) Run(token string, msgBuffer chan<- JobMsg) {
 	metrics.BindingJobStarted()
 	var podName string
 	var extCreds *apb.ExtractedCredentials
@@ -71,7 +55,7 @@ func (p *BindingJob) Run(token string, msgBuffer chan<- WorkMsg) {
 		// send error message
 		// can't have an error type in a struct you want marshalled
 		// https://github.com/golang/go/issues/5161
-		msgBuffer <- BindingMsg{InstanceUUID: p.serviceInstance.ID.String(),
+		msgBuffer <- JobMsg{InstanceUUID: p.serviceInstance.ID.String(),
 			JobToken: token, SpecID: p.serviceInstance.Spec.ID, PodName: "", Msg: "", Error: err.Error()}
 		return
 	}
@@ -79,11 +63,11 @@ func (p *BindingJob) Run(token string, msgBuffer chan<- WorkMsg) {
 	// send creds
 	jsonmsg, err := json.Marshal(extCreds)
 	if err != nil {
-		msgBuffer <- BindingMsg{InstanceUUID: p.serviceInstance.ID.String(),
+		msgBuffer <- JobMsg{InstanceUUID: p.serviceInstance.ID.String(),
 			JobToken: token, SpecID: p.serviceInstance.Spec.ID, PodName: "", Msg: "", Error: err.Error()}
 		return
 	}
 
-	msgBuffer <- BindingMsg{InstanceUUID: p.serviceInstance.ID.String(),
+	msgBuffer <- JobMsg{InstanceUUID: p.serviceInstance.ID.String(),
 		JobToken: token, SpecID: p.serviceInstance.Spec.ID, PodName: podName, Msg: string(jsonmsg), Error: ""}
 }

--- a/pkg/broker/binding_job.go
+++ b/pkg/broker/binding_job.go
@@ -23,7 +23,6 @@ package broker
 import (
 	"encoding/json"
 
-	logging "github.com/op/go-logging"
 	"github.com/openshift/ansible-service-broker/pkg/apb"
 	"github.com/openshift/ansible-service-broker/pkg/metrics"
 )
@@ -31,8 +30,6 @@ import (
 // BindingJob - Job to provision
 type BindingJob struct {
 	serviceInstance *apb.ServiceInstance
-	clusterConfig   apb.ClusterConfig
-	log             *logging.Logger
 }
 
 // BindingMsg - Message to be returned from the binding job
@@ -52,13 +49,9 @@ func (m BindingMsg) Render() string {
 }
 
 // NewBindingJob - Create a new binding job.
-func NewBindingJob(serviceInstance *apb.ServiceInstance, clusterConfig apb.ClusterConfig,
-	log *logging.Logger,
-) *BindingJob {
+func NewBindingJob(serviceInstance *apb.ServiceInstance) *BindingJob {
 	return &BindingJob{
 		serviceInstance: serviceInstance,
-		clusterConfig:   clusterConfig,
-		log:             log,
 	}
 }
 
@@ -68,11 +61,11 @@ func (p *BindingJob) Run(token string, msgBuffer chan<- WorkMsg) {
 	var podName, extCreds string
 	var err error
 
-	// podName, extCreds, err := apb.Provision(p.serviceInstance, p.clusterConfig, p.log)
+	// podName, extCreds, err := apb.Provision(p.serviceInstance)
 
 	if err != nil {
-		p.log.Error("broker::Binding error occurred.")
-		p.log.Errorf("%s", err.Error())
+		log.Error("broker::Binding error occurred.")
+		log.Errorf("%s", err.Error())
 
 		// send error message
 		// can't have an error type in a struct you want marshalled

--- a/pkg/broker/binding_subscriber.go
+++ b/pkg/broker/binding_subscriber.go
@@ -1,0 +1,89 @@
+//
+// Copyright (c) 2017 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Red Hat trademarks are not licensed under Apache License, Version 2.
+// No permission is granted to use or replicate Red Hat trademarks that
+// are incorporated in this software or its documentation.
+//
+package broker
+
+import (
+	"encoding/json"
+
+	logging "github.com/op/go-logging"
+	"github.com/openshift/ansible-service-broker/pkg/dao"
+	"github.com/openshift/ansible-service-broker/pkg/metrics"
+)
+
+// BindingWorkSubscriber - Listen for binding messages
+type BindingWorkSubscriber struct {
+	dao       *dao.Dao
+	log       *logging.Logger
+	msgBuffer <-chan WorkMsg
+}
+
+func NewBindingWorkSubscriber(dao *dao.Dao, log *logging.Logger) *BindingWorkSubscriber {
+	return &BindingWorkSubscriber{dao: dao, log: log}
+}
+
+func (b *BindingWorkSubscriber) Subscribe(msgBuffer <-chan WorkMsg) {
+	b.msgBuffer = msgBuffer
+
+	go func() {
+		b.log.Info("Listening for binding messages")
+		for {
+			msg := <-msgBuffer
+			var bmsg *BindingMsg
+			//var extCreds *apb.ExtractedCredentials
+			metrics.BindingJobFinished()
+
+			b.log.Debug("Processed binding message from buffer")
+			// HACK: this seems like a hack, there's probably a better way to
+			// get the data sent through instead of a string
+			json.Unmarshal([]byte(msg.Render()), &bmsg)
+
+			/*
+				if pmsg.Error != "" {
+					b.log.Errorf("Provision job reporting error: %s", pmsg.Error)
+					b.dao.SetState(pmsg.InstanceUUID, apb.JobState{
+						Token:   pmsg.JobToken,
+						State:   apb.StateFailed,
+						Podname: pmsg.PodName,
+						Method:  apb.JobMethodProvision,
+					})
+				} else if pmsg.Msg == "" {
+					// HACK: OMG this is horrible. We should probably pass in a
+					// state. Since we'll also be using this to get more granular
+					// updates one day.
+					b.dao.SetState(pmsg.InstanceUUID, apb.JobState{
+						Token:   pmsg.JobToken,
+						State:   apb.StateInProgress,
+						Podname: pmsg.PodName,
+						Method:  apb.JobMethodProvision,
+					})
+				} else {
+					json.Unmarshal([]byte(pmsg.Msg), &extCreds)
+					b.dao.SetState(pmsg.InstanceUUID, apb.JobState{
+						Token:   pmsg.JobToken,
+						State:   apb.StateSucceeded,
+						Podname: pmsg.PodName,
+						Method:  apb.JobMethodProvision,
+					})
+					b.dao.SetExtractedCredentials(pmsg.InstanceUUID, extCreds)
+				}
+			*/
+		}
+	}()
+}

--- a/pkg/broker/binding_subscriber.go
+++ b/pkg/broker/binding_subscriber.go
@@ -17,6 +17,7 @@
 // No permission is granted to use or replicate Red Hat trademarks that
 // are incorporated in this software or its documentation.
 //
+
 package broker
 
 import (

--- a/pkg/broker/binding_subscriber.go
+++ b/pkg/broker/binding_subscriber.go
@@ -30,7 +30,7 @@ import (
 // BindingWorkSubscriber - Listen for binding messages
 type BindingWorkSubscriber struct {
 	dao       *dao.Dao
-	msgBuffer <-chan WorkMsg
+	msgBuffer <-chan JobMsg
 }
 
 // NewBindingWorkSubscriber - Creates a new work subscriber
@@ -39,14 +39,14 @@ func NewBindingWorkSubscriber(dao *dao.Dao) *BindingWorkSubscriber {
 }
 
 // Subscribe - will start a work subscriber listening for bind job messages
-func (b *BindingWorkSubscriber) Subscribe(msgBuffer <-chan WorkMsg) {
+func (b *BindingWorkSubscriber) Subscribe(msgBuffer <-chan JobMsg) {
 	b.msgBuffer = msgBuffer
 
 	go func() {
 		log.Info("Listening for binding messages")
 		for {
 			msg := <-msgBuffer
-			var bmsg *BindingMsg
+			var bmsg *JobMsg
 			var extCreds *apb.ExtractedCredentials
 			metrics.BindingJobFinished()
 

--- a/pkg/broker/binding_subscriber.go
+++ b/pkg/broker/binding_subscriber.go
@@ -64,6 +64,7 @@ func (b *BindingWorkSubscriber) Subscribe(msgBuffer <-chan JobMsg) {
 					Method:  apb.JobMethodBind,
 				})
 			} else if bmsg.Msg == "" {
+				log.Debug("BS: IN PROGRESS")
 				b.dao.SetState(bmsg.InstanceUUID, apb.JobState{
 					Token:   bmsg.JobToken,
 					State:   apb.StateInProgress,
@@ -71,6 +72,7 @@ func (b *BindingWorkSubscriber) Subscribe(msgBuffer <-chan JobMsg) {
 					Method:  apb.JobMethodBind,
 				})
 			} else {
+				log.Debug("BS: GETTING CREDS")
 				json.Unmarshal([]byte(bmsg.Msg), &extCreds)
 				b.dao.SetState(bmsg.InstanceUUID, apb.JobState{
 					Token:   bmsg.JobToken,
@@ -78,7 +80,8 @@ func (b *BindingWorkSubscriber) Subscribe(msgBuffer <-chan JobMsg) {
 					Podname: bmsg.PodName,
 					Method:  apb.JobMethodBind,
 				})
-				b.dao.SetExtractedCredentials(bmsg.InstanceUUID, extCreds)
+				log.Debug("CALL SetExtractedCredentials $v - %v", bmsg.BindingUUID, extCreds)
+				b.dao.SetExtractedCredentials(bmsg.BindingUUID, extCreds)
 			}
 		}
 	}()

--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -890,9 +890,14 @@ func (a AnsibleBroker) Bind(instance apb.ServiceInstance, bindingUUID uuid.UUID,
 		}
 	}
 
+	log.Errorf("calling SetBindInstance for %v - [%v]", bindingUUID, bindingInstance)
+
 	if err := a.dao.SetBindInstance(bindingUUID.String(), bindingInstance); err != nil {
+		log.Errorf("FAILED to store bind instance: %v - [%v] %v", bindingUUID.String(), bindingInstance, err)
 		return nil, err
 	}
+
+	log.Errorf("HEY bind was set for %v - [%v]", bindingUUID, bindingInstance)
 
 	// Add the DB Credentials this will allow the apb to use these credentials
 	// if it so chooses.
@@ -912,7 +917,7 @@ func (a AnsibleBroker) Bind(instance apb.ServiceInstance, bindingUUID uuid.UUID,
 		// asynchronous mode, requires that the launch apb config
 		// entry is on, and that async comes in from the catalog
 		log.Info("ASYNC binding in progress")
-		bindjob := NewBindingJob(&instance, &params)
+		bindjob := NewBindingJob(&instance, bindingUUID, &params)
 
 		token, err = a.engine.StartNewJob("", bindjob, BindingTopic)
 		if err != nil {

--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -1027,6 +1027,7 @@ func (a AnsibleBroker) Unbind(
 	}
 	metrics.ActionStarted("unbind")
 
+	var token string
 	if async && a.brokerConfig.LaunchApbOnBind {
 		// asynchronous mode, required that the launch apb config
 		// entry is on, and that async comes in from the catalog
@@ -1045,8 +1046,6 @@ func (a AnsibleBroker) Unbind(
 		}); err != nil {
 			log.Errorf("failed to set initial jobstate for %v, %v", token, err.Error())
 		}
-
-		return &UnbindResponse{Operation: token}, nil
 
 	} else if a.brokerConfig.LaunchApbOnBind {
 		// only launch apb if we are always launching the APB.
@@ -1081,6 +1080,9 @@ func (a AnsibleBroker) Unbind(
 		return nil, err
 	}
 
+	if token != "" {
+		return &UnbindResponse{Operation: token}, nil
+	}
 	return &UnbindResponse{}, nil
 }
 

--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -890,14 +890,9 @@ func (a AnsibleBroker) Bind(instance apb.ServiceInstance, bindingUUID uuid.UUID,
 		}
 	}
 
-	log.Errorf("calling SetBindInstance for %v - [%v]", bindingUUID, bindingInstance)
-
 	if err := a.dao.SetBindInstance(bindingUUID.String(), bindingInstance); err != nil {
-		log.Errorf("FAILED to store bind instance: %v - [%v] %v", bindingUUID.String(), bindingInstance, err)
 		return nil, err
 	}
-
-	log.Errorf("HEY bind was set for %v - [%v]", bindingUUID, bindingInstance)
 
 	// Add the DB Credentials this will allow the apb to use these credentials
 	// if it so chooses.

--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -770,6 +770,8 @@ func (a AnsibleBroker) isJobInProgress(instance *apb.ServiceInstance,
 	return len(methodJobs) > 0, token, nil
 }
 
+// GetBind - will return the binding between a service created via an async
+// binding event.
 func (a AnsibleBroker) GetBind(instance apb.ServiceInstance, bindingUUID uuid.UUID) (*BindResponse, error) {
 
 	log.Debug("XXX entered GetBind")

--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -874,19 +874,19 @@ func (a AnsibleBroker) Bind(instance apb.ServiceInstance, bindingUUID uuid.UUID,
 	// put the LaunchApbOnBind gate here
 	if async {
 		if !a.brokerConfig.LaunchApbOnBind {
-			continue
+			log.Error("LAUNCH APB ON BIND IS DISABLED")
 		}
 
-		a.log.Info("ASYNC binding in progress")
-		bjob := NewBindingJob(serviceInstance, a.clusterConfig, a.log)
+		log.Info("ASYNC binding in progress")
+		bjob := NewBindingJob(&instance)
 
 		token, err = a.engine.StartNewJob("", bjob, BindingTopic)
 		if err != nil {
-			a.log.Error("Failed to start new job for async binding\n%s", err.Error())
+			log.Error("Failed to start new job for async binding\n%s", err.Error())
 			return nil, err
 		}
 
-		a.dao.SetState(instanceUUID.String(), apb.JobState{
+		a.dao.SetState(instance.ID.String(), apb.JobState{
 			Token:  token,
 			State:  apb.StateInProgress,
 			Method: apb.JobMethodBind,
@@ -900,7 +900,7 @@ func (a AnsibleBroker) Bind(instance apb.ServiceInstance, bindingUUID uuid.UUID,
 				return nil, err
 			}
 		} else {
-			a.log.Warning("Broker configured to *NOT* launch and run APB bind")
+			log.Warning("Broker configured to *NOT* launch and run APB bind")
 		}
 	}
 

--- a/pkg/broker/types.go
+++ b/pkg/broker/types.go
@@ -43,12 +43,14 @@ const (
 	ProvisionTopic   WorkTopic = "provision_topic"
 	DeprovisionTopic WorkTopic = "deprovision_topic"
 	UpdateTopic      WorkTopic = "update_topic"
+	BindingTopic     WorkTopic = "binding_topic"
 )
 
 var workTopicSet = map[WorkTopic]bool{
 	ProvisionTopic:   true,
 	DeprovisionTopic: true,
 	UpdateTopic:      true,
+	BindingTopic:     true,
 }
 
 // IsValidWorkTopic - Check if WorkTopic is part of acceptable set

--- a/pkg/broker/types.go
+++ b/pkg/broker/types.go
@@ -226,7 +226,9 @@ type DeprovisionResponse struct {
 
 // UnbindResponse - Response for unbinding
 // Defined here https://github.com/openservicebrokerapi/servicebroker/blob/v2.12/spec.md#response-5
-type UnbindResponse struct{}
+type UnbindResponse struct {
+	Operation string `json:"operation,omitempty"`
+}
 
 // ErrorResponse - Error response for all broker errors
 // Defined here https://github.com/openservicebrokerapi/servicebroker/blob/v2.12/spec.md#broker-errors

--- a/pkg/broker/types.go
+++ b/pkg/broker/types.go
@@ -44,6 +44,7 @@ const (
 	DeprovisionTopic WorkTopic = "deprovision_topic"
 	UpdateTopic      WorkTopic = "update_topic"
 	BindingTopic     WorkTopic = "binding_topic"
+	UnbindingTopic   WorkTopic = "unbinding_topic"
 )
 
 var workTopicSet = map[WorkTopic]bool{
@@ -51,6 +52,7 @@ var workTopicSet = map[WorkTopic]bool{
 	DeprovisionTopic: true,
 	UpdateTopic:      true,
 	BindingTopic:     true,
+	UnbindingTopic:   true,
 }
 
 // IsValidWorkTopic - Check if WorkTopic is part of acceptable set

--- a/pkg/broker/types.go
+++ b/pkg/broker/types.go
@@ -241,6 +241,14 @@ type BootstrapResponse struct {
 	ImageCount int `json:"image_count"`
 }
 
+// ServiceInstanceResponse - The response for a get service instance request
+type ServiceInstanceResponse struct {
+	ServiceID    string         `json:"service_id"`
+	PlanID       string         `json:"plan_id"`
+	DashboardURL string         `json:"dashboard_url,omitempty"`
+	Parameters   apb.Parameters `json:"parameters,omitempty"`
+}
+
 // UserInfo - holds information about the user that created a resource.
 type UserInfo struct {
 	Username string              `json:"username"`

--- a/pkg/broker/types.go
+++ b/pkg/broker/types.go
@@ -213,6 +213,7 @@ type BindResponse struct {
 	SyslogDrainURL  string                 `json:"syslog_drain_url,omitempty"`
 	RouteServiceURL string                 `json:"route_service_url,omitempty"`
 	VolumeMounts    []interface{}          `json:"volume_mounts,omitempty"`
+	Operation       string                 `json:"operation,omitempty"`
 }
 
 // DeprovisionResponse - Response for a deprovision

--- a/pkg/broker/types.go
+++ b/pkg/broker/types.go
@@ -265,6 +265,7 @@ type JobMsg struct {
 	PodName      string `json:"podname"`
 	Error        string `json:"error"`
 	Msg          string `json:"msg"`
+	BindingUUID  string `json:"binding_uuid"`
 }
 
 // Render - Display the job message.

--- a/pkg/broker/unbinding_job.go
+++ b/pkg/broker/unbinding_job.go
@@ -45,14 +45,14 @@ func NewUnbindingJob(serviceInstance *apb.ServiceInstance, params *apb.Parameter
 func (p *UnbindingJob) Run(token string, msgBuffer chan<- JobMsg) {
 	metrics.UnbindingJobStarted()
 
-	log.Debug("BJ: unbinding job started, calling apb.Unbind")
+	log.Debug("unbindjob: unbinding job started, calling apb.Unbind")
 
 	err := apb.Unbind(p.serviceInstance, p.params)
 
-	log.Debug("BJ: RETURNED from apb.Unbind")
+	log.Debug("unbindjob: returned from apb.Unbind")
 
 	if err != nil {
-		log.Errorf("broker::Unbinding error occurred.\n%s", err.Error())
+		log.Errorf("unbindjob::Unbinding error occurred.\n%s", err.Error())
 
 		// send error message
 		// can't have an error type in a struct you want marshalled
@@ -63,18 +63,15 @@ func (p *UnbindingJob) Run(token string, msgBuffer chan<- JobMsg) {
 		return
 	}
 
-	log.Debug("BJ: No error, going to marshal the credentials")
-
 	// send creds
 	if err != nil {
-		log.Debug("BJ: ERROR during marshal")
 		msgBuffer <- JobMsg{InstanceUUID: p.serviceInstance.ID.String(),
 			BindingUUID: p.bindingUUID.String(), JobToken: token,
 			SpecID: p.serviceInstance.Spec.ID, PodName: "", Msg: "", Error: err.Error()}
 		return
 	}
 
-	log.Debug("BJ: Looks like we're done")
+	log.Debug("unbindjob: Looks like we're done")
 	msgBuffer <- JobMsg{InstanceUUID: p.serviceInstance.ID.String(),
 		BindingUUID: p.bindingUUID.String(), JobToken: token,
 		SpecID: p.serviceInstance.Spec.ID, PodName: "", Msg: "unbind finished", Error: ""}

--- a/pkg/broker/unbinding_job.go
+++ b/pkg/broker/unbinding_job.go
@@ -1,0 +1,76 @@
+//
+// Copyright (c) 2017 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Red Hat trademarks are not licensed under Apache License, Version 2.
+// No permission is granted to use or replicate Red Hat trademarks that
+// are incorporated in this software or its documentation.
+//
+
+package broker
+
+import (
+	"github.com/openshift/ansible-service-broker/pkg/apb"
+	"github.com/openshift/ansible-service-broker/pkg/metrics"
+)
+
+// UnbindingJob - Job to provision
+type UnbindingJob struct {
+	serviceInstance *apb.ServiceInstance
+	params          *apb.Parameters
+}
+
+// NewUnbindingJob - Create a new binding job.
+func NewUnbindingJob(serviceInstance *apb.ServiceInstance, params *apb.Parameters) *UnbindingJob {
+	return &UnbindingJob{
+		serviceInstance: serviceInstance,
+		params:          params,
+	}
+}
+
+// Run - run the binding job.
+func (p *UnbindingJob) Run(token string, msgBuffer chan<- JobMsg) {
+	metrics.UnbindingJobStarted()
+
+	log.Debug("BJ: unbinding job started, calling apb.Unbind")
+
+	err := apb.Unbind(p.serviceInstance, p.params)
+
+	log.Debug("BJ: RETURNED from apb.Unbind")
+
+	if err != nil {
+		log.Errorf("broker::Unbinding error occurred.\n%s", err.Error())
+
+		// send error message
+		// can't have an error type in a struct you want marshalled
+		// https://github.com/golang/go/issues/5161
+		msgBuffer <- JobMsg{InstanceUUID: p.serviceInstance.ID.String(),
+			JobToken: token, SpecID: p.serviceInstance.Spec.ID, PodName: "", Msg: "", Error: err.Error()}
+		return
+	}
+
+	log.Debug("BJ: No error, going to marshal the credentials")
+
+	// send creds
+	if err != nil {
+		log.Debug("BJ: ERROR during marshal")
+		msgBuffer <- JobMsg{InstanceUUID: p.serviceInstance.ID.String(),
+			JobToken: token, SpecID: p.serviceInstance.Spec.ID, PodName: "", Msg: "", Error: err.Error()}
+		return
+	}
+
+	log.Debug("BJ: Looks like we're done")
+	msgBuffer <- JobMsg{InstanceUUID: p.serviceInstance.ID.String(),
+		JobToken: token, SpecID: p.serviceInstance.Spec.ID, PodName: "", Msg: "unbind finished", Error: ""}
+}

--- a/pkg/broker/unbinding_job.go
+++ b/pkg/broker/unbinding_job.go
@@ -23,11 +23,13 @@ package broker
 import (
 	"github.com/openshift/ansible-service-broker/pkg/apb"
 	"github.com/openshift/ansible-service-broker/pkg/metrics"
+	"github.com/pborman/uuid"
 )
 
 // UnbindingJob - Job to provision
 type UnbindingJob struct {
 	serviceInstance *apb.ServiceInstance
+	bindingUUID     uuid.UUID
 	params          *apb.Parameters
 }
 
@@ -56,7 +58,8 @@ func (p *UnbindingJob) Run(token string, msgBuffer chan<- JobMsg) {
 		// can't have an error type in a struct you want marshalled
 		// https://github.com/golang/go/issues/5161
 		msgBuffer <- JobMsg{InstanceUUID: p.serviceInstance.ID.String(),
-			JobToken: token, SpecID: p.serviceInstance.Spec.ID, PodName: "", Msg: "", Error: err.Error()}
+			BindingUUID: p.bindingUUID.String(), JobToken: token,
+			SpecID: p.serviceInstance.Spec.ID, PodName: "", Msg: "", Error: err.Error()}
 		return
 	}
 
@@ -66,11 +69,13 @@ func (p *UnbindingJob) Run(token string, msgBuffer chan<- JobMsg) {
 	if err != nil {
 		log.Debug("BJ: ERROR during marshal")
 		msgBuffer <- JobMsg{InstanceUUID: p.serviceInstance.ID.String(),
-			JobToken: token, SpecID: p.serviceInstance.Spec.ID, PodName: "", Msg: "", Error: err.Error()}
+			BindingUUID: p.bindingUUID.String(), JobToken: token,
+			SpecID: p.serviceInstance.Spec.ID, PodName: "", Msg: "", Error: err.Error()}
 		return
 	}
 
 	log.Debug("BJ: Looks like we're done")
 	msgBuffer <- JobMsg{InstanceUUID: p.serviceInstance.ID.String(),
-		JobToken: token, SpecID: p.serviceInstance.Spec.ID, PodName: "", Msg: "unbind finished", Error: ""}
+		BindingUUID: p.bindingUUID.String(), JobToken: token,
+		SpecID: p.serviceInstance.Spec.ID, PodName: "", Msg: "unbind finished", Error: ""}
 }

--- a/pkg/broker/unbinding_subscriber.go
+++ b/pkg/broker/unbinding_subscriber.go
@@ -78,7 +78,7 @@ func (b *UnbindingWorkSubscriber) Subscribe(msgBuffer <-chan JobMsg) {
 					Podname: bmsg.PodName,
 					Method:  apb.JobMethodBind,
 				})
-				b.dao.SetExtractedCredentials(bmsg.InstanceUUID, extCreds)
+				b.dao.SetExtractedCredentials(bmsg.BindingUUID, extCreds)
 			}
 		}
 	}()

--- a/pkg/broker/unbinding_subscriber.go
+++ b/pkg/broker/unbinding_subscriber.go
@@ -1,0 +1,85 @@
+//
+// Copyright (c) 2017 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Red Hat trademarks are not licensed under Apache License, Version 2.
+// No permission is granted to use or replicate Red Hat trademarks that
+// are incorporated in this software or its documentation.
+//
+
+package broker
+
+import (
+	"encoding/json"
+
+	"github.com/openshift/ansible-service-broker/pkg/apb"
+	"github.com/openshift/ansible-service-broker/pkg/dao"
+	"github.com/openshift/ansible-service-broker/pkg/metrics"
+)
+
+// UnbindingWorkSubscriber - Listen for binding messages
+type UnbindingWorkSubscriber struct {
+	dao       *dao.Dao
+	msgBuffer <-chan JobMsg
+}
+
+// NewUnbindingWorkSubscriber - Creates a new work subscriber
+func NewUnbindingWorkSubscriber(dao *dao.Dao) *UnbindingWorkSubscriber {
+	return &UnbindingWorkSubscriber{dao: dao}
+}
+
+// Subscribe - will start a work subscriber listening for bind job messages
+func (b *UnbindingWorkSubscriber) Subscribe(msgBuffer <-chan JobMsg) {
+	b.msgBuffer = msgBuffer
+
+	go func() {
+		log.Info("Listening for binding messages")
+		for {
+			msg := <-msgBuffer
+			var bmsg *JobMsg
+			var extCreds *apb.ExtractedCredentials
+			metrics.UnbindingJobFinished()
+
+			log.Debug("Processed binding message from buffer")
+
+			json.Unmarshal([]byte(msg.Render()), &bmsg)
+
+			if bmsg.Error != "" {
+				log.Errorf("Unbinding job reporting error: %s", bmsg.Error)
+				b.dao.SetState(bmsg.InstanceUUID, apb.JobState{
+					Token:   bmsg.JobToken,
+					State:   apb.StateFailed,
+					Podname: bmsg.PodName,
+					Method:  apb.JobMethodBind,
+				})
+			} else if bmsg.Msg == "" {
+				b.dao.SetState(bmsg.InstanceUUID, apb.JobState{
+					Token:   bmsg.JobToken,
+					State:   apb.StateInProgress,
+					Podname: bmsg.PodName,
+					Method:  apb.JobMethodBind,
+				})
+			} else {
+				json.Unmarshal([]byte(bmsg.Msg), &extCreds)
+				b.dao.SetState(bmsg.InstanceUUID, apb.JobState{
+					Token:   bmsg.JobToken,
+					State:   apb.StateSucceeded,
+					Podname: bmsg.PodName,
+					Method:  apb.JobMethodBind,
+				})
+				b.dao.SetExtractedCredentials(bmsg.InstanceUUID, extCreds)
+			}
+		}
+	}()
+}

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -439,6 +439,11 @@ func (h handler) bind(w http.ResponseWriter, r *http.Request, params map[string]
 		return
 	}
 
+	var async bool
+
+	// ignore the error, if async can't be parsed it will be false
+	async, _ = strconv.ParseBool(r.FormValue("accepts_incomplete"))
+
 	var req *broker.BindRequest
 	if err := readRequest(r, &req); err != nil {
 		writeResponse(w, http.StatusInternalServerError, broker.ErrorResponse{Description: err.Error()})
@@ -475,7 +480,7 @@ func (h handler) bind(w http.ResponseWriter, r *http.Request, params map[string]
 	}
 
 	// process binding request
-	resp, err := h.broker.Bind(serviceInstance, bindingUUID, req)
+	resp, err := h.broker.Bind(serviceInstance, bindingUUID, req, async)
 
 	if err != nil {
 		switch err {

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -461,7 +461,6 @@ func (h handler) getbind(w http.ResponseWriter, r *http.Request, params map[stri
 	defer r.Body.Close()
 	h.printRequest(r)
 
-	log.Debug("handler: entered getbind")
 	// validate input uuids
 	instanceUUID := uuid.Parse(params["instance_uuid"])
 	if instanceUUID == nil {
@@ -469,15 +468,11 @@ func (h handler) getbind(w http.ResponseWriter, r *http.Request, params map[stri
 		return
 	}
 
-	log.Debug("handler: instanceuuid is valid")
-
 	bindingUUID := uuid.Parse(params["binding_uuid"])
 	if bindingUUID == nil {
 		writeResponse(w, http.StatusBadRequest, broker.ErrorResponse{Description: "invalid binding_uuid"})
 		return
 	}
-
-	log.Debug("handler: binduuid is valid")
 
 	serviceInstance, err := h.broker.GetServiceInstance(instanceUUID)
 	if err != nil {
@@ -488,19 +483,14 @@ func (h handler) getbind(w http.ResponseWriter, r *http.Request, params map[stri
 			writeResponse(w, http.StatusInternalServerError, broker.ErrorResponse{Description: err.Error()})
 		}
 	}
-	log.Debug("handler: found service instance")
 
 	resp, err := h.broker.GetBind(serviceInstance, bindingUUID)
-
-	log.Debug("handler: GetBind called")
 
 	if err != nil {
 		switch err {
 		case broker.ErrorNotFound:
-			log.Debug("handler: bind not found")
 			writeResponse(w, http.StatusNotFound, broker.ErrorResponse{Description: err.Error()})
 		default:
-			log.Debug("handler: something went bad during the getbind")
 			writeResponse(w, http.StatusBadRequest, broker.ErrorResponse{Description: err.Error()})
 		}
 		return

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -243,6 +243,7 @@ func (h handler) getinstance(w http.ResponseWriter, r *http.Request, params map[
 		default: // return 422
 			writeResponse(w, http.StatusUnprocessableEntity, broker.ErrorResponse{Description: err.Error()})
 		}
+		return
 	}
 
 	// planParameterKey is unexported. Using the value here instead of
@@ -477,13 +478,6 @@ func (h handler) getbind(w http.ResponseWriter, r *http.Request, params map[stri
 	}
 
 	log.Debug("handler: binduuid is valid")
-	/*
-		var req *broker.BindRequest
-		if err := readRequest(r, &req); err != nil {
-			writeResponse(w, http.StatusInternalServerError, broker.ErrorResponse{Description: err.Error()})
-			return
-		}
-	*/
 
 	serviceInstance, err := h.broker.GetServiceInstance(instanceUUID)
 	if err != nil {
@@ -509,10 +503,11 @@ func (h handler) getbind(w http.ResponseWriter, r *http.Request, params map[stri
 			log.Debug("handler: something went bad during the getbind")
 			writeResponse(w, http.StatusBadRequest, broker.ErrorResponse{Description: err.Error()})
 		}
-	} else {
-		log.Debug("handler: bind found")
-		writeDefaultResponse(w, http.StatusOK, resp, err)
+		return
 	}
+
+	log.Debug("handler: bind found")
+	writeDefaultResponse(w, http.StatusOK, resp, err)
 }
 
 func (h handler) bind(w http.ResponseWriter, r *http.Request, params map[string]string) {

--- a/pkg/handler/handler_test.go
+++ b/pkg/handler/handler_test.go
@@ -92,7 +92,7 @@ func (m MockBroker) Deprovision(apb.ServiceInstance, string, bool, bool) (*broke
 	m.called("deprovision", true)
 	return nil, m.Err
 }
-func (m MockBroker) Bind(apb.ServiceInstance, uuid.UUID, *broker.BindRequest) (*broker.BindResponse, error) {
+func (m MockBroker) Bind(apb.ServiceInstance, uuid.UUID, *broker.BindRequest, bool) (*broker.BindResponse, error) {
 	m.called("bind", true)
 	return nil, m.Err
 }

--- a/pkg/handler/handler_test.go
+++ b/pkg/handler/handler_test.go
@@ -96,7 +96,7 @@ func (m MockBroker) Bind(apb.ServiceInstance, uuid.UUID, *broker.BindRequest, bo
 	m.called("bind", true)
 	return nil, m.Err
 }
-func (m MockBroker) Unbind(apb.ServiceInstance, uuid.UUID, string, bool) (*broker.UnbindResponse, error) {
+func (m MockBroker) Unbind(apb.ServiceInstance, uuid.UUID, string, bool, bool) (*broker.UnbindResponse, error) {
 	m.called("unbind", true)
 	return nil, m.Err
 }

--- a/pkg/handler/handler_test.go
+++ b/pkg/handler/handler_test.go
@@ -128,6 +128,11 @@ func (m MockBroker) RemoveSpecs() error {
 	return nil
 }
 
+func (m MockBroker) GetBind(si apb.ServiceInstance, bindid uuid.UUID) (*broker.BindResponse, error) {
+	m.called("getBind", true)
+	return nil, nil
+}
+
 func TestNewHandler(t *testing.T) {
 	testb := MockBroker{Name: "testbroker"}
 	c, err := config.CreateConfig("testdata/broker.yaml")

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -68,6 +68,13 @@ var (
 			Help:      "How many update jobs are actively in the buffer.",
 		})
 
+	bindingJob = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Subsystem: subsystem,
+			Name:      "binding_jobs",
+			Help:      "How many binding jobs are actively in the buffer.",
+		})
+
 	requests = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Subsystem: subsystem,
@@ -147,6 +154,12 @@ func DeprovisionJobStarted() {
 	deprovisionJob.Inc()
 }
 
+// BindingJobStarted - Add a provision job to the counter.
+func BindingJobStarted() {
+	defer recoverMetricPanic()
+	bindingJob.Inc()
+}
+
 // ProvisionJobFinished - Remove a provision job from the counter.
 func ProvisionJobFinished() {
 	defer recoverMetricPanic()
@@ -169,6 +182,12 @@ func UpdateJobStarted() {
 func UpdateJobFinished() {
 	defer recoverMetricPanic()
 	updateJob.Dec()
+}
+
+// BindingJobFinished - Remove a provision job from the counter.
+func BindingJobFinished() {
+	defer recoverMetricPanic()
+	bindingJob.Dec()
 }
 
 // ActionStarted - Registers that an action has been started.

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -75,6 +75,13 @@ var (
 			Help:      "How many binding jobs are actively in the buffer.",
 		})
 
+	unbindingJob = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Subsystem: subsystem,
+			Name:      "unbinding_jobs",
+			Help:      "How many unbinding jobs are actively in the buffer.",
+		})
+
 	requests = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Subsystem: subsystem,
@@ -160,6 +167,12 @@ func BindingJobStarted() {
 	bindingJob.Inc()
 }
 
+// UnbindingJobStarted - Add a provision job to the counter.
+func UnbindingJobStarted() {
+	defer recoverMetricPanic()
+	unbindingJob.Inc()
+}
+
 // ProvisionJobFinished - Remove a provision job from the counter.
 func ProvisionJobFinished() {
 	defer recoverMetricPanic()
@@ -188,6 +201,12 @@ func UpdateJobFinished() {
 func BindingJobFinished() {
 	defer recoverMetricPanic()
 	bindingJob.Dec()
+}
+
+// UnbindingJobFinished - Remove a provision job from the counter.
+func UnbindingJobFinished() {
+	defer recoverMetricPanic()
+	unbindingJob.Dec()
 }
 
 // ActionStarted - Registers that an action has been started.


### PR DESCRIPTION
The async bind feature is used to allow binds that need more time to execute than the 60 seconds response time allotted in the Open Service Broker API spec. Async bind will spawn a binding job and return the job token immediately. The catalog will use the last_operation to monitor the state of the running job until either successful completion or a failure.

There are no new dependencies for this feature.

There is a new binding_subscriber to monitor the JobMsgs sent from the new binding_job. The Bind method in the broker was updated to take in the async flag and determine if it should spawn an APB for bind or simply return what was already stored like it did before.

Another set of critical additions was the new getserviceinstance and getbind calls added to the handler. These are to implement the required getters for async bind, particularly the getbind. Prior to async bind, when bind was called we would return the credentials at the end of the request. Since it is now asynchronous, we return the job token as the operation, but we will need a way to get the bind that was created once the job is done.

Aysnc bind is gated by the LaunchApbOnBind broker configuration setting. This MUST be set to True for the async bind to even be an option. Also, accepts_incomplete=true must accompany all PUT requests on the bind endpoint for async to be used. Both of those conditions need to be satisfied before using the async feature.