### PR TITLE
Bug 1533208 - Re adding registry auth as secrets and files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,4 @@ script:
   - ./scripts/travis.sh setup-broker
   - ./scripts/travis.sh ci
   - ./scripts/broker-ci/gather-logs.sh
+  - 'oc get pods --all-namespaces'

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -200,7 +200,8 @@ func CreateApp() App {
 
 	log.Debug("Connecting Registry")
 	for name := range app.config.GetSubConfig("registry").ToMap() {
-		reg, err := registries.NewRegistry(app.config.GetSubConfig(fmt.Sprintf("%v.%v", "registry", name)))
+		reg, err := registries.NewRegistry(app.config.GetSubConfig(fmt.Sprintf("%v.%v", "registry", name)),
+			app.config.GetString("openshift.namespace"))
 		if err != nil {
 			log.Errorf(
 				"Failed to initialize %v Registry err - %v \n", name, err)

--- a/pkg/clients/kubernetes.go
+++ b/pkg/clients/kubernetes.go
@@ -177,3 +177,19 @@ func (k KubernetesClient) DeleteRoleBinding(roleBindingName string, namespace st
 	}
 	return nil
 }
+
+// GetSecretData - Returns the data insdie of a given secret.
+func GetSecretData(secretName, namespace string) (map[string][]byte, error) {
+	k8scli, err := Kubernetes()
+	if err != nil {
+		return nil, err
+	}
+	secretData, err := k8scli.Client.CoreV1().Secrets(namespace).Get(secretName, metav1.GetOptions{})
+	if err != nil {
+		log.Errorf("Unable to load secret '%s' from namespace '%s'", secretName, namespace)
+		return make(map[string][]byte), nil
+	}
+	log.Debugf("Found secret with name %v\n", secretName)
+
+	return secretData.Data, nil
+}

--- a/pkg/registries/registry_test.go
+++ b/pkg/registries/registry_test.go
@@ -334,7 +334,7 @@ func TestNewRegistryRHCC(t *testing.T) {
 	if err != nil {
 		ft.AssertTrue(t, false)
 	}
-	reg, err := NewRegistry(c.GetSubConfig("registry.rhcc"))
+	reg, err := NewRegistry(c.GetSubConfig("registry.rhcc"), "")
 	if err != nil {
 		ft.AssertTrue(t, false)
 	}
@@ -347,7 +347,7 @@ func TestNewRegistryDockerHub(t *testing.T) {
 	if err != nil {
 		ft.AssertTrue(t, false)
 	}
-	reg, err := NewRegistry(c.GetSubConfig("registry.dh"))
+	reg, err := NewRegistry(c.GetSubConfig("registry.dh"), "")
 	if err != nil {
 		ft.AssertTrue(t, false)
 	}
@@ -360,7 +360,7 @@ func TestNewRegistryMock(t *testing.T) {
 	if err != nil {
 		ft.AssertTrue(t, false)
 	}
-	reg, err := NewRegistry(c.GetSubConfig("registry.mock"))
+	reg, err := NewRegistry(c.GetSubConfig("registry.mock"), "")
 	if err != nil {
 		ft.AssertTrue(t, false)
 	}
@@ -377,13 +377,13 @@ func TestPanicOnUnknow(t *testing.T) {
 		}
 	}()
 	c, _ := config.CreateConfig("testdata/registry.yaml")
-	r, err := NewRegistry(c.GetSubConfig("registry.makes-no-sense"))
+	r, err := NewRegistry(c.GetSubConfig("registry.makes-no-sense"), "")
 	fmt.Printf("%#v\n\n %v\n", r, err)
 }
 
 func TestValidateName(t *testing.T) {
 	c, _ := config.CreateConfig("testdata/registry.yaml")
-	_, err := NewRegistry(c.GetSubConfig("registry.makes_no_sense"))
+	_, err := NewRegistry(c.GetSubConfig("registry.makes_no_sense"), "")
 	if err == nil {
 		ft.AssertTrue(t, false)
 	}

--- a/templates/deploy-ansible-service-broker.template.yaml
+++ b/templates/deploy-ansible-service-broker.template.yaml
@@ -320,6 +320,7 @@ objects:
         bearer_token_file: "${BEARER_TOKEN_FILE}"
         image_pull_policy: "${IMAGE_PULL_POLICY}"
         sandbox_role: "${SANDBOX_ROLE}"
+        namespace: ansible-service-broker
         keep_namespace: ${KEEP_NAMESPACE}
         keep_namespace_on_error: ${KEEP_NAMESPACE_ON_ERROR}
       broker:


### PR DESCRIPTION
* This was in place and was changed most likely due to a bad rebase.

**Describe what this PR does and why we need it**:

Changes proposed in this pull request
 - Re-adding getting of secrets if auth type is secret
 - Re-adding of getting of secrets from file if auth type is file
 - Re-adding dealing with plain text config auth

**Does this PR depend on another PR (Use this to track when PRs should be merged)**
depends-on <PR>
This is tied to PR: #628 
**Which issue this PR fixes (This will close that issue when PR gets merged)**
fixes BZ 1533208


This was intially added in PR: https://github.com/openshift/ansible-service-broker/pull/502
