### PR TITLE
Fix vet test

### DIFF
--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -72,7 +72,7 @@ func TestGetProviders(t *testing.T) {
 	t.Skip("requires /var/run/asb-auth/{username,password} to be present")
 	config, err := config.CreateConfig("testdata/test-config.yaml")
 	if err != nil {
-		t.Fatal("Unable to create config - %v", err)
+		t.Fatalf("Unable to create config - %v", err)
 	}
 
 	testproviders := GetProviders(config)


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
The print message should be fatalf since it includes a variable.

This also fixes the gate.