### PR TITLE
Bug 1540121 - Return 400 for bad update requests

### DIFF
--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -364,8 +364,16 @@ func (h handler) update(w http.ResponseWriter, r *http.Request, params map[strin
 			writeResponse(w, http.StatusBadRequest, broker.ErrorResponse{Description: err.Error()})
 		case broker.ErrorNoUpdateRequested:
 			writeResponse(w, http.StatusOK, resp)
-		default:
+		case broker.ErrorNoUpdateRequested:
+			writeResponse(w, http.StatusOK, resp)
+		case broker.ErrorPlanNotFound,
+			broker.ErrorParameterNotUpdatable,
+			broker.ErrorParameterNotFound,
+			broker.ErrorParameterUnknownEnum,
+			broker.ErrorPlanUpdateNotPossible:
 			writeResponse(w, http.StatusBadRequest, broker.ErrorResponse{Description: err.Error()})
+		default:
+			writeResponse(w, http.StatusInternalServerError, broker.ErrorResponse{Description: err.Error()})
 		}
 	} else if async {
 		writeDefaultResponse(w, http.StatusAccepted, resp, err)


### PR DESCRIPTION
**Describe what this PR does and why we need it**:

Changes proposed in this pull request
* Filters unchanged parameters from update requests
* Returns 400 error when a user requests updating a non-updatable parameter

**Which issue this PR fixes (This will close that issue when PR gets merged)**
fixes #732 

I'm labeling this as DO-NOT-MERGE because I want to close #732 with this as well. Quoting here:

> There are a couple branches of parameter validation where we are ignoring erroneous inputs:
> * Users passing updated parameters that don't exist on a plan.
> * Users passing enum values that aren't part of the acceptable set of values.
>
> In both cases, we strip them from the request parameters. I think they should be Bad Request 400s, mainly because I think these represent a user's explicit intent, and they will be surprised when that intent has silently been ignored because it is fundamentally invalid.

~~See the TODOs, I'm arguing they should also be Bad Requests, but I'd like to get some feedback here before adding the changes.~~

I updated them to return an error after talking with @jmontleon. If anyone feels differently, feel free to chirp at me.