### PR TITLE
Bug 1538321 - Continue to load specs even when a spec fails to load

### DIFF
--- a/pkg/registries/adapters/dockerhub_adapter.go
+++ b/pkg/registries/adapters/dockerhub_adapter.go
@@ -111,8 +111,7 @@ func (r DockerHubAdapter) FetchSpecs(imageNames []string) ([]*apb.Spec, error) {
 	for _, imageName := range imageNames {
 		spec, err := r.loadSpec(imageName)
 		if err != nil {
-			r.Log.Errorf("unable to retrieve spec data for image - %v", err)
-			return specs, err
+			r.Log.Errorf("Failed to retrieve spec data for image %s - %v", imageName, err)
 		}
 		if spec != nil {
 			specs = append(specs, spec)

--- a/pkg/registries/adapters/openshift_adapter.go
+++ b/pkg/registries/adapters/openshift_adapter.go
@@ -67,8 +67,7 @@ func (r OpenShiftAdapter) FetchSpecs(imageNames []string) ([]*apb.Spec, error) {
 		r.Log.Debug("%v", imageName)
 		spec, err := r.loadSpec(imageName)
 		if err != nil {
-			r.Log.Errorf("unable to retrieve spec data for image - %v", err)
-			return specs, err
+			r.Log.Errorf("Failed to retrieve spec data for image %s - %v", imageName, err)
 		}
 		if spec != nil {
 			specs = append(specs, spec)


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
When a spec fails to load, it will cause all the specs from that registry adaptor to be ignored.  If the broker is configure to look at only one adaptor, it causes the broker to fail.

Let's log the spec failure and continue processing valid specs.

Changes proposed in this pull request
 - Be more fault tolerant to failed specs

**Which issue this PR fixes (This will close that issue when PR gets merged)**
fixes https://github.com/openshift/ansible-service-broker/issues/681
