### PR TITLE
Add some missing networking permissions to the k8s template

### DIFF
--- a/templates/k8s-ansible-service-broker.yaml.j2
+++ b/templates/k8s-ansible-service-broker.yaml.j2
@@ -26,10 +26,10 @@ rules:
 - apiGroups: ["authentication.k8s.io"]
   resources: ["tokenreviews"]
   verbs: ["create"]
-- apiGroups: ["image.openshift.io", ""]
+- apiGroups: ["networking.k8s.io", ""]
   attributeRestrictions: null
-  resources: ["images"]
-  verbs: ["get", "list"]
+  resources: ["networkpolicies"]
+  verbs: ["create", "delete"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
The clusterrole was missing some networking permissions. Also, remove the perms for openshift.io.

Changes proposed in this pull request
 - Add networking policy to the asb-auth clusterrole

**Which issue this PR fixes (This will close that issue when PR gets merged)**
fixes https://github.com/openshift/ansible-service-broker/issues/651
