### PR TITLE
Bug 1543521 - Fix async bind with job already in progress.

### DIFF
--- a/pkg/apb/executor.go
+++ b/pkg/apb/executor.go
@@ -207,10 +207,10 @@ func createExtraVars(context *Context, parameters *Parameters) (string, error) {
 	}
 
 	if context != nil {
-		paramsCopy["namespace"] = context.Namespace
+		paramsCopy[NamespaceKey] = context.Namespace
 	}
 
-	paramsCopy["cluster"] = runtime.Provider.GetRuntime()
+	paramsCopy[ClusterKey] = runtime.Provider.GetRuntime()
 	extraVars, err := json.Marshal(paramsCopy)
 	return string(extraVars), err
 }

--- a/pkg/broker/binding_subscriber.go
+++ b/pkg/broker/binding_subscriber.go
@@ -48,7 +48,7 @@ func (b *BindingWorkSubscriber) Subscribe(msgBuffer <-chan JobMsg) {
 					log.Errorf("failed to set extracted credentials after bind %v", err)
 				}
 			}
-			if err := b.dao.SetState(msg.InstanceUUID, msg.State); err != nil {
+			if _, err := b.dao.SetState(msg.InstanceUUID, msg.State); err != nil {
 				log.Errorf("failed to set state after provision %v", err)
 			}
 		}

--- a/pkg/broker/deprovision_subscriber.go
+++ b/pkg/broker/deprovision_subscriber.go
@@ -40,7 +40,7 @@ func (d *DeprovisionWorkSubscriber) Subscribe(msgBuffer <-chan JobMsg) {
 		for msg := range msgBuffer {
 			log.Debug("received deprovision message from buffer")
 
-			if err := d.dao.SetState(msg.InstanceUUID, msg.State); err != nil {
+			if _, err := d.dao.SetState(msg.InstanceUUID, msg.State); err != nil {
 				log.Errorf("failed to set state after deprovision %v", err)
 				continue
 			}
@@ -68,7 +68,7 @@ func (d *DeprovisionWorkSubscriber) Subscribe(msgBuffer <-chan JobMsg) {
 func setFailedDeprovisionJob(dao *dao.Dao, dmsg JobMsg) {
 	// have to set the state here manually as the logic that triggers this is in the subscriber
 	dmsg.State.State = apb.StateFailed
-	if err := dao.SetState(dmsg.InstanceUUID, dmsg.State); err != nil {
+	if _, err := dao.SetState(dmsg.InstanceUUID, dmsg.State); err != nil {
 		log.Errorf("failed to set state after deprovision %v", err)
 	}
 }

--- a/pkg/broker/provision_subscriber.go
+++ b/pkg/broker/provision_subscriber.go
@@ -43,7 +43,7 @@ func (p *ProvisionWorkSubscriber) Subscribe(msgBuffer <-chan JobMsg) {
 					log.Errorf("failed to set extracted credentials after provision %v", err)
 				}
 			}
-			if err := p.dao.SetState(msg.InstanceUUID, msg.State); err != nil {
+			if _, err := p.dao.SetState(msg.InstanceUUID, msg.State); err != nil {
 				log.Errorf("failed to set state after provision %v", err)
 			}
 		}

--- a/pkg/broker/provision_subscriber_test.go
+++ b/pkg/broker/provision_subscriber_test.go
@@ -166,16 +166,16 @@ func (mp *mockProvisionSubscriberDAO) SetExtractedCredentials(id string, extCred
 	return mp.err
 
 }
-func (mp *mockProvisionSubscriberDAO) SetState(id string, state apb.JobState) error {
+func (mp *mockProvisionSubscriberDAO) SetState(id string, state apb.JobState) (string, error) {
 	assert := mp.assertOn["SetState"]
 	if nil != assert {
 		if err := assert(id, state); err != nil {
 			mp.assertErr = append(mp.assertErr, err)
-			return err
+			return "", err
 		}
 	}
 	mp.calls["SetState"]++
-	return mp.err
+	return "", mp.err
 
 }
 

--- a/pkg/broker/types.go
+++ b/pkg/broker/types.go
@@ -299,5 +299,5 @@ func (jm JobMsg) Render() string {
 // SubscriberDAO defines the interface subscribers use when persisting state
 type SubscriberDAO interface {
 	SetExtractedCredentials(id string, extCreds *apb.ExtractedCredentials) error
-	SetState(id string, state apb.JobState) error
+	SetState(id string, state apb.JobState) (string, error)
 }

--- a/pkg/broker/unbinding_subscriber.go
+++ b/pkg/broker/unbinding_subscriber.go
@@ -41,7 +41,7 @@ func (b *UnbindingWorkSubscriber) Subscribe(msgBuffer <-chan JobMsg) {
 		log.Info("Listening for binding messages")
 		for msg := range msgBuffer {
 			log.Debug("Processed binding message from buffer")
-			if err := b.dao.SetState(msg.InstanceUUID, msg.State); err != nil {
+			if _, err := b.dao.SetState(msg.InstanceUUID, msg.State); err != nil {
 				log.Errorf("failed to set state after deprovision %v", err)
 			}
 		}

--- a/pkg/broker/update_subscriber.go
+++ b/pkg/broker/update_subscriber.go
@@ -43,7 +43,7 @@ func (u *UpdateWorkSubscriber) Subscribe(msgBuffer <-chan JobMsg) {
 					log.Errorf("failed to set extracted credentials after update %v", err)
 				}
 			}
-			if err := u.dao.SetState(msg.InstanceUUID, msg.State); err != nil {
+			if _, err := u.dao.SetState(msg.InstanceUUID, msg.State); err != nil {
 				log.Errorf("failed to set state after update %v", err)
 			}
 		}

--- a/pkg/dao/dao.go
+++ b/pkg/dao/dao.go
@@ -334,14 +334,20 @@ func (d *Dao) DeleteExtractedCredentials(id string) error {
 }
 
 // SetState - Set the Job State in the kvp API for id.
-func (d *Dao) SetState(id string, state apb.JobState) error {
-	return d.setObject(stateKey(id, state.Token), state)
+func (d *Dao) SetState(id string, state apb.JobState) (string, error) {
+	key := stateKey(id, state.Token)
+	return key, d.setObject(key, state)
 }
 
 // GetState - Retrieve a job state from the kvp API for an ID and Token.
 func (d *Dao) GetState(id string, token string) (apb.JobState, error) {
+	return d.GetStateByKey(stateKey(id, token))
+}
+
+// GetStateByKey - Retrieve a job state from the kvp API for a job key
+func (d *Dao) GetStateByKey(key string) (apb.JobState, error) {
 	state := apb.JobState{}
-	if err := d.getObject(stateKey(id, token), &state); err != nil {
+	if err := d.getObject(key, &state); err != nil {
 		return apb.JobState{State: apb.StateFailed}, err
 	}
 	return state, nil


### PR DESCRIPTION
The broker now stores a reference to a bind job with the BindInstance, so that
it can be looked up in the future if successive equivalent requests are
received.

fixes #670

The solution was discussed here: https://github.com/openshift/ansible-service-broker/pull/680