### PR TITLE
Make the endpoints headless for local brokers

### DIFF
--- a/scripts/kubernetes/resources.sh
+++ b/scripts/kubernetes/resources.sh
@@ -34,9 +34,6 @@ function cluster::process {
 apiVersion: v1
 kind: Endpoints
 metadata:
-  labels:
-    app: ansible-service-broker
-    service: asb
   name: asb
 subsets:
 - addresses:

--- a/scripts/prep_local_devel_env.sh
+++ b/scripts/prep_local_devel_env.sh
@@ -172,6 +172,7 @@ cluster::deployments delete asb-etcd -n ${ASB_PROJECT}
 kubectl delete endpoints asb -n ${ASB_PROJECT}
 cluster::routes delete asb-etcd -n ${ASB_PROJECT}
 kubectl delete service asb-etcd -n ${ASB_PROJECT}
+kubectl delete service asb -n ${ASB_PROJECT}
 
 # Process required changes for local development
 cluster::process ${TEMPLATE_LOCAL_DEV} ${ASB_PROJECT} -p BROKER_IP_ADDR=${BROKER_IP_ADDR} -p TERMINATION=${TERMINATION}

--- a/templates/deploy-local-dev-changes.yaml
+++ b/templates/deploy-local-dev-changes.yaml
@@ -99,9 +99,6 @@ objects:
 - apiVersion: v1
   kind: Endpoints
   metadata:
-    labels:
-      app: ansible-service-broker
-      service: asb
     name: asb
   subsets:
   - addresses:
@@ -110,6 +107,19 @@ objects:
     - name: port-1338
       port: 1338
       protocol: TCP
+
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: asb
+    annotations:
+      service.alpha.openshift.io/serving-cert-secret-name: asb-tls
+  spec:
+    ports:
+      - name: port-1338
+        port: 1338
+        targetPort: 1338
+        protocol: TCP
 
 parameters:
 - description: Name of the etcd target port to connect to

--- a/templates/k8s-local-dev-changes.yaml
+++ b/templates/k8s-local-dev-changes.yaml
@@ -12,6 +12,18 @@ spec:
     service: asb-etcd
 
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: asb
+spec:
+  ports:
+    - name: port-1338
+      port: 1338
+      targetPort: 1338
+      protocol: TCP
+
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
When using labels on the endpoint, we're associating the endpoint to an object that may not always be around, the locally running broker. This seems to cause the endpoint lose it's ip address. Instead, make the endpoint have no association to an app so it will always be around.

Changes proposed in this pull request
 - Keep the endpoint ip address around all the time

**Which issue this PR fixes (This will close that issue when PR gets merged)**
fixes https://github.com/openshift/ansible-service-broker/issues/660
