### PR TITLE
No longer only search for apbs that end with -apb

### DIFF
--- a/pkg/registries/registry.go
+++ b/pkg/registries/registry.go
@@ -111,8 +111,6 @@ func (r Registry) LoadSpecs() ([]*apb.Spec, int, error) {
 			r.config.Name, err)
 		return []*apb.Spec{}, 0, err
 	}
-	// Registry will throw out all images that do not end in -apb
-	imageNames = registryFilterImagesForAPBs(imageNames)
 	validNames, filteredNames := r.filter.Run(imageNames)
 
 	log.Debug("Filter applied against registry: %s", r.config.Name)
@@ -157,16 +155,6 @@ func (r Registry) LoadSpecs() ([]*apb.Spec, int, error) {
 	metrics.SpecsLoaded(r.RegistryName(), len(validatedSpecs))
 
 	return validatedSpecs, len(imageNames), nil
-}
-
-func registryFilterImagesForAPBs(imageNames []string) []string {
-	newNames := []string{}
-	for _, imagesName := range imageNames {
-		if strings.HasSuffix(strings.ToLower(imagesName), "-apb") {
-			newNames = append(newNames, imagesName)
-		}
-	}
-	return newNames
 }
 
 // Fail - will determine if the registry should cause a failure.

--- a/pkg/registries/registry_test.go
+++ b/pkg/registries/registry_test.go
@@ -264,7 +264,7 @@ func TestRegistryLoadSpecsNoError(t *testing.T) {
 	}
 	ft.AssertTrue(t, a.Called["GetImageNames"])
 	ft.AssertTrue(t, a.Called["FetchSpecs"])
-	ft.AssertEqual(t, numImages, 1)
+	ft.AssertEqual(t, numImages, 2)
 	ft.AssertEqual(t, len(specs), 1)
 	ft.AssertEqual(t, specs[0], &s)
 }


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
Give full respect to the whitelist config value by no longer filtering for '-apb'.

Changes proposed in this pull request
 - Remove hardcoded filter on the suffix '-apb'

**Which issue this PR fixes (This will close that issue when PR gets merged)**
fixes https://github.com/openshift/ansible-service-broker/issues/685
