### PR TITLE
Bug 1537367 - missing last_operation for bindings

### DIFF
--- a/test/last_operation_bind.sh
+++ b/test/last_operation_bind.sh
@@ -1,0 +1,30 @@
+#!/bin/bash -e
+
+INSTANCE_ID="$1"
+BINDING_ID="$2"
+OPERATION="$3"
+PLAN_UUID="$4"
+SERVICE_UUID="$5"
+
+validate_param() {
+  if [ "$1" = "" ]
+  then
+    echo "Usage: $0 <instance uuid> <binding uuid> <plan uuid> <service uuid>"
+    exit
+  fi
+}
+
+#validate_param "$INSTANCE_ID"
+#validate_param "$BINDING_ID"
+#validate_param "$OPERATION"
+#validate_param "$PLAN_UUID"
+#validate_param "$SERVICE_UUID"
+
+curl \
+    -k \
+    -X GET \
+    -H "Authorization: bearer $(oc whoami -t)" \
+    -H "Content-type: application/json" \
+    -H "Accept: application/json" \
+    -H "X-Broker-API-Originating-Identity: " \
+    "https://asb-1338-ansible-service-broker.172.17.0.1.nip.io/ansible-service-broker/v2/service_instances/$INSTANCE_ID/service_bindings/$BINDING_ID/last_operation?operation=$OPERATION&service_id=$SERVICE_UUID&plan_id=$PLAN_UUID"


### PR DESCRIPTION
Missing last_operation for the async binds. The service_instance method would work because our jobs are the same. But OSB platforms will want to call the last_operation binding.