### PR TITLE
Bug 1541461 - Deal with buggy encoded scopes from service catalog.

### DIFF
--- a/pkg/broker/types.go
+++ b/pkg/broker/types.go
@@ -243,5 +243,6 @@ type UserInfo struct {
 	Username string              `json:"username"`
 	UID      string              `json:"uid"`
 	Groups   []string            `json:"groups,omitempty"`
+	Scopes   []string            `json:"scopes.authorization.openshift.io"`
 	Extra    map[string][]string `json:"extra,omitempty"`
 }

--- a/pkg/clients/openshift.go
+++ b/pkg/clients/openshift.go
@@ -304,12 +304,8 @@ func setConfigDefaults(config *rest.Config, APIPath string) error {
 
 // SubjectRulesReview - create and run a OpenShift Subject Rules Review
 func (o OpenshiftClient) SubjectRulesReview(user string, groups []string,
-	extra map[string][]string, namespace string, log *logging.Logger) (result []rbac.PolicyRule, err error) {
+	scopes []string, namespace string, log *logging.Logger) (result []rbac.PolicyRule, err error) {
 
-	var scopes []string
-	if extra != nil {
-		scopes = extra["scopes.authorization.openshift.io"]
-	}
 	body := &SubjectRulesReview{
 		Spec: SubjectRulesReviewSpec{
 			User:   user,


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
Will allow us to handle scope that has been incorrectly encoded

Changes proposed in this pull request
 - Deal with the other way of encoding scopes
 - Default to close if both scopes are preset
