### PR TITLE
[WIP] Debugging openshift bind CI failure

### DIFF
--- a/scripts/broker-ci/gather-logs.sh
+++ b/scripts/broker-ci/gather-logs.sh
@@ -93,4 +93,9 @@ function print-all-logs {
     catalog-logs
 }
 
+mediawiki=$(kubectl get pods | grep mediawiki | awk '{ print $1 }')
+postgresql=$(kubectl get pods | grep postgresql | awk '{ print $1 }')
+kubectl get pods -o yaml $mediawiki
+kubectl logs $mediawiki
+kubectl logs $postgresql
 print-all-logs


### PR DESCRIPTION
openshift uses: ```oc env dc ...``` to load bind creds and kubernetes uses: ```kubectl set env deploy ...```.  It could be something in the client causing openshift's ci job to periodically fail.