### PR TITLE
Avoid version collisions

### DIFF
--- a/ansible-service-broker.spec
+++ b/ansible-service-broker.spec
@@ -38,7 +38,7 @@
 %define modulename ansible-service-broker
 
 Name: %{repo}
-Version: 1.0.19
+Version: 1.0.19.0
 Release: 1%{build_timestamp}%{?dist}
 Summary: Ansible Service Broker
 License: ASL 2.0


### PR DESCRIPTION
This branch needs its own version to avoid collisions with official release branches.