### PR TITLE
Skip running the travis job if we're only changing docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,15 @@ jobs:
   include:
     - stage: "OpenShift and Kubernetes CI"
       before_install:
+        # Copied from https://github.com/facebook/react/pull/2000
+        - |
+            if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+              TRAVIS_COMMIT_RANGE="FETCH_HEAD...$TRAVIS_BRANCH"
+            fi
+            git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(\.md$)|(^(docs|examples))/' || {
+              echo "Only docs were updated, stopping build process."
+              exit 0
+            }
         - ./scripts/travis.sh before_install
       install:
         - ./scripts/travis.sh install

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,16 @@ jobs:
         - ./scripts/travis.sh ci
         - ./scripts/broker-ci/gather-logs.sh
     -
+      before_install:
+        # Copied from https://github.com/facebook/react/pull/2000
+        - |
+            if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+              TRAVIS_COMMIT_RANGE="FETCH_HEAD...$TRAVIS_BRANCH"
+            fi
+            git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(\.md$)|(^(docs|examples))/' || {
+              echo "Only docs were updated, stopping build process."
+              exit 0
+            }
       before_script:
         - ./scripts/travis.sh setup-minikube
         - ./scripts/travis.sh k8s-catalog


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
We don't need to run CI on doc changes so exit early.

Changes proposed in this pull request
 - Check to see that only docs are being changed, then exit 0.
 