### PR TITLE
adding sprint139 images for 1.0 release CI

### DIFF
--- a/scripts/broker-ci/setup.sh
+++ b/scripts/broker-ci/setup.sh
@@ -18,6 +18,7 @@ function cluster-setup () {
 ---
 dockerhub_org: ansibleplaybookbundle
 broker_tag: latest
+apbtag: sprint139
 broker_kind: ClusterServiceBroker
 EOF
 


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
adds the tag for the apb  images for the release 1.0 branch

