### PR TITLE
Bug 1541265 - avoid broker panic, check for nil

### DIFF
--- a/pkg/broker/update_job.go
+++ b/pkg/broker/update_job.go
@@ -64,9 +64,12 @@ func (u *UpdateJob) Run(token string, msgBuffer chan<- JobMsg) {
 		msgBuffer <- jobMsg
 		return
 	}
+
 	jobMsg.State.State = apb.StateSucceeded
 	jobMsg.State.Podname = podName
-	jobMsg.ExtractedCredentials = *extCreds
+	if extCreds != nil {
+		jobMsg.ExtractedCredentials = *extCreds
+	}
 	jobMsg.PodName = podName
 	msgBuffer <- jobMsg
 }


### PR DESCRIPTION
The apb.Update call can return nil for extCreds. This is a valid use
case, we need to check nil objects before trying to dereference them.
