### PR TITLE
Bug 1539542 - return bindings_retrievable

### DIFF
--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -465,6 +465,14 @@ func (a AnsibleBroker) Catalog() (*CatalogResponse, error) {
 		if err != nil {
 			log.Errorf("not adding spec %v to list of services due to error transforming to service - %v", spec.FQName, err)
 		} else {
+			// Bug 1539542 - in order for async bind to work,
+			// bindings_retrievable needs to be set to true. We only want to
+			// set BindingsRetrievable to true if the service is bindable
+			// AND we the broker is configured to launch apbs on bind
+			if ser.Bindable && a.brokerConfig.LaunchApbOnBind {
+				ser.BindingsRetrievable = true
+			}
+
 			services = append(services, ser)
 		}
 	}

--- a/pkg/broker/types.go
+++ b/pkg/broker/types.go
@@ -65,16 +65,18 @@ func IsValidWorkTopic(topic WorkTopic) bool {
 // Service - Service object to be returned.
 // based on https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#service-objects
 type Service struct {
-	Name            string                 `json:"name"`
-	ID              string                 `json:"id"`
-	Description     string                 `json:"description"`
-	Tags            []string               `json:"tags,omitempty"`
-	Requires        []string               `json:"requires,omitempty"`
-	Bindable        bool                   `json:"bindable"`
-	Metadata        map[string]interface{} `json:"metadata,omitempty"`
-	DashboardClient *DashboardClient       `json:"dashboard_client,omitempty"`
-	PlanUpdatable   bool                   `json:"plan_updateable,omitempty"`
-	Plans           []Plan                 `json:"plans"`
+	Name                 string                 `json:"name"`
+	ID                   string                 `json:"id"`
+	Description          string                 `json:"description"`
+	Tags                 []string               `json:"tags,omitempty"`
+	Requires             []string               `json:"requires,omitempty"`
+	Bindable             bool                   `json:"bindable"`
+	Metadata             map[string]interface{} `json:"metadata,omitempty"`
+	DashboardClient      *DashboardClient       `json:"dashboard_client,omitempty"`
+	InstancesRetrievable bool                   `json:"instances_retrievable"`
+	BindingsRetrievable  bool                   `json:"bindings_retrievable"`
+	PlanUpdatable        bool                   `json:"plan_updateable,omitempty"`
+	Plans                []Plan                 `json:"plans"`
 }
 
 // DashboardClient - Dashboard Client to be returned

--- a/pkg/broker/util.go
+++ b/pkg/broker/util.go
@@ -42,14 +42,17 @@ func SpecToService(spec *apb.Spec) (Service, error) {
 		return Service{}, err
 	}
 	retSvc := Service{
-		ID:            spec.ID,
-		Name:          spec.FQName,
-		Description:   spec.Description,
-		Tags:          make([]string, len(spec.Tags)),
-		Bindable:      spec.Bindable,
-		PlanUpdatable: planUpdatable(spec.Plans),
-		Plans:         plans,
-		Metadata:      spec.Metadata,
+		ID:                   spec.ID,
+		Name:                 spec.FQName,
+		Description:          spec.Description,
+		Tags:                 make([]string, len(spec.Tags)),
+		Bindable:             spec.Bindable,
+		PlanUpdatable:        planUpdatable(spec.Plans),
+		Plans:                plans,
+		Metadata:             spec.Metadata,
+		InstancesRetrievable: true,
+		// NOTE: not setting BindingsRetrievable here since that is dependent on
+		// whether we have async bind enabled.
 	}
 
 	copy(retSvc.Tags, spec.Tags)


### PR DESCRIPTION
the async bind spec change requires bindings_retrievable when we support
async binding for a service. We are taking the approach that if an apb
is bindable, it will support async bind.

fixes BZ 1539542 https://bugzilla.redhat.com/show_bug.cgi?id=1539542
