### PR TITLE
One CI fix and a few improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ jobs:
         # Copied from https://github.com/facebook/react/pull/2000
         - |
             if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
-              TRAVIS_COMMIT_RANGE="FETCH_HEAD...$TRAVIS_BRANCH"
+              TRAVIS_COMMIT_RANGE="$TRAVIS_BRANCH"
             fi
             git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(\.md$)|(^(docs|examples))/' || {
               git diff --name-only HEAD^

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,11 @@ jobs:
               TRAVIS_COMMIT_RANGE="FETCH_HEAD...$TRAVIS_BRANCH"
             fi
             git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(\.md$)|(^(docs|examples))/' || {
+              git diff --name-only HEAD^
+              echo $TRAVIS_COMMIT_RANGE
+              echo $(git diff --name-only $TRAVIS_COMMIT_RANGE)
+              echo $(git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(\.md$)|(^(docs|examples))/')
+
               echo "Only docs were updated, stopping build process."
               exit 0
             }

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,6 @@ jobs:
               TRAVIS_COMMIT_RANGE="$TRAVIS_BRANCH"
             fi
             git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(\.md$)|(^(docs|examples))/' || {
-              git diff --name-only HEAD^
-              echo $TRAVIS_COMMIT_RANGE
-              echo $(git diff --name-only $TRAVIS_COMMIT_RANGE)
-              echo $(git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(\.md$)|(^(docs|examples))/')
-
               echo "Only docs were updated, stopping build process."
               exit 0
             }
@@ -45,7 +40,7 @@ jobs:
         # Copied from https://github.com/facebook/react/pull/2000
         - |
             if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
-              TRAVIS_COMMIT_RANGE="FETCH_HEAD...$TRAVIS_BRANCH"
+              TRAVIS_COMMIT_RANGE="$TRAVIS_BRANCH"
             fi
             git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(\.md$)|(^(docs|examples))/' || {
               echo "Only docs were updated, stopping build process."

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 
+// TODO: REMOVE Comment
 package app
 
 import (

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -14,7 +14,6 @@
 // limitations under the License.
 //
 
-// TODO: REMOVE Comment
 package app
 
 import (

--- a/scripts/broker-ci/gather-logs.sh
+++ b/scripts/broker-ci/gather-logs.sh
@@ -45,7 +45,7 @@ function instance-logs {
 function catalog-logs {
     log-header "catalog-logs"
     catalog_ns=$(kubectl get ns | grep catalog | cut -f 1 -d ' ' | head -1)
-    kubectl logs $(kubectl get pods -o name -l app=controller-manager --all-namespaces | cut -f 2 -d '/') -n $catalog_ns
+    kubectl logs $(kubectl get pods -n $catalog_ns | grep controller-manager | awk '{ print $1 }') -n $catalog_ns
     log-footer "catalog-logs"
 }
 

--- a/scripts/broker-ci/gather-logs.sh
+++ b/scripts/broker-ci/gather-logs.sh
@@ -16,6 +16,12 @@ function log-footer {
     travis_fold end $footer
 }
 
+function docker-images {
+    log-header "docker-images"
+    docker images
+    log-footer "docker-images"
+}
+
 function pod-logs {
     log-header "pod-logs"
     kubectl get pods --all-namespaces
@@ -45,7 +51,7 @@ function instance-logs {
 function catalog-logs {
     log-header "catalog-logs"
     catalog_ns=$(kubectl get ns | grep catalog | cut -f 1 -d ' ' | head -1)
-    kubectl logs --since=10m $(kubectl get pods -n $catalog_ns | grep controller-manager | awk '{ print $1 }') -n $catalog_ns
+    kubectl logs --since=5m $(kubectl get pods -n $catalog_ns | grep controller-manager | awk '{ print $1 }') -n $catalog_ns
     log-footer "catalog-logs"
 }
 
@@ -79,6 +85,7 @@ function print-pod-errors {
 
 function print-all-logs {
     print-pod-errors
+    docker-images
     secret-logs
     pod-logs
     instance-logs

--- a/scripts/broker-ci/gather-logs.sh
+++ b/scripts/broker-ci/gather-logs.sh
@@ -45,7 +45,7 @@ function instance-logs {
 function catalog-logs {
     log-header "catalog-logs"
     catalog_ns=$(kubectl get ns | grep catalog | cut -f 1 -d ' ' | head -1)
-    kubectl logs $(kubectl get pods -n $catalog_ns | grep controller-manager | awk '{ print $1 }') -n $catalog_ns
+    kubectl logs --since=10m $(kubectl get pods -n $catalog_ns | grep controller-manager | awk '{ print $1 }') -n $catalog_ns
     log-footer "catalog-logs"
 }
 

--- a/scripts/broker-ci/setup-catalog.sh
+++ b/scripts/broker-ci/setup-catalog.sh
@@ -33,10 +33,10 @@ function service-catalog {
     helm install /tmp/service-catalog/charts/catalog \
     --name catalog \
     --namespace catalog \
-    --set apiserver.image="apiserver:canary" \
-    --set apiserver.imagePullPolicy="Never" \
-    --set controllerManager.image="controller-manager:canary" \
-    --set controllerManager.imagePullPolicy="Never"
+    --set imagePullPolicy="Never" \
+    --set image="service-catalog:canary" \
+    --set apiserver.verbosity="2" \
+    --set controllerManager.verbosity="2"
 }
 
 echo "Starting the Service Catalog"


### PR DESCRIPTION
Fix:
  - ```git diff FETCH_HEAD...$TRAVIS_BRANCH``` was always returning true.  Instead, just use ```git diff $TRAVIS_BRANCH``` it will compare the diff from the current PR branch to the master branch.

Improvement:
  - Use the freshly built service-catalog images
  - Reduce service-catalog log-level to 2
  - Only gather logs from the service-catalog from the last 5 minutes.
  - List the docker images that travis has
 