### PR TITLE
make build-image isn't retrying

### DIFF
--- a/scripts/broker-ci/setup-broker.sh
+++ b/scripts/broker-ci/setup-broker.sh
@@ -6,7 +6,7 @@ source "${BROKER_DIR}/scripts/broker-ci/error.sh"
 set -ex
 
 function make-build-image {
-    set +x
+    set +ex
     RETRIES=3
     for x in $(seq $RETRIES); do
 	make build-image
@@ -23,7 +23,7 @@ function make-build-image {
 	exit 1
     fi
 
-    set -x
+    set -ex
 }
 
 function make-deploy {


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
Sometimes travis fails because of mirror timeouts when building
containers.  The retry logic around make build-image was suppose
to mitigate these failures, but it wasn't retrying.

Changes proposed in this pull request
 - Add ```+e``` for error tolerance when running ```make build-image```
