### PR TITLE
Fail faster with travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ install:
   - ./scripts/travis.sh install
 before_script:
   - ./scripts/travis.sh before_script
-script:
   - ./scripts/travis.sh format
   - ./scripts/travis.sh vet
   - ./scripts/travis.sh lint
@@ -19,6 +18,7 @@ script:
   - ./scripts/travis.sh test
   - ./scripts/travis.sh setup-cluster
   - ./scripts/travis.sh setup-broker
+script:
   - ./scripts/travis.sh ci
   - ./scripts/broker-ci/gather-logs.sh
   - 'oc get pods --all-namespaces'

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -13,7 +13,6 @@ if [[ "$action" == "before_install" ]]; then
   echo "================================="
   echo "        Before Install           "
   echo "================================="
-  exit 1
   sudo do-release-upgrade -f DistUpgradeViewNonInteractive
   sudo apt-get -qq update
   sudo apt-get install -y python-apt autoconf pkg-config e2fslibs-dev libblkid-dev zlib1g-dev liblzo2-dev asciidoc

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -13,6 +13,7 @@ if [[ "$action" == "before_install" ]]; then
   echo "================================="
   echo "        Before Install           "
   echo "================================="
+  exit 1
   sudo do-release-upgrade -f DistUpgradeViewNonInteractive
   sudo apt-get -qq update
   sudo apt-get install -y python-apt autoconf pkg-config e2fslibs-dev libblkid-dev zlib1g-dev liblzo2-dev asciidoc


### PR DESCRIPTION
**Describe what this PR does and why we need it**
Everything that runs in the scripts section won't error out on a failure. Move everything that is part of the setup for the CI job out of the scripts section so we fail faster if the setup fails.
 