### PR TITLE
Bug 1548311 - Return success on depro extcred miss

### DIFF
--- a/pkg/broker/deprovision_subscriber.go
+++ b/pkg/broker/deprovision_subscriber.go
@@ -17,6 +17,7 @@
 package broker
 
 import (
+	"github.com/coreos/etcd/client"
 	"github.com/openshift/ansible-service-broker/pkg/apb"
 	"github.com/openshift/ansible-service-broker/pkg/dao"
 )
@@ -77,8 +78,10 @@ func cleanupDeprovision(instance *apb.ServiceInstance, dao *dao.Dao) error {
 	var err error
 	id := instance.ID.String()
 
-	if err = dao.DeleteExtractedCredentials(id); err != nil {
-		log.Error("failed to delete extracted credentials - %v", err)
+	err = dao.DeleteExtractedCredentials(id)
+	if err != nil && client.IsKeyNotFound(err) {
+		log.Infof("Attempted to delete extracted credentials, but key was not found: [%v]", id)
+	} else if err != nil {
 		return err
 	}
 


### PR DESCRIPTION
**Describe what this PR does and why we need it**:

Deprovision tries to delete extracted credentials despite the fact that they legitimately may not exist in etcd (in the case of failed provisions), and it reports that deprovision as a failure. Instead, the miss should not be considered a critical error and debug logged.

Changes proposed in this pull request
 - Debug log when a delete of extracted credentials fails during a deprovision, and continue to report success in that case, since it is not considered a critical error.