### PR TITLE
Bug 588 - Run latest build with a default public ip.

### DIFF
--- a/scripts/run_latest_build.sh
+++ b/scripts/run_latest_build.sh
@@ -34,7 +34,8 @@
 #
 
 DOCKER_IP="$(ip addr show docker0 | grep -Po 'inet \K[\d.]+')"
-PUBLIC_IP=${DOCKER_IP:-"127.0.0.1"}
+DOCKER_IP=${DOCKER_IP:-"127.0.0.1"}
+PUBLIC_IP=${PUBLIC_IP:-$DOCKER_IP}
 HOSTNAME=${PUBLIC_IP}.nip.io
 ROUTING_SUFFIX="${HOSTNAME}"
 ORIGIN_IMAGE=${ORIGIN_IMAGE:-"docker.io/openshift/origin"}

--- a/scripts/run_latest_build.sh
+++ b/scripts/run_latest_build.sh
@@ -34,7 +34,7 @@
 #
 
 DOCKER_IP="$(ip addr show docker0 | grep -Po 'inet \K[\d.]+')"
-PUBLIC_IP=${PUBLIC_IP:-$DOCKER_IP}
+PUBLIC_IP=${DOCKER_IP:-"127.0.0.1"}
 HOSTNAME=${PUBLIC_IP}.nip.io
 ROUTING_SUFFIX="${HOSTNAME}"
 ORIGIN_IMAGE=${ORIGIN_IMAGE:-"docker.io/openshift/origin"}


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
This PR will default the `PUBLIC_IP` to the localhost. 

This value will allow for macOS to have this value because it can not find the docker interface `docker0`.

The issue that used to exist where the service catalog could not contact the broker is no longer a concern
 
**Which issue this PR fixes (This will close that issue when PR gets merged)**
fixes #588 