### PR TITLE
Revert image back to match blog post in simple broker template.

### DIFF
--- a/templates/simple-broker-template.yaml
+++ b/templates/simple-broker-template.yaml
@@ -130,7 +130,7 @@ objects:
       spec:
         serviceAccount: asb
         containers:
-        - image: ansibleplaybookbundle/origin-ansible-service-broker:latest
+        - image: ansibleplaybookbundle/origin-ansible-service-broker:sprint142
           name: asb
           imagePullPolicy: IfNotPresent
           volumeMounts:
@@ -373,7 +373,7 @@ parameters:
 - description: APB Image Tag
   displayname: APB Image Tag
   name: TAG
-  value: latest
+  value: sprint142 
 
 - description: OpenShift User Password
   displayname: OpenShift User Password


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
reverts the image to a version that is compatible

