### PR TITLE
Bug 1542387 - Print out status of response from RHCC registry if not 200

### DIFF
--- a/pkg/registries/adapters/rhcc_adapter.go
+++ b/pkg/registries/adapters/rhcc_adapter.go
@@ -18,6 +18,7 @@ package adapters
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -103,7 +104,9 @@ func (r RHCCAdapter) loadImages(Query string) (RHCCImageResponse, error) {
 	}
 	defer resp.Body.Close()
 
-	r.Log.Debug("Got Image Response from RHCC")
+	if resp.StatusCode != 200 {
+		return RHCCImageResponse{}, errors.New(resp.Status)
+	}
 	imageList, err := ioutil.ReadAll(resp.Body)
 
 	imageResp := RHCCImageResponse{}


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
Previous logging output was not helpful in determining the issue. Before we were getting 'invalid character' in the logs along with "Got Image Response from RHCC".

Now if RHCC fails to bootstrap it returns the status response (for current bug):
```
[2018-02-07T09:32:26.16-05:00] [ERROR] - unable to retrieve image names for registry rhcc - 500 INTERNAL SERVER ERROR
```
