### PR TITLE
Bug 1539308 - Do not report errors on dupe depros

### DIFF
--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -150,10 +150,10 @@ func (a AnsibleBroker) GetServiceInstance(instanceUUID uuid.UUID) (apb.ServiceIn
 	instance, err := a.dao.GetServiceInstance(instanceUUID.String())
 	if err != nil {
 		if client.IsKeyNotFound(err) {
-			log.Errorf("Could not find a service instance in dao - %v", err)
+			log.Infof("Could not find a service instance in dao - %v", err)
 			return apb.ServiceInstance{}, ErrorNotFound
 		}
-		log.Error("Couldn't find a service instance: ", err)
+		log.Info("Couldn't find a service instance: ", err)
 		return apb.ServiceInstance{}, err
 	}
 	return *instance, nil


### PR DESCRIPTION
* These logs suggest an unexpected error has occurred if broker::GetServiceInstance
fails to find the instance. During the normal deprovision cycle, we will
likely see multiple requests to deprovision the same instance. This
method is called in the deprovision handler before it ever hits
broker::Deprovision, so it's entirely normal for these etcd gets to
miss. Therefore, these really aren't errors. Still useful to log
however, as info.
