### PR TITLE
Bug 1534715 - Moves BindInstance retrieval and error handling to handler.go

### DIFF
--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -606,7 +606,23 @@ func (h handler) unbind(w http.ResponseWriter, r *http.Request, params map[strin
 
 	serviceInstance, err := h.broker.GetServiceInstance(instanceUUID)
 	if err != nil {
-		writeResponse(w, http.StatusGone, nil)
+		switch err {
+		case broker.ErrorNotFound:
+			writeResponse(w, http.StatusGone, nil)
+		default:
+			writeResponse(w, http.StatusInternalServerError, broker.ErrorResponse{Description: err.Error()})
+		}
+		return
+	}
+
+	bindInstance, err := h.broker.GetBindInstance(bindingUUID)
+	if err != nil {
+		switch err {
+		case broker.ErrorNotFound:
+			writeResponse(w, http.StatusGone, nil)
+		default:
+			writeResponse(w, http.StatusInternalServerError, broker.ErrorResponse{Description: err.Error()})
+		}
 		return
 	}
 
@@ -636,7 +652,7 @@ func (h handler) unbind(w http.ResponseWriter, r *http.Request, params map[strin
 		log.Debugf("Auto Escalate has been set to true, we are escalating permissions")
 	}
 
-	resp, err := h.broker.Unbind(serviceInstance, bindingUUID, planID, nsDeleted, async)
+	resp, err := h.broker.Unbind(serviceInstance, bindInstance, planID, nsDeleted, async)
 
 	if err != nil {
 		switch err {

--- a/pkg/handler/handler_test.go
+++ b/pkg/handler/handler_test.go
@@ -96,7 +96,7 @@ func (m MockBroker) Bind(apb.ServiceInstance, uuid.UUID, *broker.BindRequest, bo
 	m.called("bind", true)
 	return nil, m.Err
 }
-func (m MockBroker) Unbind(apb.ServiceInstance, uuid.UUID, string, bool, bool) (*broker.UnbindResponse, error) {
+func (m MockBroker) Unbind(apb.ServiceInstance, apb.BindInstance, string, bool, bool) (*broker.UnbindResponse, error) {
 	m.called("unbind", true)
 	return nil, m.Err
 }
@@ -107,6 +107,10 @@ func (m MockBroker) LastOperation(uuid.UUID, *broker.LastOperationRequest) (*bro
 
 func (m MockBroker) GetServiceInstance(uuid.UUID) (apb.ServiceInstance, error) {
 	return apb.ServiceInstance{}, nil
+}
+
+func (m MockBroker) GetBindInstance(uuid.UUID) (apb.BindInstance, error) {
+	return apb.BindInstance{}, nil
 }
 
 func (m MockBroker) Recover() (string, error) {


### PR DESCRIPTION
This matches how ServiceInstance retrieval takes place.

re #640