### PR TITLE
Bug 1536659 - bind PUT returns http code 202 when operation runs async

### DIFF
--- a/pkg/broker/types.go
+++ b/pkg/broker/types.go
@@ -18,6 +18,7 @@ package broker
 
 import (
 	"encoding/json"
+	"errors"
 
 	schema "github.com/lestrrat/go-jsschema"
 	"github.com/openshift/ansible-service-broker/pkg/apb"
@@ -216,6 +217,23 @@ type BindResponse struct {
 	RouteServiceURL string                 `json:"route_service_url,omitempty"`
 	VolumeMounts    []interface{}          `json:"volume_mounts,omitempty"`
 	Operation       string                 `json:"operation,omitempty"`
+}
+
+// NewBindResponse - creates a BindResponse based on available credentials.
+func NewBindResponse(pCreds, bCreds *apb.ExtractedCredentials) (*BindResponse, error) {
+	// Can't bind to anything if we have nothing to return to the catalog
+	if pCreds == nil && bCreds == nil {
+		log.Errorf("No extracted credentials found from provision or bind instance ID")
+		return nil, errors.New("No credentials available")
+	}
+
+	if bCreds != nil {
+		log.Debugf("bind creds: %v", bCreds.Credentials)
+		return &BindResponse{Credentials: bCreds.Credentials}, nil
+	}
+
+	log.Debugf("provision bind creds: %v", pCreds.Credentials)
+	return &BindResponse{Credentials: pCreds.Credentials}, nil
 }
 
 // DeprovisionResponse - Response for a deprovision

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -553,7 +553,7 @@ func (h handler) bind(w http.ResponseWriter, r *http.Request, params map[string]
 	}
 
 	// process binding request
-	resp, err := h.broker.Bind(serviceInstance, bindingUUID, req, async)
+	resp, ranAsync, err := h.broker.Bind(serviceInstance, bindingUUID, req, async)
 
 	if err != nil {
 		switch err {
@@ -566,6 +566,10 @@ func (h handler) bind(w http.ResponseWriter, r *http.Request, params map[string]
 		default:
 			writeResponse(w, http.StatusBadRequest, broker.ErrorResponse{Description: err.Error()})
 		}
+		return
+	}
+	if ranAsync {
+		writeDefaultResponse(w, http.StatusAccepted, resp, err)
 	} else {
 		writeDefaultResponse(w, http.StatusCreated, resp, err)
 	}

--- a/pkg/handler/handler_test.go
+++ b/pkg/handler/handler_test.go
@@ -93,9 +93,9 @@ func (m MockBroker) Deprovision(apb.ServiceInstance, string, bool, bool) (*broke
 	m.called("deprovision", true)
 	return nil, m.Err
 }
-func (m MockBroker) Bind(apb.ServiceInstance, uuid.UUID, *broker.BindRequest, bool) (*broker.BindResponse, error) {
+func (m MockBroker) Bind(apb.ServiceInstance, uuid.UUID, *broker.BindRequest, bool) (*broker.BindResponse, bool, error) {
 	m.called("bind", true)
-	return nil, m.Err
+	return nil, false, m.Err
 }
 func (m MockBroker) Unbind(apb.ServiceInstance, apb.BindInstance, string, bool, bool) (*broker.UnbindResponse, error) {
 	m.called("unbind", true)


### PR DESCRIPTION
Previously the http response incorrectly had code 201.

Once async logic was removed from buildBindRequest, it looked an awful lot like
a simple constructor. That's why I moved it next to the type definition and
renamed it NewBindRequest to match golang convention.

fixes #667