### PR TITLE
Bug 1535182 - adding ability to retrieve an array of sub configs

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -28,93 +28,9 @@ import (
 	ft "github.com/openshift/ansible-service-broker/pkg/fusortest"
 )
 
-/*func TestCreateConfig(t *testing.T) {
-	config, err := CreateConfig("testdata/test-config.yaml")
-	if err != nil {
-		t.Fatal(err.Error())
-	}
-
-	ft.AssertEqual(t, config.Registry[0].Type, "dockerhub", "mismatch registry type")
-	ft.AssertEqual(t, config.Registry[0].Name, "docker", "mismatch registry name")
-	ft.AssertEqual(t, config.Registry[0].URL, "https://registry.hub.docker.com",
-		"mismatch registry url")
-	ft.AssertEqual(t, config.Registry[0].User, "DOCKERHUB_USER", "mismatch registry user")
-	ft.AssertEqual(t, config.Registry[0].Pass, "DOCKERHUB_PASS", "mismatch registry pass")
-	ft.AssertEqual(t, config.Registry[0].Org, "DOCKERHUB_ORG", "mismatch registry org")
-	ft.AssertFalse(t, config.Registry[0].Fail, "mismatch registry fail")
-	ft.AssertEqual(t, config.Registry[1].WhiteList[0], "^legitimate.*-apb$",
-		"mismatch whitelist entry")
-	ft.AssertEqual(t, config.Registry[1].BlackList[1], "^specific-blacklist-apb$",
-		"mismatch blacklist entry")
-
-	ft.AssertEqual(t, config.Dao.EtcdHost, "localhost", "")
-	ft.AssertEqual(t, config.Dao.EtcdPort, "2379", "")
-
-	ft.AssertEqual(t, config.Log.LogFile, "/var/log/ansible-service-broker/asb.log", "")
-	ft.AssertTrue(t, config.Log.Stdout, "")
-	ft.AssertTrue(t, config.Log.Color, "")
-	ft.AssertEqual(t, config.Log.Level, "debug", "")
-
-	ft.AssertEqual(t, config.Openshift.Host, "", "")
-	ft.AssertEqual(t, config.Openshift.CAFile, "", "")
-	ft.AssertEqual(t, config.Openshift.BearerTokenFile, "", "")
-	ft.AssertEqual(t, config.Openshift.PullPolicy, "IfNotPresent", "")
-	ft.AssertEqual(t, config.Openshift.SandboxRole, "edit", "")
-
-	ft.AssertTrue(t, config.Broker.BootstrapOnStartup, "mismatch bootstrap")
-	ft.AssertTrue(t, config.Broker.DevBroker, "mismatch dev")
-	ft.AssertTrue(t, config.Broker.Recovery, "mismatch recovery")
-	ft.AssertTrue(t, config.Broker.OutputRequest, "mismatch output")
-	ft.AssertFalse(t, config.Broker.LaunchApbOnBind, "mismatch launch")
-	ft.AssertEqual(t, config.Broker.SSLCert, "/path/to/cert", "mismatch cert")
-	ft.AssertEqual(t, config.Broker.SSLCertKey, "/path/to/key", "mismatch key")
-
-	ft.AssertEqual(t, config.Broker.Auth[0].Type, "basic", "mismatch basic")
-	ft.AssertTrue(t, config.Broker.Auth[0].Enabled, "mismatch enable")
-	ft.AssertEqual(t, config.Broker.Auth[1].Type, "oauth", "mismatch basic")
-	ft.AssertFalse(t, config.Broker.Auth[1].Enabled, "mismatch enable")
-}
-*/
-
 var config *Config
 
 func TestMain(m *testing.M) {
-	/*
-		config = Config{config: map[string]interface{}{
-			"registry": []interface{}{
-				map[string]interface{}{
-					"type": "dockerhub",
-					"name": "dh",
-					"url":  "https://registry.hub.docker.com",
-					"user": "shurley",
-					"pass": "testingboom",
-					"org":  "shurley",
-				}, map[string]interface{}{
-					"pass": "testingboom",
-					"org":  "ansibleplaybookbundle",
-					"type": "dockerhub",
-					"name": "play",
-					"url":  "https://registry.hub.docker.com",
-					"user": "shurley",
-				},
-			},
-			"broker": map[string]interface{}{
-				"launch_apb_on_bind":   "false",
-				"bootstrap_on_startup": true,
-				"recovery":             true,
-				"output_request":       true,
-				"ssl_cert_key":         "/var/run/secrets/kubernetes.io/serviceaccount/tls.key",
-				"ssl_cert":             "/var/run/secrets/kubernetes.io/serviceaccount/tls.crt",
-				"refresh_interval":     "600s",
-				"dev_broker":           true,
-				"testInt":              100,
-				"testFloat32":          32.87,
-				"testFloat64":          45677.0799485958595,
-			},
-		},
-			mutex: sync.RWMutex{},
-		}
-	*/
 	c, err := CreateConfig("testdata/generated_local_development.yaml")
 	if err != nil {
 		fmt.Printf("Unable to create config - %v", err)
@@ -179,24 +95,30 @@ func TestConfigGetBool(t *testing.T) {
 
 func TestConfigGetSubMap(t *testing.T) {
 	testInvalidSubMap := config.GetSubConfig("makes.no.sense")
-	testNoNameArray := config.GetSubConfig("dh_no_names")
-	testSubMap := config.GetSubConfig("registry")
-	ft.AssertEqual(t, testSubMap.GetString("dh.name"), "dh")
-	ft.AssertEqual(t, testSubMap.GetString("play.user"), "shurley")
-	ft.AssertEqual(t, testSubMap.GetString("dh.url"), "https://registry.hub.docker.com")
-	ft.AssertEqual(t, testSubMap.GetString("dh.pass"), "testingboom")
-	ft.AssertEqual(t, testSubMap.GetString("dh.org"), "shurley")
-	ft.AssertEqual(t, testSubMap.GetString("play.org"), "ansibleplaybookbundle")
-	ft.AssertEqual(t, testSubMap.GetString("dh.type"), "dockerhub")
-	ft.AssertEqual(t, testSubMap.GetString("play.type"), "dockerhub")
+	testInvalidSubConfigArray := config.GetSubConfig("registry")
+	testSubMap := config.GetSubConfig("broker.new_object")
+	testSubMapBroker := config.GetSubConfig("broker")
+	ft.AssertEqual(t, testSubMap.GetString("key"), "value1")
+	ft.AssertEqual(t, testSubMap.GetString("key2"), "value2")
+	ft.AssertEqual(t, testSubMapBroker.GetString("new_object.key"), "value1")
+	ft.AssertEqual(t, testSubMapBroker.GetString("new_object.key2"), "value2")
 	ft.AssertTrue(t, testInvalidSubMap.Empty())
-	ft.AssertTrue(t, testNoNameArray.Empty())
+	ft.AssertTrue(t, testInvalidSubConfigArray.Empty())
 }
 
 func TestConfigGetMap(t *testing.T) {
-	testMap := config.GetSubConfig("registry").ToMap()
-	_, ok := testMap["dh"]
+	testMap := config.GetSubConfig("broker").ToMap()
+	_, ok := testMap["dev_broker"]
 	ft.AssertTrue(t, ok)
-	_, ok = testMap["dockerhub"]
-	ft.AssertFalse(t, ok)
+	_, ok = testMap["recovery"]
+	ft.AssertTrue(t, ok)
+}
+
+func TestGetSubConfigArray(t *testing.T) {
+	testSubConfig := config.GetSubConfigArray("registry")
+	testInvalidSubConfig := config.GetSubConfigArray("makes.no_sense")
+	ft.AssertEqual(t, len(testInvalidSubConfig), 0)
+	ft.AssertEqual(t, len(testSubConfig), 2)
+	ft.AssertEqual(t, testSubConfig[0].GetString("name"), "dh")
+	ft.AssertEqual(t, testSubConfig[1].GetString("name"), "play")
 }

--- a/pkg/config/testdata/generated_local_development.yaml
+++ b/pkg/config/testdata/generated_local_development.yaml
@@ -42,3 +42,6 @@ broker:
   testInt: 100
   testFloat32: 32.87
   testFloat64: 45677.0799485958595
+  new_object:
+    key: value1
+    key2: value2


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
Adds ability for the config package to handle an array of elements 

**Changes proposed in this pull request**
* Fixing registry unique name regression.
* Adding ability to get an array of sub configs.
* Handling the case that final object is an array will return an array
now.
* if not the final key, will still attempt to look into an array based on
the name then type.

**Does this PR depend on another PR (Use this to track when PRs should be merged)**
depends-on <PR>

**Which issue this PR fixes (This will close that issue when PR gets merged)**
fixes #644 