### PR TITLE
Bug 1541461 - Deal with buggy encoded scopes from service catalog.

### DIFF
--- a/pkg/broker/types.go
+++ b/pkg/broker/types.go
@@ -274,6 +274,7 @@ type UserInfo struct {
 	Username string              `json:"username"`
 	UID      string              `json:"uid"`
 	Groups   []string            `json:"groups,omitempty"`
+	Scopes   []string            `json:"scopes.authorization.openshift.io"`
 	Extra    map[string][]string `json:"extra,omitempty"`
 }
 

--- a/pkg/clients/openshift.go
+++ b/pkg/clients/openshift.go
@@ -337,12 +337,8 @@ func setConfigDefaults(config *rest.Config, APIPath string) error {
 
 // SubjectRulesReview - create and run a OpenShift Subject Rules Review
 func (o OpenshiftClient) SubjectRulesReview(user string, groups []string,
-	extra map[string][]string, namespace string) (result []rbac.PolicyRule, err error) {
+	scopes []string, namespace string) (result []rbac.PolicyRule, err error) {
 
-	var scopes []string
-	if extra != nil {
-		scopes = extra["scopes.authorization.openshift.io"]
-	}
 	body := &SubjectRulesReview{
 		Spec: SubjectRulesReviewSpec{
 			User:   user,

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -858,7 +858,18 @@ func (h handler) validateUser(userInfo broker.UserInfo, namespace string) (bool,
 		return false, http.StatusInternalServerError, fmt.Errorf("Unable to connect to the cluster")
 	}
 	// Retrieving the rules for the user in the namespace.
-	prs, err := openshiftClient.SubjectRulesReview(userInfo.Username, userInfo.Groups, userInfo.Extra, namespace)
+	s := userInfo.Scopes
+	if userInfo.Extra != nil {
+		scope, ok := userInfo.Extra["scopes.authorization.openshift.io"]
+		switch {
+		case ok && userInfo.Scopes != nil:
+			log.Infof("Unable to determine correct scope to use. Found both top level scope and scope in extras.")
+			return false, http.StatusForbidden, fmt.Errorf("unable to determine correct scope to use")
+		case ok:
+			s = scope
+		}
+	}
+	prs, err := openshiftClient.SubjectRulesReview(userInfo.Username, userInfo.Groups, s, namespace)
 	if err != nil {
 		return false, http.StatusInternalServerError, fmt.Errorf("Unable to connect to the cluster")
 	}


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
Will allow us to handle scope that has been incorrectly encoded

Changes proposed in this pull request
 - Deal with the other way of encoding scopes
 - Default to close if both scopes are preset
