### PR TITLE
add namespace config to k8s deployment template

### DIFF
--- a/templates/k8s-ansible-service-broker.yaml.j2
+++ b/templates/k8s-ansible-service-broker.yaml.j2
@@ -173,6 +173,7 @@ data:
       bearer_token_file: "{{ bearer_token_file }}"
       image_pull_policy: "{{ image_pull_policy }}"
       sandbox_role: "{{ sandbox_role }}"
+      namespace: ansible-service-broker
       keep_namespace: {{ keep_namespace }}
       keep_namespace_on_error: {{ keep_namespace_on_error }}
     broker:


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
This PR adds the required configuration value `openshift.namespace`