### PR TITLE
Remove plan dao methods

### DIFF
--- a/pkg/apb/types.go
+++ b/pkg/apb/types.go
@@ -103,15 +103,26 @@ type Spec struct {
 	Plans       []Plan                 `json:"plans"`
 }
 
-// GetPlan - retrieves a reference to a plan from a spec by name. Will return
-// nil if the requested plan does not exist.
-func (s *Spec) GetPlan(name string) *Plan {
-	for i, plan := range s.Plans {
+// GetPlan - retrieves a  plan from a spec by name. Will return
+// empty plan and false if the requested plan does not exist.
+func (s *Spec) GetPlan(name string) (Plan, bool) {
+	for _, plan := range s.Plans {
 		if plan.Name == name {
-			return &s.Plans[i]
+			return plan, true
 		}
 	}
-	return nil
+	return Plan{}, false
+}
+
+// GetPlanFromID - retrieves a refernece to a plan from a spec by name. Will return
+// empty plan and false if the requested plan does not exist.
+func (s *Spec) GetPlanFromID(id string) (Plan, bool) {
+	for _, plan := range s.Plans {
+		if plan.ID == id {
+			return plan, true
+		}
+	}
+	return Plan{}, false
 }
 
 // Context - Determines the context in which the service is running

--- a/pkg/apb/types.go
+++ b/pkg/apb/types.go
@@ -103,7 +103,7 @@ type Spec struct {
 	Plans       []Plan                 `json:"plans"`
 }
 
-// GetPlan - retrieves a  plan from a spec by name. Will return
+// GetPlan - retrieves a plan from a spec by name. Will return
 // empty plan and false if the requested plan does not exist.
 func (s *Spec) GetPlan(name string) (Plan, bool) {
 	for _, plan := range s.Plans {
@@ -114,7 +114,7 @@ func (s *Spec) GetPlan(name string) (Plan, bool) {
 	return Plan{}, false
 }
 
-// GetPlanFromID - retrieves a refernece to a plan from a spec by name. Will return
+// GetPlanFromID - retrieves a plan from a spec by id. Will return
 // empty plan and false if the requested plan does not exist.
 func (s *Spec) GetPlanFromID(id string) (Plan, bool) {
 	for _, plan := range s.Plans {

--- a/pkg/dao/dao.go
+++ b/pkg/dao/dao.go
@@ -90,13 +90,4 @@ type Dao interface {
 
 	// GetStateByKey - Retrieve a job state from the kvp API for a job key
 	GetStateByKey(key string) (apb.JobState, error)
-
-	// BatchSetPlanNames - set plannames based on PlanNameManifest in the kvp API.
-	BatchSetPlanNames(map[string]string) error
-
-	// SetPlanName - Set the Plan name in the kvp API for the given id.
-	SetPlanName(string, string) error
-
-	// GetPlanName - Retrieve the plan name associated with the ID
-	GetPlanName(string) (string, error)
 }

--- a/pkg/dao/etcd/dao.go
+++ b/pkg/dao/etcd/dao.go
@@ -353,30 +353,6 @@ func (d *Dao) GetStateByKey(key string) (apb.JobState, error) {
 	return state, nil
 }
 
-// BatchSetPlanNames - set plannames based on PlanNameManifest in the kvp API.
-func (d *Dao) BatchSetPlanNames(planNames map[string]string) error {
-	for id, planName := range planNames {
-		err := d.SetPlanName(id, planName)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// SetPlanName - Set the Plan name in the kvp API for the given id.
-func (d *Dao) SetPlanName(id string, name string) error {
-	// it's just a string so no other work is needed
-	return d.SetRaw(planNameKey(id), name)
-}
-
-// GetPlanName - Retrieve the plan name associated with the ID
-func (d *Dao) GetPlanName(id string) (string, error) {
-	// it's just a string so no other work is needed
-	return d.GetRaw(planNameKey(id))
-}
-
 func (d *Dao) getObject(key string, data interface{}) error {
 	raw, err := d.GetRaw(key)
 	if err != nil {


### PR DESCRIPTION
Currently, we save a mapping between names and id and have the data in
the spec already.
This was a convenience method to quickly get that data, but when moving
to CRDs I don't think we should create a resource for a single value
mapping

Changes proposed in this pull request
 - Remove all interface and implementation methods for plans
 - Add helper method on spec to get plans from ID
 - Remove pointer to spec values memory when getting plans. Makes it more memory safe

