### PR TITLE
Bug 1526949 - Do not ignore credentials if auth_type is not set

### DIFF
--- a/pkg/app/config.go
+++ b/pkg/app/config.go
@@ -100,8 +100,9 @@ func CreateConfig(configFile string) (Config, error) {
 			username = config.Registry[regCount].User
 			password = config.Registry[regCount].Pass
 		case "":
-			username = ""
-			password = ""
+			// Assuming that the user has either no credentials or defined them in the config
+			username = reg.User
+			password = reg.Pass
 		default:
 			return Config{}, fmt.Errorf("Unrecognized registry AuthType: %s", reg.AuthType)
 		}


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
QE was not setting `auth_type` in the config which was causing nil credentials. This PR assumes the user defined creds in the config if `auth_type` is not set.

Changes proposed in this pull request
 - Set user/pass instead of nil if `auth_type` is not defined