### PR TITLE
Filter everything when whitelist is empty

### DIFF
--- a/docs/filtering_apbs.md
+++ b/docs/filtering_apbs.md
@@ -12,7 +12,7 @@ total set of discovered APBs for a given registry, determining matches.
 |     present    |                     allowed                     |                blocked               |
 |:--------------:|:-----------------------------------------------:|:------------------------------------:|
 | only whitelist | matches a regex in list                         | *ANY* APB that does not match        |
-| only blacklist | *ALL* APBs that do not match                    | APBs that match a regex in list      |
+| only blacklist | *No* APBs from the registry                     | *All* APBs from that registry        |
 |  both present  | matches regex in whitelist but NOT in blacklist | APBs that match a regex in blacklist |
 |  None | *No* APBs from the registry | *All* APBs from that registry |
 

--- a/pkg/registries/filter.go
+++ b/pkg/registries/filter.go
@@ -192,7 +192,11 @@ func applyMatchSets(
 	filteredVals := []string{}
 	totalSet := toMatchSetT(totalList)
 
-	if len(whiteMatchSet) != 0 && len(blackMatchSet) != 0 {
+	if len(whiteMatchSet) == 0 {
+		// If nothing is whitelisted, filter everything
+		filteredVals = totalList
+		totalSet = nil
+	} else if len(blackMatchSet) != 0 && len(whiteMatchSet) != 0 {
 		// Blacklist matches override white
 		for k := range blackMatchSet {
 			if _, ok := blackMatchSet[k]; ok {

--- a/pkg/registries/filter_test.go
+++ b/pkg/registries/filter_test.go
@@ -29,6 +29,7 @@ import (
 
 const testWhitelistFile = "whitelist.yaml"
 const testBlacklistFile = "blacklist.yaml"
+const emptyWhiteListFile = "empty_whitelist.yaml"
 const testBlacklistOverrideFile = "blacklist_override.yaml"
 
 func testGetRegexFromFile(file string) []string {
@@ -103,7 +104,9 @@ func TestOnlyBlacklist(t *testing.T) {
 		blacklist: testGetRegexFromFile(testBlacklistFile)}
 	filter.Init()
 
-	expectedValidNames := []string{
+	expectedValidNames := []string{}
+
+	expectedFilteredNames := []string{
 		"legitimate-postgresql-apb",
 		"legitimate-mediawiki-apb",
 		"foo-apb",
@@ -111,9 +114,6 @@ func TestOnlyBlacklist(t *testing.T) {
 		"rhscl-postgresql-apb",
 		"baz-apb",
 		"foobar-apb",
-	}
-
-	expectedFilteredNames := []string{
 		"totally-not-malicious-apb",
 		"malicious-bar-apb",
 		"specific-blacklist-apb",
@@ -147,6 +147,34 @@ func TestOnlyWhitelist(t *testing.T) {
 		// Not explicitly whitelisted, so should be filtered
 		"baz-apb",
 		"foobar-apb",
+	}
+
+	validNames, filteredNames := filter.Run(testNames())
+
+	expectedTotal := append(expectedValidNames, expectedFilteredNames...)
+	ft.AssertTrue(t, testSetEq(expectedValidNames, validNames))
+	ft.AssertTrue(t, testSetEq(expectedFilteredNames, filteredNames))
+	ft.AssertTrue(t, testSetEq(expectedTotal, testNames()))
+}
+
+func TestEmptyWhitelist(t *testing.T) {
+	filter := Filter{whitelist: testGetRegexFromFile(emptyWhiteListFile),
+		blacklist: []string{}}
+	filter.Init()
+
+	expectedValidNames := []string{}
+
+	expectedFilteredNames := []string{
+		"totally-not-malicious-apb",
+		"malicious-bar-apb",
+		"specific-blacklist-apb",
+		"baz-apb",
+		"foobar-apb",
+		"legitimate-postgresql-apb",
+		"legitimate-mediawiki-apb",
+		"foo-apb",
+		"bar-apb",
+		"rhscl-postgresql-apb",
 	}
 
 	validNames, filteredNames := filter.Run(testNames())

--- a/pkg/registries/testdata/empty_whitelist.yaml
+++ b/pkg/registries/testdata/empty_whitelist.yaml
@@ -1,0 +1,2 @@
+---
+- ".*-nothingwillmatchthis$"


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
We currently filter nothing when blacklist is empty and whitelist is empty. 

Another way of saying this is if I have this whitelist config:
```yaml
    white_list:
      - ".*-apb$"
```
In my registry I have nothing that ends in ```*-apb```.  The result is that everything goes unfiltered.
```
[2018-02-21T12:12:20.868-05:00] [DEBUG] - APBs passing white/blacklist filter:
[2018-02-21T12:12:20.868-05:00] [DEBUG] - -> docker.io/centos/python-36-centos7
[2018-02-21T12:12:20.868-05:00] [DEBUG] - -> docker.io/centos/postgresql-95-centos7
[2018-02-21T12:12:20.868-05:00] [DEBUG] - -> docker.io/openshift/mongodb-24-centos7
[2018-02-21T12:12:20.868-05:00] [DEBUG] - -> docker.io/openshift/jenkins-2-centos7
[2018-02-21T12:12:20.868-05:00] [DEBUG] - -> docker.io/centos/ruby-23-centos7
[2018-02-21T12:12:20.868-05:00] [DEBUG] - -> docker.io/openshift/ruby-20-centos7
[2018-02-21T12:12:20.868-05:00] [DEBUG] - -> docker.io/centos/nodejs-6-centos7
[2018-02-21T12:12:20.868-05:00] [DEBUG] - -> docker.io/centos/nginx-110-centos7
[2018-02-21T12:12:20.868-05:00] [DEBUG] - -> docker.io/centos/perl-520-centos7
[2018-02-21T12:12:20.868-05:00] [DEBUG] - -> docker.io/openshift/wildfly-100-centos7
[2018-02-21T12:12:20.868-05:00] [DEBUG] - -> docker.io/centos/mariadb-102-centos7
[2018-02-21T12:12:20.868-05:00] [DEBUG] - -> docker.io/openshift/nodejs-010-centos7
[2018-02-21T12:12:20.868-05:00] [DEBUG] - -> docker.io/centos/python-34-centos7
...
```
 
Changes proposed in this pull request
 - Filter everything when nothing is whitelisted

**Which issue this PR fixes (This will close that issue when PR gets merged)**
fixes: https://github.com/openshift/ansible-service-broker/issues/745
fixes: https://github.com/ansibleplaybookbundle/ansible-playbook-bundle/issues/215