### PR TITLE
Update test bash scripts

### DIFF
--- a/test/bind.sh
+++ b/test/bind.sh
@@ -1,23 +1,39 @@
 #!/bin/bash -e
 
-. shared.sh
+INSTANCE_ID=$1
+BINDING_ID=$2
+PLAN_UUID="7f4a5e35e4af2beb70076e72fab0b7ff"
+SERVICE_UUID="dh-postgresql-apb-s964m"
 
-# mlab with params
-instanceUUID="8c9adf85-9221-4776-aa18-aae7b7acc436"
+if [ "$INSTANCE_ID" = "" ]
+then
+  echo "Usage: $0 <instance uuid> <binding uuid>"
+  exit
+fi
+
+if [ "$BINDING_ID" = "" ]
+then
+  echo "Usage: $0 <instance uuid> <binding uuid>"
+  exit
+fi
+
 req="{
-  \"plan_id\": \"$planUUID\",
-  \"service_id\": \"$serviceUUID\",
+  \"plan_id\": \"$PLAN_UUID\",
+  \"service_id\": \"$SERVICE_UUID\",
+  \"context\": \"blog-project\",
   \"app_guid\":\"\",
   \"bind_resource\":{},
-  \"parameters\": {
-    \"user\": \"acct_one\"
-  }
+  \"parameters\": {}
 }"
 
 curl \
-  -X PUT \
-  -H 'X-Broker-API-Version: 2.9' \
-  -H 'Content-Type: application/json' \
-  -d "$req" \
-  -v \
-  http://localhost:1338/v2/service_instances/$instanceUUID/service_bindings/$bindingUUID
+    -k \
+    -X PUT \
+    -H "Authorization: bearer $(oc whoami -t)" \
+    -H "Content-type: application/json" \
+    -H "Accept: application/json" \
+    -H "X-Broker-API-Originating-Identity: " \
+    -d "$req" \
+    "https://asb-1338-ansible-service-broker.172.17.0.1.nip.io/ansible-service-broker/v2/service_instances/$INSTANCE_ID/service_bindings/$BINDING_ID?accepts_incomplete=true"
+
+

--- a/test/bootstrap.sh
+++ b/test/bootstrap.sh
@@ -1,9 +1,11 @@
 #!/bin/bash -e
 
-. shared.sh
-
 curl \
-  -H 'X-Broker-API-Version: 2.9' \
-  -X POST \
-  -v \
-  http://localhost:1338/v2/bootstrap
+    -k \
+    -X POST \
+    -H "Authorization: bearer $(oc whoami -t)" \
+    -H "Content-type: application/json" \
+    -H "Accept: application/json" \
+    -H "X-Broker-API-Originating-Identity: " \
+    -d "$req" \
+    "https://asb-1338-ansible-service-broker.172.17.0.1.nip.io/ansible-service-broker/v2/bootstrap"

--- a/test/catalog.sh
+++ b/test/catalog.sh
@@ -1,8 +1,9 @@
 #!/bin/bash -e
 
-. shared.sh
-
 curl \
-  -H 'X-Broker-API-Version: 2.9' \
-  -s \
-  http://localhost:1338/v2/catalog
+    -k \
+    -X GET \
+    -H "Authorization: bearer $(oc whoami -t)" \
+    -H "Content-type: application/json" \
+    -H "Accept: application/json" \
+    "https://asb-1338-ansible-service-broker.172.17.0.1.nip.io/ansible-service-broker/v2/catalog"

--- a/test/deprovision.sh
+++ b/test/deprovision.sh
@@ -1,9 +1,18 @@
 #!/bin/bash -e
 
-instanceUUID="688eea24-9cf9-43e3-9942-d1863b2a16af"
+INSTANCE_ID=$1
+
+if [ "$INSTANCE_ID" = "" ]
+then
+  echo "Usage: $0 <instance uuid>"
+  exit
+fi
 
 curl \
-  -X DELETE \
-  -H 'X-Broker-API-Version: 2.9' \
-  -v \
-  http://localhost:1338/v2/service_instances/$instanceUUID
+    -k \
+    -X DELETE \
+    -H "Authorization: bearer $(oc whoami -t)" \
+    -H "Content-type: application/json" \
+    -H "Accept: application/json" \
+    -H "X-Broker-API-Originating-Identity: " \
+    "https://asb-1338-ansible-service-broker.172.17.0.1.nip.io/ansible-service-broker/v2/service_instances/$INSTANCE_ID"

--- a/test/getbind.sh
+++ b/test/getbind.sh
@@ -3,6 +3,7 @@
 INSTANCE_ID=$1
 BINDING_ID=$2
 PLAN_UUID="7f4a5e35e4af2beb70076e72fab0b7ff"
+SERVICE_UUID="dh-postgresql-apb-s964m"
 
 if [ "$INSTANCE_ID" = "" ]
 then
@@ -16,13 +17,22 @@ then
   exit
 fi
 
+req="{
+  \"plan_id\": \"$PLAN_UUID\",
+  \"service_id\": \"$SERVICE_UUID\",
+  \"context\": \"blog-project\",
+  \"app_guid\":\"\",
+  \"bind_resource\":{},
+  \"parameters\": {}
+}"
+
 curl \
     -k \
-    -X DELETE \
+    -X GET \
     -H "Authorization: bearer $(oc whoami -t)" \
     -H "Content-type: application/json" \
     -H "Accept: application/json" \
     -H "X-Broker-API-Originating-Identity: " \
-    "https://asb-1338-ansible-service-broker.172.17.0.1.nip.io/ansible-service-broker/v2/service_instances/$INSTANCE_ID/service_bindings/$BINDING_ID?accepts_incomplete=true&plan_id=$PLAN_UUID"
+    "https://asb-1338-ansible-service-broker.172.17.0.1.nip.io/ansible-service-broker/v2/service_instances/$INSTANCE_ID/service_bindings/$BINDING_ID"
 
 

--- a/test/getinstance.sh
+++ b/test/getinstance.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -e
+
+INSTANCE_ID=$1
+
+if [ "$INSTANCE_ID" = "" ]
+then
+  echo "Usage: $0 <instance uuid> <binding uuid>"
+  exit
+fi
+
+curl \
+    -k \
+    -X GET \
+    -H "Authorization: bearer $(oc whoami -t)" \
+    -H "Content-type: application/json" \
+    -H "Accept: application/json" \
+    -H "X-Broker-API-Originating-Identity: " \
+    "https://asb-1338-ansible-service-broker.172.17.0.1.nip.io/ansible-service-broker/v2/service_instances/$INSTANCE_ID"

--- a/test/last_operation.sh
+++ b/test/last_operation.sh
@@ -1,15 +1,27 @@
 #!/bin/bash -e
 
-#instanceUUID="688eea24-9cf9-43e3-9942-d1863b2a16af"
-instanceUUID="abd21149-07d7-4a8a-b40b-4b815110c3cc"
-planUUID="4c10ff42-be89-420a-9bab-27a9bef9aed8"
-serviceUUID="84e8173e-5ced-4489-9b4d-aac7e779c47e"
+INSTANCE_ID=$1
+OPERATION=$2
+PLAN_UUID="7f4a5e35e4af2beb70076e72fab0b7ff"
+SERVICE_UUID="dh-postgresql-apb-s964m"
 
-operation=$1
+if [ "$INSTANCE_ID" = "" ]
+then
+  echo "Usage: $0 <instance uuid> <operation uuid>"
+  exit
+fi
+
+if [ "$OPERATION" = "" ]
+then
+  echo "Usage: $0 <instance uuid> <operation uuid>"
+  exit
+fi
 
 curl \
-  -X GET \
-  -H 'X-Broker-API-Version: 2.9' \
-  -H 'Content-Type: application/json' \
-  -v \
-  "http://localhost:1338/v2/service_instances/$instanceUUID/last_operation?operation=$operation&service_id=$serviceUUID&plan_id=$planUUID"
+    -k \
+    -X GET \
+    -H "Authorization: bearer $(oc whoami -t)" \
+    -H "Content-type: application/json" \
+    -H "Accept: application/json" \
+    -H "X-Broker-API-Originating-Identity: " \
+    "https://asb-1338-ansible-service-broker.172.17.0.1.nip.io/ansible-service-broker/v2/service_instances/$INSTANCE_ID/last_operation?operation=$OPERATION&service_id=$SERVICE_UUID&plan_id=$PLAN_UUID"

--- a/test/provision-200.sh
+++ b/test/provision-200.sh
@@ -1,12 +1,25 @@
 #!/bin/bash -e
 
-instanceUUID="abd21149-07d7-4a8a-b40b-4b815110c3cc"
-planUUID="4c10ff42-be89-420a-9bab-27a9bef9aed8"
-serviceUUID="0aaafc10-132b-41a8-a58c-73268ff1006a"
+INSTANCE_ID=$1
+BINDING_ID=$2
+PLAN_UUID="7f4a5e35e4af2beb70076e72fab0b7ff"
+SERVICE_UUID="dh-postgresql-apb-s964m"
+
+if [ "$INSTANCE_ID" = "" ]
+then
+  echo "Usage: $0 <instance uuid> <binding uuid>"
+  exit
+fi
+
+if [ "$BINDING_ID" = "" ]
+then
+  echo "Usage: $0 <instance uuid> <binding uuid>"
+  exit
+fi
 
 req="{
-  \"plan_id\": \"$planUUID\",
-  \"service_id\": \"$serviceUUID\",
+  \"plan_id\": \"$PLAN_UUID\",
+  \"service_id\": \"$SERVICE_UUID\",
   \"parameters\": {
     \"aws_access_key\": \"key\",
     \"aws_secret_key\": \"secret\",
@@ -30,9 +43,13 @@ req="{
 }"
 
 curl \
-  -X PUT \
-  -H 'X-Broker-API-Version: 2.9' \
-  -H 'Content-Type: application/json' \
-  -d "$req" \
-  -v \
-  "http://localhost:1338/v2/service_instances/$instanceUUID?accepts_incomplete=true"
+    -k \
+    -X PUT \
+    -H "Authorization: bearer $(oc whoami -t)" \
+    -H "Content-type: application/json" \
+    -H "Accept: application/json" \
+    -H "X-Broker-API-Originating-Identity: " \
+    -d "$req" \
+    "https://asb-1338-ansible-service-broker.172.17.0.1.nip.io/ansible-service-broker/v2/service_instances/$INSTANCE_ID?accepts_incomplete=true"
+
+

--- a/test/provision-409.sh
+++ b/test/provision-409.sh
@@ -1,13 +1,25 @@
 #!/bin/bash -e
 
-# same instanceUUID but different parameters
-instanceUUID="abd21149-07d7-4a8a-b40b-4b815110c3cc"
-planUUID="4c10ff42-be89-420a-9bab-27a9bef9aed8"
-serviceUUID="0aaafc10-132b-41a8-a58c-73268ff1006a"
+INSTANCE_ID=$1
+BINDING_ID=$2
+PLAN_UUID="7f4a5e35e4af2beb70076e72fab0b7ff"
+SERVICE_UUID="dh-postgresql-apb-s964m"
+
+if [ "$INSTANCE_ID" = "" ]
+then
+  echo "Usage: $0 <instance uuid> <binding uuid>"
+  exit
+fi
+
+if [ "$BINDING_ID" = "" ]
+then
+  echo "Usage: $0 <instance uuid> <binding uuid>"
+  exit
+fi
 
 req="{
-  \"plan_id\": \"$planUUID\",
-  \"service_id\": \"$serviceUUID\",
+  \"plan_id\": \"$PLAN_UUID\",
+  \"service_id\": \"$SERVICE_UUID\",
   \"parameters\": {
     \"aws_access_key\": \"key\",
     \"aws_secret_key\": \"secret\",
@@ -31,9 +43,13 @@ req="{
 }"
 
 curl \
-  -X PUT \
-  -H 'X-Broker-API-Version: 2.9' \
-  -H 'Content-Type: application/json' \
-  -d "$req" \
-  -v \
-  "http://localhost:1338/v2/service_instances/$instanceUUID?accepts_incomplete=true"
+    -k \
+    -X PUT \
+    -H "Authorization: bearer $(oc whoami -t)" \
+    -H "Content-type: application/json" \
+    -H "Accept: application/json" \
+    -H "X-Broker-API-Originating-Identity: " \
+    -d "$req" \
+    "https://asb-1338-ansible-service-broker.172.17.0.1.nip.io/ansible-service-broker/v2/service_instances/$INSTANCE_ID?accepts_incomplete=true"
+
+

--- a/test/provision.sh
+++ b/test/provision.sh
@@ -1,25 +1,42 @@
 #!/bin/bash -e
 
-instanceUUID="abd21149-07d7-4a8a-b40b-4b815110c3cc"
-planUUID="4c10ff42-be89-420a-9bab-27a9bef9aed8"
-serviceUUID="0aaafc10-132b-41a8-a58c-73268ff1006a"
+INSTANCE_ID=$1
+BINDING_ID=$2
+PLAN_UUID="7f4a5e35e4af2beb70076e72fab0b7ff"
+SERVICE_UUID="dh-postgresql-apb-s964m"
+
+if [ "$INSTANCE_ID" = "" ]
+then
+  echo "Usage: $0 <instance uuid> <binding uuid>"
+  exit
+fi
+
+if [ "$BINDING_ID" = "" ]
+then
+  echo "Usage: $0 <instance uuid> <binding uuid>"
+  exit
+fi
 
 req="{
-  \"plan_id\": \"$planUUID\",
-  \"service_id\": \"$serviceUUID\",
+  \"plan_id\": \"$PLAN_UUID\",
+  \"service_id\": \"$SERVICE_UUID\",
   \"context\": {
     \"platform\": \"kubernetes\",
-    \"namespace\": \"mysql-project\"
-  }
-  \"parameters\": {
-    \"MYSQL_USER\": \"username\"
-  }
+    \"namespace\": \"blog-project\"
+  },
+  \"app_guid\":\"\",
+  \"bind_resource\":{},
+  \"parameters\": {}
 }"
 
 curl \
-  -X PUT \
-  -H 'X-Broker-API-Version: 2.9' \
-  -H 'Content-Type: application/json' \
-  -d "$req" \
-  -v \
-  "http://localhost:1338/v2/service_instances/$instanceUUID?accepts_incomplete=true"
+    -k \
+    -X PUT \
+    -H "Authorization: bearer $(oc whoami -t)" \
+    -H "Content-type: application/json" \
+    -H "Accept: application/json" \
+    -H "X-Broker-API-Originating-Identity: " \
+    -d "$req" \
+    "https://asb-1338-ansible-service-broker.172.17.0.1.nip.io/ansible-service-broker/v2/service_instances/$INSTANCE_ID?accepts_incomplete=true"
+
+

--- a/test/shared.sh
+++ b/test/shared.sh
@@ -1,6 +1,0 @@
-#!/bin/bash -e
-
-defaultplanUUID=4c10ff42-be89-420a-9bab-27a9bef9aed8
-
-instanceUUID=${instanceUUID-a71f7ab8-e448-4826-8f05-32a185222dd7}
-bindingUUID=${bindingUUID-dde0226b-ff95-4f9d-af51-2e9ec06b1f02}


### PR DESCRIPTION
During async bind, I had a set of bash scripts: `bind.sh`, `unbind.sh`, `getbind.sh`, and `getinstance.sh` which worked with the broker's route. They were duplicates of the original bash scripts in the `test` folder. 

The older scripts were also outdated, so I brought them up to date with my newer scripts. They now also take in parameters for some of the arguments. They are not perfect but get the job done.