### PR TITLE
Add auth_type params to our template

### DIFF
--- a/templates/deploy-ansible-service-broker.template.yaml
+++ b/templates/deploy-ansible-service-broker.template.yaml
@@ -273,8 +273,8 @@ objects:
     name: ${REGISTRY_SECRET_NAME}
     namespace: ansible-service-broker
   data:
-    username: ${DOCKERHUB_USER}
-    password: ${DOCKERHUB_PASS}
+    username: ${REGISTRY_USER}
+    password: ${REGISTRY_PASS}
 
 - apiVersion: v1
   kind: Secret
@@ -307,6 +307,8 @@ objects:
           name: "${REGISTRY_NAME}"
           url: "${REGISTRY_URL}"
           org: "${DOCKERHUB_ORG}"
+          auth_type: "${REGISTRY_AUTH_TYPE}"
+          auth_name: "${REGISTRY_SECRET_NAME}"
           tag: "${TAG}"
           white_list:
             - ".*-apb$"
@@ -617,14 +619,14 @@ parameters:
   name: BROKER_USER
   value: YWRtaW4=
 
-- description: Dockerhub user password
-  displayname: Dockerhub user password
-  name: DOCKERHUB_PASS
+- description: Registry user password
+  displayname: Registry user password
+  name: REGISTRY_PASS
   value: ""
 
-- description: Dockerhub user name
-  displayname: Dockerhub user name
-  name: DOCKERHUB_USER
+- description: Registry user name
+  displayname: Registry user name
+  name: REGISTRY_USER
   value: ""
 
 ############################################################


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
Adds `auth_type` to the default registry config.

Changes proposed in this pull request
 - Add auth_type and auth_name to deploy template
