### PR TITLE
Bug 1533425 - handle missing pod action error

### DIFF
--- a/pkg/apb/bind.go
+++ b/pkg/apb/bind.go
@@ -52,7 +52,7 @@ func Bind(instance *ServiceInstance,
 	if instance.Spec.Runtime >= 2 {
 		err := watchPod(executionContext.PodName, executionContext.Namespace)
 		if err != nil {
-			log.Errorf("APB Execution failed - %v", err)
+			log.Errorf("Bind action failed - %v", err)
 			return executionContext.PodName, nil, err
 		}
 	}

--- a/pkg/apb/deprovision.go
+++ b/pkg/apb/deprovision.go
@@ -62,7 +62,7 @@ func Deprovision(instance *ServiceInstance) (string, error) {
 
 	err = watchPod(executionContext.PodName, executionContext.Namespace)
 	if err != nil {
-		log.Errorf("APB Execution failed - %v", err)
+		log.Errorf("Deprovision action failed - %v", err)
 		return executionContext.PodName, err
 	}
 

--- a/pkg/apb/provision_or_update.go
+++ b/pkg/apb/provision_or_update.go
@@ -81,7 +81,7 @@ func provisionOrUpdate(method executionMethod,
 	if instance.Spec.Runtime >= 2 || !instance.Spec.Bindable {
 		err := watchPod(executionContext.PodName, executionContext.Namespace)
 		if err != nil {
-			log.Errorf("APB Execution failed - %v", err)
+			log.Errorf("Provision or Update action failed - %v", err)
 			return executionContext.PodName, nil, err
 		}
 	}

--- a/pkg/apb/unbind.go
+++ b/pkg/apb/unbind.go
@@ -49,7 +49,7 @@ func Unbind(instance *ServiceInstance, parameters *Parameters) error {
 
 	err = watchPod(executionContext.PodName, executionContext.Namespace)
 	if err != nil {
-		log.Errorf("APB Execution failed - %v", err)
+		log.Errorf("Unbind action failed - %v", err)
 		return err
 	}
 

--- a/pkg/clients/kubernetes.go
+++ b/pkg/clients/kubernetes.go
@@ -57,7 +57,7 @@ func (k KubernetesClient) GetSecretData(secretName, namespace string) (map[strin
 	secretData, err := k.Client.CoreV1().Secrets(namespace).Get(secretName, metav1.GetOptions{})
 	if err != nil {
 		log.Errorf("Unable to load secret '%s' from namespace '%s'", secretName, namespace)
-		return make(map[string][]byte), nil
+		return make(map[string][]byte), err
 	}
 	log.Debugf("Found secret with name %v\n", secretName)
 
@@ -184,12 +184,6 @@ func GetSecretData(secretName, namespace string) (map[string][]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	secretData, err := k8scli.Client.CoreV1().Secrets(namespace).Get(secretName, metav1.GetOptions{})
-	if err != nil {
-		log.Errorf("Unable to load secret '%s' from namespace '%s'", secretName, namespace)
-		return make(map[string][]byte), nil
-	}
-	log.Debugf("Found secret with name %v\n", secretName)
 
-	return secretData.Data, nil
+	return k8scli.GetSecretData(secretName, namespace)
 }


### PR DESCRIPTION
apb-base will now return a non-zero exit status meaning the pod will be marked as failed when an action that doesn't exist is used. For example, calling bind on an apb that does NOT have a bind.yaml. 

PR depends on 2 others to satisfy the bugzilla:

apb-base: https://github.com/ansibleplaybookbundle/apb-base/pull/17