### PR TITLE
Bug 1506978 - Include lowercase proxy vars

### DIFF
--- a/pkg/apb/executor.go
+++ b/pkg/apb/executor.go
@@ -255,6 +255,18 @@ func createPodEnv(executionContext ExecutionContext) []v1.EnvVar {
 			v1.EnvVar{
 				Name:  noProxyEnvVar,
 				Value: conf.NoProxy,
+			},
+			v1.EnvVar{
+				Name:  strings.ToLower(httpProxyEnvVar),
+				Value: conf.HTTPProxy,
+			},
+			v1.EnvVar{
+				Name:  strings.ToLower(httpsProxyEnvVar),
+				Value: conf.HTTPSProxy,
+			},
+			v1.EnvVar{
+				Name:  strings.ToLower(noProxyEnvVar),
+				Value: conf.NoProxy,
 			}}...)
 	}
 


### PR DESCRIPTION
* We've seen the boto (*not* boto3) python lib expecting lowercase
"http_proxy". Need to also include lowercase variants.