### PR TITLE
Lock asb-brew releaser to 3.9 branch

### DIFF
--- a/.tito/releasers.conf
+++ b/.tito/releasers.conf
@@ -13,18 +13,6 @@ remote_location = http://repos.fedorapeople.org/asb/
 copr_options = --timeout 600
 builder.test = 1
 
-[asb-brew-36]
-releaser = tito.release.DistGitReleaser
-branches = rhaos-3.6-asb-rhel-7
-
-[asb-brew-37]
-releaser = tito.release.DistGitReleaser
-branches = rhaos-3.7-asb-rhel-7
-
-[asb-brew-38]
-releaser = tito.release.DistGitReleaser
-branches = rhaos-3.8-asb-rhel-7
-
-[asb-brew-39]
+[asb-brew]
 releaser = tito.release.DistGitReleaser
 branches = rhaos-3.9-asb-rhel-7


### PR DESCRIPTION
Doing this will prevent future self from accidentally releasing to the
wrong downstream branch.