### PR TITLE
Remove platform version header check comment

### DIFF
--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -174,9 +174,6 @@ func NewHandler(b broker.Broker, brokerConfig *config.Config, prefix string,
 		s = h.router.PathPrefix(prefix).Subrouter()
 	}
 
-	// TODO: Reintroduce router restriction based on API version when settled upstream
-	// root := h.router.Headers("X-Broker-API-Version", "2.9").Subrouter()
-
 	s.HandleFunc("/v2/bootstrap", createVarHandler(h.bootstrap)).Methods("POST")
 	s.HandleFunc("/v2/catalog", createVarHandler(h.catalog)).Methods("GET")
 	s.HandleFunc("/v2/service_instances/{instance_uuid}", createVarHandler(h.getinstance)).Methods("GET")


### PR DESCRIPTION
**Describe what this PR does and why we need it**:

PR does nothing but remove a very old header check that has been commented out. Background on this is when we inherited our original http server from the template broker, it was checking for the presence of the `X-Broker-API-Version`, [which MUST be sent by the platform to brokers](https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#api-version-header). The broker has no obligation with regard to this header; it's there in case brokers rely on features that may not be present in the platform they're currently talking to. IIRC, I created this issue because at the time, the catalog was not sending the header.

I'm removing the comment (and want to close the issue) because I don't see an immediate need for us to re-introduce the check, especially considering we're often a project that is validating proposed features to the spec that do not yet exist in OSB master. The issue should be reopened, or a new issue filed if we find a need to cooperate with platforms that are not the k8s service catalog (could forsee this as we start to talk about the BrokerSDK).

**Which issue this PR fixes (This will close that issue when PR gets merged)**
fixes #34
