### PR TITLE
Bug 1534467 - apiserver was not told how to output error response

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -130,6 +130,7 @@ func apiServer(config *config.Config,
 
 	log.Debug("Creating k8s apiserver")
 	s := informers.NewSharedInformerFactory(k8s.Client, 2*time.Hour)
+	metav1.AddToGroupVersion(Scheme, metav1.Unversioned)
 	return serverConfig.Complete(s).New("ansible-service-broker", genericapiserver.EmptyDelegate)
 }
 


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
Allows for the unauthorized requests to be returned as JSON

Changes proposed in this pull request
* Thanks to Jordan Liggitt for helping me diagonse this one
* The apiserver codec/seriallizer did not know how to deal with our
unversioned api.

**fixes (This will close that issue when PR gets merged)**
fixes 1534467