### PR TITLE
Save extracted credentials into a secret

### DIFF
--- a/docs/proposals/extracted_credentials_saved_as_secrets.md
+++ b/docs/proposals/extracted_credentials_saved_as_secrets.md
@@ -8,9 +8,7 @@ The problem is that we should not manage data that is of a sensitive nature if w
 In the secret, we will save the data in the following format.
 ```yaml
 data:
-  DB_PASSWORD: <GOB_ENCODED_VALUE>
-  DB_USERNAME: <GOB_ENCODED_VALUE>
-  ....
+  credentials: <base64 encoded json>
 apiVersion: v1
 kind: Secret
 metadata:
@@ -20,7 +18,7 @@ metadata:
     <labels provided>
 ```
 
-[Gob encoding](https://godoc.org/encoding/gob) will allow us to save arbitrary data in the secret for a key. The secrets keys will look rational to a user who looks at the created secret. This user would need permissions to see the secret, but if someone is looking at the secret making it obvious what data is in there will be helpful. 
+To encode the credentials in a generic way, we must marshal a `map[string]interface{}` so that we can retrieve the data. This is not how I wanted the secret to look, but will allow anyone to use the credentials and will allow us to retrieve the credentials without writing our own gob parser.
 
 The functions for saving and retrieving will be in the `clients` package. This means the callers will be required to use the underlying extracted credentials type `map[string]interface{}` because we do not want a circular dependency between `apb` package and `clients` package. 
 
@@ -56,9 +54,9 @@ type ExtractedCredentials interface {
 
 
 ### Work Items
-- [ ] Add kubernetes client methods to interact with extracted credentials in the [namespace](https://github.com/openshift/ansible-service-broker/blob/master/docs/config.md#openshift-configuration). 
-- [ ] Add runtime methods for interacting with extracted credentials. These methods should be overridable. 
-- [ ] Remove all dao implementation and interface methods regarding extracted credentials.
-- [ ] Remove all instances of interacting with dao extracted credentials in the `broker` package. Add back call to APB package to get extracted credentials when needed.
-- [ ] Update APB package to create/save/delete extracted credentials for the correct actions. this should call the correct `runtime` package methods.
-- [ ] Add exposed method on APB  that will retrieve the extracted credentials.
+- [x] Add kubernetes client methods to interact with extracted credentials in the [namespace](https://github.com/openshift/ansible-service-broker/blob/master/docs/config.md#openshift-configuration). 
+- [x] Add runtime methods for interacting with extracted credentials. These methods should be overridable. 
+- [x] Remove all dao implementation and interface methods regarding extracted credentials.
+- [x] Remove all instances of interacting with dao extracted credentials in the `broker` package. Add back call to APB package to get extracted credentials when needed.
+- [x] Update APB package to create/save/delete extracted credentials for the correct actions. this should call the correct `runtime` package methods.
+- [x] Add exposed method on APB  that will retrieve the extracted credentials.

--- a/pkg/apb/bind.go
+++ b/pkg/apb/bind.go
@@ -26,7 +26,7 @@ import (
 
 // Bind - Will run the APB with the bind action.
 func (e *executor) Bind(
-	instance *ServiceInstance, parameters *Parameters,
+	instance *ServiceInstance, parameters *Parameters, bindingID string,
 ) <-chan StatusMessage {
 	log.Notice("============================================================")
 	log.Notice("                       BINDING                              ")
@@ -84,6 +84,13 @@ func (e *executor) Bind(
 			return
 		}
 
+		labels := map[string]string{"apbAction": "bind", "apbName": instance.Spec.FQName}
+		err = runtime.Provider.CreateExtractedCredential(bindingID, clusterConfig.Namespace, creds.Credentials, labels)
+		if err != nil {
+			log.Errorf("apb::%v error occurred - %v", executionMethodProvision, err)
+			e.actionFinishedWithError(err)
+			return
+		}
 		e.extractedCredentials = creds
 		e.actionFinishedWithSuccess()
 	}()

--- a/pkg/apb/deprovision.go
+++ b/pkg/apb/deprovision.go
@@ -74,6 +74,12 @@ func (e *executor) Deprovision(instance *ServiceInstance) <-chan StatusMessage {
 			e.actionFinishedWithError(err)
 			return
 		}
+		err = runtime.Provider.DeleteExtractedCredential(instance.ID.String(), clusterConfig.Namespace)
+		if err != nil {
+			log.Errorf("unable to delete the extracted credentials - %v", err)
+			e.actionFinishedWithError(err)
+			return
+		}
 
 		e.actionFinishedWithSuccess()
 	}()

--- a/pkg/apb/executor.go
+++ b/pkg/apb/executor.go
@@ -44,8 +44,8 @@ type ExecutorAccessors interface {
 type ExecutorAsync interface {
 	Provision(*ServiceInstance) <-chan StatusMessage
 	Deprovision(instance *ServiceInstance) <-chan StatusMessage
-	Bind(instance *ServiceInstance, parameters *Parameters) <-chan StatusMessage
-	Unbind(instance *ServiceInstance, parameters *Parameters) <-chan StatusMessage
+	Bind(instance *ServiceInstance, parameters *Parameters, bindingID string) <-chan StatusMessage
+	Unbind(instance *ServiceInstance, parameters *Parameters, bindingID string) <-chan StatusMessage
 	Update(instance *ServiceInstance) <-chan StatusMessage
 }
 

--- a/pkg/apb/ext_creds.go
+++ b/pkg/apb/ext_creds.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/openshift/ansible-service-broker/pkg/clients"
+	"github.com/openshift/ansible-service-broker/pkg/runtime"
 	"github.com/openshift/ansible-service-broker/pkg/version"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -184,4 +185,25 @@ func decodeOutput(output []byte) ([]byte, error) {
 	}
 
 	return decodedjson, nil
+}
+
+// GetExtractedCredentials - Will get the extracted credentials for a caller of the APB package.
+func GetExtractedCredentials(id string) (*ExtractedCredentials, error) {
+	creds, err := runtime.Provider.GetExtractedCredential(id, clusterConfig.Namespace)
+	if err != nil {
+		log.Errorf("unable to get the extracted credential secret - %v", err)
+	}
+	return &ExtractedCredentials{Credentials: creds}, nil
+}
+
+// DeleteExtractedCredentials - Will delete the extracted credentials for a caller of the APB package.
+// Please use this method with caution.
+func DeleteExtractedCredentials(id string) error {
+	return runtime.Provider.DeleteExtractedCredential(id, clusterConfig.Namespace)
+}
+
+// SetExtractedCredentials - Will set new credentials for an id.
+// Please use this method with caution.
+func SetExtractedCredentials(id string, creds *ExtractedCredentials) error {
+	return runtime.Provider.CreateExtractedCredential(id, clusterConfig.Namespace, creds.Credentials, nil)
 }

--- a/pkg/apb/mock_executor.go
+++ b/pkg/apb/mock_executor.go
@@ -10,12 +10,12 @@ type MockExecutor struct {
 }
 
 // Bind provides a mock function with given fields: instance, parameters
-func (_m *MockExecutor) Bind(instance *ServiceInstance, parameters *Parameters) <-chan StatusMessage {
+func (_m *MockExecutor) Bind(instance *ServiceInstance, parameters *Parameters, bindingID string) <-chan StatusMessage {
 	ret := _m.Called(instance, parameters)
 
 	var r0 <-chan StatusMessage
-	if rf, ok := ret.Get(0).(func(*ServiceInstance, *Parameters) <-chan StatusMessage); ok {
-		r0 = rf(instance, parameters)
+	if rf, ok := ret.Get(0).(func(*ServiceInstance, *Parameters, string) <-chan StatusMessage); ok {
+		r0 = rf(instance, parameters, bindingID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(<-chan StatusMessage)
@@ -102,12 +102,12 @@ func (_m *MockExecutor) Provision(_a0 *ServiceInstance) <-chan StatusMessage {
 }
 
 // Unbind provides a mock function with given fields: instance, parameters
-func (_m *MockExecutor) Unbind(instance *ServiceInstance, parameters *Parameters) <-chan StatusMessage {
+func (_m *MockExecutor) Unbind(instance *ServiceInstance, parameters *Parameters, bindingID string) <-chan StatusMessage {
 	ret := _m.Called(instance, parameters)
 
 	var r0 <-chan StatusMessage
-	if rf, ok := ret.Get(0).(func(*ServiceInstance, *Parameters) <-chan StatusMessage); ok {
-		r0 = rf(instance, parameters)
+	if rf, ok := ret.Get(0).(func(*ServiceInstance, *Parameters, string) <-chan StatusMessage); ok {
+		r0 = rf(instance, parameters, bindingID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(<-chan StatusMessage)

--- a/pkg/apb/provision.go
+++ b/pkg/apb/provision.go
@@ -33,12 +33,15 @@ func (e *executor) Provision(instance *ServiceInstance) <-chan StatusMessage {
 
 	go func() {
 		e.provisionOrUpdate(executionMethodProvision, instance)
-		labels := map[string]string{"apbAction": string(executionMethodProvision), "apbName": instance.Spec.FQName}
-		err := runtime.Provider.CreateExtractedCredential(instance.ID.String(), clusterConfig.Namespace, e.extractedCredentials.Credentials, labels)
-		if err != nil {
-			log.Errorf("apb::%v error occurred - %v", executionMethodProvision, err)
-			e.actionFinishedWithError(err)
-			return
+		// Provision can not have extracted credentials.
+		if e.extractedCredentials != nil {
+			labels := map[string]string{"apbAction": string(executionMethodProvision), "apbName": instance.Spec.FQName}
+			err := runtime.Provider.CreateExtractedCredential(instance.ID.String(), clusterConfig.Namespace, e.extractedCredentials.Credentials, labels)
+			if err != nil {
+				log.Errorf("apb::%v error occurred - %v", executionMethodProvision, err)
+				e.actionFinishedWithError(err)
+				return
+			}
 		}
 		e.actionFinishedWithSuccess()
 	}()

--- a/pkg/apb/provision.go
+++ b/pkg/apb/provision.go
@@ -32,7 +32,13 @@ func (e *executor) Provision(instance *ServiceInstance) <-chan StatusMessage {
 	log.Notice("============================================================")
 
 	go func() {
-		e.provisionOrUpdate(executionMethodProvision, instance)
+		e.actionStarted()
+		err := e.provisionOrUpdate(executionMethodProvision, instance)
+		if err != nil {
+			log.Errorf("Provision APB error: %v", err)
+			e.actionFinishedWithError(err)
+			return
+		}
 		// Provision can not have extracted credentials.
 		if e.extractedCredentials != nil {
 			labels := map[string]string{"apbAction": string(executionMethodProvision), "apbName": instance.Spec.FQName}

--- a/pkg/apb/provision_or_update.go
+++ b/pkg/apb/provision_or_update.go
@@ -111,6 +111,4 @@ func (e *executor) provisionOrUpdate(method executionMethod, instance *ServiceIn
 	}
 
 	e.extractedCredentials = creds
-	e.actionFinishedWithSuccess()
-	return
 }

--- a/pkg/apb/unbind.go
+++ b/pkg/apb/unbind.go
@@ -26,7 +26,7 @@ import (
 
 // Unbind - runs the abp with the unbind action.
 func (e *executor) Unbind(
-	instance *ServiceInstance, parameters *Parameters,
+	instance *ServiceInstance, parameters *Parameters, bindingID string,
 ) <-chan StatusMessage {
 	log.Notice("============================================================")
 	log.Notice("                       UNBINDING                            ")
@@ -67,6 +67,13 @@ func (e *executor) Unbind(
 			k8scli.Client.CoreV1().Pods(executionContext.Namespace), e.updateDescription)
 		if err != nil {
 			log.Errorf("Unbind action failed - %v", err)
+			e.actionFinishedWithError(err)
+			return
+		}
+		// Delete the binding extracted credential here.
+		err = runtime.Provider.DeleteExtractedCredential(bindingID, clusterConfig.Namespace)
+		if err != nil {
+			log.Errorf("Unbind failed to delete extracted credential - %v", err)
 			e.actionFinishedWithError(err)
 			return
 		}

--- a/pkg/apb/unbind.go
+++ b/pkg/apb/unbind.go
@@ -73,9 +73,7 @@ func (e *executor) Unbind(
 		// Delete the binding extracted credential here.
 		err = runtime.Provider.DeleteExtractedCredential(bindingID, clusterConfig.Namespace)
 		if err != nil {
-			log.Errorf("Unbind failed to delete extracted credential - %v", err)
-			e.actionFinishedWithError(err)
-			return
+			log.Infof("Unbind failed to delete extracted credential m- %v", err)
 		}
 
 		e.actionFinishedWithSuccess()

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -185,7 +185,7 @@ func CreateApp() App {
 
 	// Initialize Runtime
 	log.Debug("Connecting to Cluster")
-	agnosticruntime.NewRuntime()
+	agnosticruntime.NewRuntime(nil)
 	agnosticruntime.Provider.ValidateRuntime()
 	if err != nil {
 		log.Error(err.Error())
@@ -257,7 +257,7 @@ func CreateApp() App {
 	// Intiialize the cluster config.
 	apb.InitializeClusterConfig(app.config.GetSubConfig("openshift"))
 	if app.broker, err = broker.NewAnsibleBroker(
-		app.dao, app.registry, *app.engine, app.config.GetSubConfig("broker"),
+		app.dao, app.registry, *app.engine, app.config.GetSubConfig("broker"), app.config.GetString("openshift.namespace"),
 	); err != nil {
 		log.Error("Failed to create AnsibleBroker\n")
 		log.Error(err.Error())

--- a/pkg/broker/binding_subscriber.go
+++ b/pkg/broker/binding_subscriber.go
@@ -21,7 +21,6 @@
 package broker
 
 import (
-	"github.com/openshift/ansible-service-broker/pkg/apb"
 	"github.com/openshift/ansible-service-broker/pkg/dao"
 )
 
@@ -42,12 +41,6 @@ func (b *BindingWorkSubscriber) Subscribe(msgBuffer <-chan JobMsg) {
 		log.Info("Listening for binding messages")
 		for msg := range msgBuffer {
 			log.Debug("Processed binding message from buffer")
-			if msg.State.State == apb.StateSucceeded {
-				log.Debug("CALL SetExtractedCredentials $v - %v", msg.BindingUUID, msg.ExtractedCredentials)
-				if err := b.dao.SetExtractedCredentials(msg.BindingUUID, &msg.ExtractedCredentials); err != nil {
-					log.Errorf("failed to set extracted credentials after bind %v", err)
-				}
-			}
 			if _, err := b.dao.SetState(msg.InstanceUUID, msg.State); err != nil {
 				log.Errorf("failed to set state after provision %v", err)
 			}

--- a/pkg/broker/deprovision_subscriber.go
+++ b/pkg/broker/deprovision_subscriber.go
@@ -17,7 +17,6 @@
 package broker
 
 import (
-	"github.com/coreos/etcd/client"
 	"github.com/openshift/ansible-service-broker/pkg/apb"
 )
 
@@ -66,16 +65,8 @@ func setFailedDeprovisionJob(dao SubscriberDAO, dmsg JobMsg) {
 	}
 }
 
-func cleanupDeprovision(instanceID string, dao SubscriberDAO) error {
-	err := dao.DeleteExtractedCredentials(instanceID)
-
-	if err != nil && client.IsKeyNotFound(err) {
-		log.Infof("Attempted to delete extracted credentials, but key was not found: [%v]", instanceID)
-	} else if err != nil {
-		return err
-	}
-
-	if err := dao.DeleteServiceInstance(instanceID); err != nil {
+func cleanupDeprovision(id string, dao SubscriberDAO) error {
+	if err := dao.DeleteServiceInstance(id); err != nil {
 		log.Error("failed to delete service instance - %v", err)
 		return err
 	}

--- a/pkg/broker/deprovision_subscriber_test.go
+++ b/pkg/broker/deprovision_subscriber_test.go
@@ -54,13 +54,6 @@ func TestDeprovisionWorkSubscriber_Subscribe(t *testing.T) {
 			},
 			DAO: func() (*mock.SubscriberDAO, map[string]int) {
 				dao := mock.NewSubscriberDAO()
-				dao.AssertOn["DeleteExtractedCredentials"] = func(args ...interface{}) error {
-					id := args[0].(string)
-					if id != "id" {
-						return fmt.Errorf("epected the id to be : id but was %s", id)
-					}
-					return nil
-				}
 				dao.AssertOn["DeleteServiceInstance"] = func(args ...interface{}) error {
 					id := args[0].(string)
 					if id != "id" {
@@ -76,9 +69,8 @@ func TestDeprovisionWorkSubscriber_Subscribe(t *testing.T) {
 					return nil
 				}
 				expectedCalls := map[string]int{
-					"DeleteExtractedCredentials": 1,
-					"DeleteServiceInstance":      1,
-					"SetState":                   1,
+					"DeleteServiceInstance": 1,
+					"SetState":              1,
 				}
 				return dao, expectedCalls
 			},
@@ -97,13 +89,6 @@ func TestDeprovisionWorkSubscriber_Subscribe(t *testing.T) {
 			},
 			DAO: func() (*mock.SubscriberDAO, map[string]int) {
 				dao := mock.NewSubscriberDAO()
-				dao.AssertOn["DeleteExtractedCredentials"] = func(args ...interface{}) error {
-					id := args[0].(string)
-					if id != "id" {
-						return fmt.Errorf("epected the id to be : id but was %s", id)
-					}
-					return nil
-				}
 				dao.AssertOn["DeleteServiceInstance"] = func(args ...interface{}) error {
 					id := args[0].(string)
 					if id != "id" {
@@ -125,56 +110,8 @@ func TestDeprovisionWorkSubscriber_Subscribe(t *testing.T) {
 				}
 				dao.Errs["DeleteServiceInstance"] = fmt.Errorf("not there")
 				expectedCalls := map[string]int{
-					"DeleteExtractedCredentials": 1,
-					"DeleteServiceInstance":      1,
-					"SetState":                   2,
-				}
-				return dao, expectedCalls
-			},
-		},
-		{
-			Name: "should set state to failed if clean up failed to delete extractedCredentials",
-			JobMsg: broker.JobMsg{
-				InstanceUUID: instanceID,
-				State: apb.JobState{
-					State:  apb.StateSucceeded,
-					Method: apb.JobMethodProvision,
-				},
-				ExtractedCredentials: apb.ExtractedCredentials{
-					Credentials: map[string]interface{}{"user": "test", "pass": "test"},
-				},
-			},
-			DAO: func() (*mock.SubscriberDAO, map[string]int) {
-				dao := mock.NewSubscriberDAO()
-				dao.AssertOn["DeleteExtractedCredentials"] = func(args ...interface{}) error {
-					id := args[0].(string)
-					if id != "id" {
-						return fmt.Errorf("epected the id to be : id but was %s", id)
-					}
-					return nil
-				}
-				dao.AssertOn["DeleteServiceInstance"] = func(args ...interface{}) error {
-
-					return fmt.Errorf("shouldn't have got to DeleteServiceInstance")
-
-				}
-				var states []apb.JobState
-				dao.AssertOn["SetState"] = func(i ...interface{}) error {
-					state := i[1].(apb.JobState)
-					states = append(states, state)
-					if states[0].State != apb.StateSucceeded {
-						return fmt.Errorf("expected to the state to be %v but was %v", apb.StateSucceeded, states[0].State)
-					}
-					if len(states) == 2 && states[1].State != apb.StateFailed {
-						return fmt.Errorf("expected to the state to be %v but was %v", apb.StateFailed, states[1].State)
-					}
-					return nil
-				}
-				dao.Errs["DeleteExtractedCredentials"] = fmt.Errorf("not there")
-				expectedCalls := map[string]int{
-					"DeleteExtractedCredentials": 1,
-					"DeleteServiceInstance":      0,
-					"SetState":                   2,
+					"DeleteServiceInstance": 1,
+					"SetState":              2,
 				}
 				return dao, expectedCalls
 			},

--- a/pkg/broker/jobs.go
+++ b/pkg/broker/jobs.go
@@ -22,6 +22,7 @@ package broker
 
 import (
 	"fmt"
+
 	"github.com/openshift/ansible-service-broker/pkg/apb"
 	"github.com/openshift/ansible-service-broker/pkg/metrics"
 )
@@ -192,7 +193,7 @@ func (j *BindJob) Run(token string, msgBuffer chan<- JobMsg) {
 		metricsJobFinishedHook: metrics.BindJobFinished,
 		skipExecution:          false,
 		run: func(e apb.Executor) <-chan apb.StatusMessage {
-			return e.Bind(j.serviceInstance, j.params)
+			return e.Bind(j.serviceInstance, j.params, j.bindingID)
 		},
 	}
 	job.Run(token, msgBuffer)
@@ -218,7 +219,7 @@ func (j *UnbindJob) Run(token string, msgBuffer chan<- JobMsg) {
 		metricsJobFinishedHook: metrics.UnbindJobFinished,
 		skipExecution:          j.skipExecution,
 		run: func(e apb.Executor) <-chan apb.StatusMessage {
-			return e.Unbind(j.serviceInstance, j.params)
+			return e.Unbind(j.serviceInstance, j.params, j.bindingID)
 		},
 	}
 	job.Run(token, msgBuffer)

--- a/pkg/broker/provision_subscriber.go
+++ b/pkg/broker/provision_subscriber.go
@@ -16,10 +16,6 @@
 
 package broker
 
-import (
-	"github.com/openshift/ansible-service-broker/pkg/apb"
-)
-
 // ProvisionWorkSubscriber - Listen for provision messages
 type ProvisionWorkSubscriber struct {
 	dao SubscriberDAO
@@ -37,12 +33,6 @@ func (p *ProvisionWorkSubscriber) Subscribe(msgBuffer <-chan JobMsg) {
 		for msg := range msgBuffer {
 			log.Debug("received provision message from buffer")
 
-			if msg.State.State == apb.StateSucceeded {
-				log.Debugf("job in state succeeded setting credentials")
-				if err := p.dao.SetExtractedCredentials(msg.InstanceUUID, &msg.ExtractedCredentials); err != nil {
-					log.Errorf("failed to set extracted credentials after provision %v", err)
-				}
-			}
 			if _, err := p.dao.SetState(msg.InstanceUUID, msg.State); err != nil {
 				log.Errorf("failed to set state after provision %v", err)
 			}

--- a/pkg/broker/provision_subscriber_test.go
+++ b/pkg/broker/provision_subscriber_test.go
@@ -52,20 +52,6 @@ func TestProvisionWorkSubscriber_Subscribe(t *testing.T) {
 			},
 			DAO: func() (*mock.SubscriberDAO, map[string]int) {
 				dao := mock.NewSubscriberDAO()
-				dao.AssertOn["SetExtractedCredentials"] = func(args ...interface{}) error {
-					cred := args[1]
-					if nil == cred {
-						return fmt.Errorf("expected credentials to passed")
-					}
-					creds := cred.(*apb.ExtractedCredentials)
-					if _, ok := creds.Credentials["user"]; !ok {
-						return fmt.Errorf("expected there to be a user field in the credentials")
-					}
-					if _, ok := creds.Credentials["pass"]; !ok {
-						return fmt.Errorf("expected there to be a pass field in the credentials")
-					}
-					return nil
-				}
 				dao.AssertOn["SetState"] = func(args ...interface{}) error {
 					state := args[1].(apb.JobState)
 					if state.Method != apb.JobMethodProvision {
@@ -78,8 +64,7 @@ func TestProvisionWorkSubscriber_Subscribe(t *testing.T) {
 
 				}
 				expectedCalls := map[string]int{
-					"SetExtractedCredentials": 1,
-					"SetState":                1,
+					"SetState": 1,
 				}
 				return dao, expectedCalls
 			},
@@ -106,8 +91,7 @@ func TestProvisionWorkSubscriber_Subscribe(t *testing.T) {
 					return nil
 				}
 				expectedCalls := map[string]int{
-					"SetExtractedCredentials": 0,
-					"SetState":                1,
+					"SetState": 1,
 				}
 				return dao, expectedCalls
 			},
@@ -133,8 +117,7 @@ func TestProvisionWorkSubscriber_Subscribe(t *testing.T) {
 					return nil
 				}
 				expectedCalls := map[string]int{
-					"SetExtractedCredentials": 0,
-					"SetState":                1,
+					"SetState": 1,
 				}
 				return dao, expectedCalls
 			},

--- a/pkg/broker/types.go
+++ b/pkg/broker/types.go
@@ -301,9 +301,7 @@ func (jm JobMsg) Render() string {
 
 // SubscriberDAO defines the interface subscribers use when persisting state
 type SubscriberDAO interface {
-	SetExtractedCredentials(id string, extCreds *apb.ExtractedCredentials) error
 	SetState(id string, state apb.JobState) (string, error)
 	GetServiceInstance(id string) (*apb.ServiceInstance, error)
-	DeleteExtractedCredentials(id string) error
 	DeleteServiceInstance(id string) error
 }

--- a/pkg/broker/unbinding_subscriber.go
+++ b/pkg/broker/unbinding_subscriber.go
@@ -87,7 +87,7 @@ func cleanupUnbind(bindInstance *apb.BindInstance, serviceInstance *apb.ServiceI
 	id := bindInstance.ID.String()
 
 	if bindExtCreds != nil {
-		if err = dao.DeleteExtractedCredentials(id); err != nil {
+		if err = apb.DeleteExtractedCredentials(id); err != nil {
 			log.Errorf("failed to delete extracted credentials - %v", err)
 			return err
 		}

--- a/pkg/broker/update_subscriber.go
+++ b/pkg/broker/update_subscriber.go
@@ -16,10 +16,6 @@
 
 package broker
 
-import (
-	"github.com/openshift/ansible-service-broker/pkg/apb"
-)
-
 // UpdateWorkSubscriber - Lissten for provision messages
 type UpdateWorkSubscriber struct {
 	dao SubscriberDAO
@@ -36,12 +32,6 @@ func (u *UpdateWorkSubscriber) Subscribe(msgBuffer <-chan JobMsg) {
 		log.Info("Listening for update messages")
 		for msg := range msgBuffer {
 			log.Debug("received update message from buffer")
-
-			if msg.State.State == apb.StateSucceeded {
-				if err := u.dao.SetExtractedCredentials(msg.InstanceUUID, &msg.ExtractedCredentials); err != nil {
-					log.Errorf("failed to set extracted credentials after update %v", err)
-				}
-			}
 			if _, err := u.dao.SetState(msg.InstanceUUID, msg.State); err != nil {
 				log.Errorf("failed to set state after update %v", err)
 			}

--- a/pkg/broker/update_subscriber_test.go
+++ b/pkg/broker/update_subscriber_test.go
@@ -52,20 +52,6 @@ func TestUpdateWorkSubscriber_Subscribe(t *testing.T) {
 			},
 			DAO: func() (*mock.SubscriberDAO, map[string]int) {
 				dao := mock.NewSubscriberDAO()
-				dao.AssertOn["SetExtractedCredentials"] = func(args ...interface{}) error {
-					cred := args[1]
-					if nil == cred {
-						return fmt.Errorf("expected credentials to passed")
-					}
-					creds := cred.(*apb.ExtractedCredentials)
-					if _, ok := creds.Credentials["user"]; !ok {
-						return fmt.Errorf("expected there to be a user field in the credentials")
-					}
-					if _, ok := creds.Credentials["pass"]; !ok {
-						return fmt.Errorf("expected there to be a pass field in the credentials")
-					}
-					return nil
-				}
 				dao.AssertOn["SetState"] = func(args ...interface{}) error {
 					state := args[1].(apb.JobState)
 					if state.Method != apb.JobMethodUpdate {
@@ -78,8 +64,7 @@ func TestUpdateWorkSubscriber_Subscribe(t *testing.T) {
 
 				}
 				expectedCalls := map[string]int{
-					"SetExtractedCredentials": 1,
-					"SetState":                1,
+					"SetState": 1,
 				}
 				return dao, expectedCalls
 			},
@@ -106,8 +91,7 @@ func TestUpdateWorkSubscriber_Subscribe(t *testing.T) {
 					return nil
 				}
 				expectedCalls := map[string]int{
-					"SetExtractedCredentials": 0,
-					"SetState":                1,
+					"SetState": 1,
 				}
 				return dao, expectedCalls
 			},
@@ -133,8 +117,7 @@ func TestUpdateWorkSubscriber_Subscribe(t *testing.T) {
 					return nil
 				}
 				expectedCalls := map[string]int{
-					"SetExtractedCredentials": 0,
-					"SetState":                1,
+					"SetState": 1,
 				}
 				return dao, expectedCalls
 			},

--- a/pkg/dao/dao.go
+++ b/pkg/dao/dao.go
@@ -73,15 +73,6 @@ type Dao interface {
 	// DeleteBindInstance - Delete the binding instance for an id in the kvp API.
 	DeleteBindInstance(string) error
 
-	// GetExtractedCredentials - Get the extracted credentials for an id in the kvp API.
-	GetExtractedCredentials(string) (*apb.ExtractedCredentials, error)
-
-	// SetExtractedCredentials - Set the extracted credentials for an id in the kvp API.
-	SetExtractedCredentials(string, *apb.ExtractedCredentials) error
-
-	// DeleteExtractedCredentials - delete the extracted credentials for an id in the kvp API.
-	DeleteExtractedCredentials(string) error
-
 	// SetState - Set the Job State in the kvp API for id.
 	SetState(string, apb.JobState) (string, error)
 

--- a/pkg/dao/etcd/dao.go
+++ b/pkg/dao/etcd/dao.go
@@ -313,26 +313,6 @@ func (d *Dao) DeleteBindInstance(id string) error {
 	return err
 }
 
-// GetExtractedCredentials - Get the extracted credentials for an id in the kvp API.
-func (d *Dao) GetExtractedCredentials(id string) (*apb.ExtractedCredentials, error) {
-	extractedCredentials := &apb.ExtractedCredentials{}
-	if err := d.getObject(extractedCredentialsKey(id), extractedCredentials); err != nil {
-		return nil, err
-	}
-	return extractedCredentials, nil
-}
-
-// SetExtractedCredentials - Set the extracted credentials for an id in the kvp API.
-func (d *Dao) SetExtractedCredentials(id string, extCreds *apb.ExtractedCredentials) error {
-	return d.setObject(extractedCredentialsKey(id), extCreds)
-}
-
-// DeleteExtractedCredentials - delete the extracted credentials for an id in the kvp API.
-func (d *Dao) DeleteExtractedCredentials(id string) error {
-	_, err := d.kapi.Delete(context.Background(), extractedCredentialsKey(id), nil)
-	return err
-}
-
 // SetState - Set the Job State in the kvp API for id.
 func (d *Dao) SetState(id string, state apb.JobState) (string, error) {
 	key := stateKey(id, state.Token)

--- a/pkg/runtime/extracted_credentials.go
+++ b/pkg/runtime/extracted_credentials.go
@@ -1,0 +1,80 @@
+package runtime
+
+import (
+	"github.com/openshift/ansible-service-broker/pkg/clients"
+)
+
+// ExtractedCredential - Interface to define CRUD operations for
+// how to manage extracted credentials
+type ExtractedCredential interface {
+	// CreateExtractedCredentials - takes id, action, namespace, and credentials will save them.
+	CreateExtractedCredential(string, string, map[string]interface{}, map[string]string) error
+	// UpdateExtractedCredentials - takes id, action, namespace, and credentials will update them.
+	UpdateExtractedCredential(string, string, map[string]interface{}, map[string]string) error
+	// GetExtractedCredential - takes id, namespace will get credentials.
+	GetExtractedCredential(string, string) (map[string]interface{}, error)
+	// DeleteExtractedCredentials - takes id, namesapce and deletes the credentials.
+	DeleteExtractedCredential(string, string) error
+}
+
+type defaultExtractedCredential struct{}
+
+func (d defaultExtractedCredential) CreateExtractedCredential(ID, ns string,
+	extCreds map[string]interface{}, labels map[string]string) error {
+
+	k8scli, err := clients.Kubernetes()
+	if err != nil {
+		log.Errorf("Unable to get kubernetes client - %v", err)
+		return err
+	}
+	err = k8scli.SaveExtractedCredentialSecret(ID, ns, extCreds, labels)
+	if err != nil {
+		log.Errorf("unable to save extracted credentials - %v", err)
+		return err
+	}
+	return nil
+}
+
+func (d defaultExtractedCredential) UpdateExtractedCredential(ID, ns string,
+	extCreds map[string]interface{}, labels map[string]string) error {
+
+	k8scli, err := clients.Kubernetes()
+	if err != nil {
+		log.Errorf("Unable to get kubernetes client - %v", err)
+		return err
+	}
+	err = k8scli.UpdateExtractedCredentialSecret(ID, ns, extCreds, labels)
+	if err != nil {
+		log.Errorf("unable to update extracted credentials - %v", err)
+		return err
+	}
+	return nil
+}
+
+func (d defaultExtractedCredential) GetExtractedCredential(ID, ns string) (map[string]interface{}, error) {
+	k8scli, err := clients.Kubernetes()
+	if err != nil {
+		log.Errorf("Unable to get kubernetes client - %v", err)
+		return nil, err
+	}
+	creds, err := k8scli.GetExtractedCredentialSecretData(ID, ns)
+	if err != nil {
+		log.Errorf("unable to get extracted credentials - %v", err)
+		return nil, err
+	}
+	return creds, nil
+}
+
+func (d defaultExtractedCredential) DeleteExtractedCredential(ID, ns string) error {
+	k8scli, err := clients.Kubernetes()
+	if err != nil {
+		log.Errorf("Unable to get kubernetes client - %v", err)
+		return err
+	}
+	err = k8scli.DeleteExtractedCredentialSecret(ID, ns)
+	if err != nil {
+		log.Errorf("unable to get extracted credentials - %v", err)
+		return err
+	}
+	return nil
+}

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -97,7 +97,7 @@ func NewRuntime(extCreds ExtractedCredential) {
 	}
 
 	var c ExtractedCredential
-	if extCreds != nil {
+	if extCreds == nil {
 		c = defaultExtractedCredential{}
 	} else {
 		c = extCreds

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -67,6 +67,10 @@ type openshift struct{}
 type kubernetes struct{}
 
 // NewRuntime - Initialize provider variable
+// extCreds - You can pass an ExtractedCredential conforming object this will
+// be used to do CRUD operations. If you want to use the default pass nil
+// and we will use the built-in default of saving them as secrets in the
+// broker namespace.
 func NewRuntime(extCreds ExtractedCredential) {
 	k8scli, err := clients.Kubernetes()
 	if err != nil {


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
This PR will implement #768
Changes proposed in this pull request
- [x] ~~Add kubernetes client methods to interact with extracted credentials in the [namespace](https://github.com/openshift/ansible-service-broker/blob/master/docs/config.md#openshift-configuration).~~
- [x] ~~Add runtime methods for interacting with extracted credentials. These methods should be overridable.~~
- [x] ~~Remove all dao implementation and interface methods regarding extracted credentials.~~
- [x] ~~Remove all instances of interacting with dao extracted credentials in the `broker` package. Add back call to APB package to get extracted credentials when needed.~~
- [x] ~~Add exposed method on APB  that will retrieve the extracted credentials.~~
- [x] ~~Update APB package to create/save/delete extracted credentials for the correct actions. this should call the correct `runtime` package methods.~~
