### PR TITLE
Bug 1534715 - unbind checks for existence of binding before trying to delete it

### DIFF
--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -995,6 +995,15 @@ func (a AnsibleBroker) Unbind(
 		return nil, errors.New(errMsg)
 	}
 
+	// Check if the binding exists
+	_, err := a.dao.GetBindInstance(bindingUUID.String())
+	if err != nil {
+		if client.IsKeyNotFound(err) {
+			return nil, ErrorNotFound
+		}
+		return nil, err
+	}
+
 	params := make(apb.Parameters)
 	provExtCreds, err := a.dao.GetExtractedCredentials(instance.ID.String())
 	if err != nil && !client.IsKeyNotFound(err) {
@@ -1054,6 +1063,7 @@ func (a AnsibleBroker) Unbind(
 			log.Debug("Skipping unbind apb execution")
 			err = nil
 		} else {
+			log.Debug("Launching apb for unbind in blocking mode")
 			err = apb.Unbind(&serviceInstance, &params)
 		}
 		if err != nil {


### PR DESCRIPTION
Unbind was not checking this previously. When doing an async unbind, this meant
multiple APBs got launched. Additionally, all but the first DELETE requests
were geting a 500 response code due to incorrect handling of "err" in code.

fixes #640