### PR TITLE
add a 3.10 releaser

### DIFF
--- a/.tito/releasers.conf
+++ b/.tito/releasers.conf
@@ -28,3 +28,7 @@ branches = rhaos-3.8-asb-rhel-7
 [asb-brew-39]
 releaser = tito.release.DistGitReleaser
 branches = rhaos-3.9-asb-rhel-7
+
+[asb-brew-310]
+releaser = tito.release.DistGitReleaser
+branches = rhaos-3.10-asb-rhel-7


### PR DESCRIPTION
adding a 3.10 releaser, the brew tag doesn't exist yet but it will prevent you from building 3.10 into 3.9.