### PR TITLE
Add fall through case to deprovision handler

### DIFF
--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -443,6 +443,9 @@ func (h handler) deprovision(w http.ResponseWriter, r *http.Request, params map[
 		case broker.ErrorDeprovisionInProgress:
 			writeResponse(w, http.StatusAccepted, broker.DeprovisionResponse{})
 			return
+		default:
+			writeResponse(w, http.StatusInternalServerError, broker.ErrorResponse{Description: err.Error()})
+			return
 		}
 	} else if async {
 		writeDefaultResponse(w, http.StatusAccepted, resp, err)


### PR DESCRIPTION
**Describe what this PR does and why we need it**:

Adds a default error to deprovision handler

Changes proposed in this pull request
- Return a 500 status code as a fallback


**Which issue this PR fixes (This will close that issue when PR gets merged)**
fixes https://github.com/openshift/ansible-service-broker/issues/698

