### PR TITLE
Fix debug statement for ISV registry to be more verbose

### DIFF
--- a/pkg/registries/adapters/openshift_adapter.go
+++ b/pkg/registries/adapters/openshift_adapter.go
@@ -54,7 +54,7 @@ func (r OpenShiftAdapter) GetImageNames() ([]string, error) {
 	r.Log.Debug("BundleSpecLabel: %s", BundleSpecLabel)
 
 	images := r.Config.Images
-	r.Log.Debug("HERE: %v", images)
+	r.Log.Debug("Configured to use images: %v", images)
 
 	return images, nil
 }


### PR DESCRIPTION
`HERE` is an atrocious debug statement. This must have been accidentally left in somewhere along the line.