### PR TITLE
Bug 1526949 - Set registry user/pass if auth_type is not defined

### DIFF
--- a/pkg/registries/registry.go
+++ b/pkg/registries/registry.go
@@ -413,8 +413,9 @@ func retrieveRegistryAuth(reg Config, asbNamespace string) (Config, error) {
 		}
 		return reg, nil
 	case "":
-		username = ""
-		password = ""
+		// Assuming that the user has either no credentials or defined them in the config
+		username = reg.User
+		password = reg.Pass
 	default:
 		return Config{}, fmt.Errorf("Unrecognized registry AuthType: %s", reg.AuthType)
 	}


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
Does not wipe out user/pass credentials just because the user didn't set auth_type. Later down the line we can explicity require auth_type if desired but it's not intuitive to set that value for long time users. This bit QE and the code was not in master for awhile so we weren't seeing this.

Changes proposed in this pull request
 - Accept registry user/pass if auth_type is not set
