### PR TITLE
Parametize namespace in deployment template and update the 'run latest build' script

### DIFF
--- a/scripts/deploy_broker.sh
+++ b/scripts/deploy_broker.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+#
+# Helper script for deploying the Broker to an existing OpenShift cluster
+# using an OpenShift template.
+#
+
+#
+# VERIFY and UPDATE the variables below
+#
+CLUSTER_ADMIN_USER="system:admin"
+TEMPLATE_URL=${TEMPLATE_URL:-"https://raw.githubusercontent.com/openshift/ansible-service-broker/master/templates/deploy-ansible-service-broker.template.yaml"}
+DOCKERHUB_ORG=${DOCKERHUB_ORG:-"ansibleplaybookbundle"} # DocherHub org where APBs can be found, default 'ansibleplaybookbundle'
+BROKER_IMAGE=${BROKER_IMAGE:-"ansibleplaybookbundle/origin-ansible-service-broker:latest"}
+ENABLE_BASIC_AUTH=${ENABLE_BASIC_AUTH:-"false"}
+PROJECT_NAME=${PROJECT_NAME:-"ansible-service-broker"}
+
+#
+# Login as the CLUSTER_ADMIN_USER
+#
+oc login -u ${CLUSTER_ADMIN_USER}
+
+#
+# Get the BROKER_CA_CERT
+#
+BROKER_CA_CERT=`oc get secret -n kube-service-catalog -o go-template='{{ range .items }}{{ if eq .type "kubernetes.io/service-account-token" }}{{ index .data "service-ca.crt" }}{{end}}{{"\n"}}{{end}}' | awk NF | tail -n 1`
+if [ "${BROKER_CA_CERT}" == "" ]; then
+    echo -e "\nUnable to set the BROKER_CA_CERT variable!"
+    echo -e "Please VERIFY that CLUSTER_ADMIN_USER is set to a user with cluster admin privileges\n"
+    exit
+fi
+
+#
+# creating ${PROJECT_NAME} project
+#
+oc new-project ${PROJECT_NAME}
+
+# Creating openssl certs to use.
+mkdir -p /tmp/etcd-cert
+openssl req -nodes -x509 -newkey rsa:4096 -keyout /tmp/etcd-cert/key.pem -out /tmp/etcd-cert/cert.pem -days 365 -subj "/CN=asb-etcd.ansible-service-broker.svc"
+openssl genrsa -out /tmp/etcd-cert/MyClient1.key 2048 \
+&& openssl req -new -key /tmp/etcd-cert/MyClient1.key -out /tmp/etcd-cert/MyClient1.csr -subj "/CN=client" \
+&& openssl x509 -req -in /tmp/etcd-cert/MyClient1.csr -CA /tmp/etcd-cert/cert.pem -CAkey /tmp/etcd-cert/key.pem -CAcreateserial -out /tmp/etcd-cert/MyClient1.pem -days 1024
+
+ETCD_CA_CERT=$(cat /tmp/etcd-cert/cert.pem | base64)
+BROKER_CLIENT_CERT=$(cat /tmp/etcd-cert/MyClient1.pem | base64)
+BROKER_CLIENT_KEY=$(cat /tmp/etcd-cert/MyClient1.key | base64)
+
+curl -s $TEMPLATE_URL \
+  | oc process \
+  -n ${PROJECT_NAME} \
+  -p DOCKERHUB_ORG="$DOCKERHUB_ORG" \
+  -p ENABLE_BASIC_AUTH="$ENABLE_BASIC_AUTH" \
+  -p ETCD_TRUSTED_CA_FILE=/var/run/etcd-auth-secret/ca.crt \
+  -p BROKER_CLIENT_CERT_PATH=/var/run/asb-etcd-auth/client.crt \
+  -p BROKER_CLIENT_KEY_PATH=/var/run/asb-etcd-auth/client.key \
+  -p ETCD_TRUSTED_CA="$ETCD_CA_CERT" \
+  -p BROKER_CLIENT_CERT="$BROKER_CLIENT_CERT" \
+  -p BROKER_CLIENT_KEY="$BROKER_CLIENT_KEY" \
+  -p NAMESPACE="${PROJECT_NAME}" \
+  -p BROKER_URL_PREFIX="${PROJECT_NAME}" \
+  -p BROKER_AUTH="{ \"bearer\": { \"secretRef\": { \"kind\": \"Secret\", \"namespace\": \"${PROJECT_NAME}\", \"name\": \"ansibleservicebroker-client\" } } }" \
+  -p BROKER_IMAGE="${BROKER_IMAGE}" \
+  -p BROKER_CA_CERT="$BROKER_CA_CERT" -f - | oc create -f -
+if [ "$?" -ne 0 ]; then
+  echo "Error processing template and creating deployment"
+  exit
+fi
+
+#
+# Then login as 'developer'/'developer' to WebUI
+# Create a project
+# Deploy mediawiki to new project (use a password other than
+#   admin since mediawiki forbids admin as password)
+# Deploy PostgreSQL(ABP) to new project
+# After they are up
+# Click 'Create Binding' on the kebab menu for Mediawiki,
+#   select postgres
+# Click deploy on mediawiki, after it's redeployed access webui
+#

--- a/templates/deploy-ansible-service-broker.template.yaml
+++ b/templates/deploy-ansible-service-broker.template.yaml
@@ -45,7 +45,7 @@ objects:
   kind: ServiceAccount
   metadata:
     name: asb
-    namespace: ansible-service-broker
+    namespace: "${NAMESPACE}"
 
 - apiVersion: rbac.authorization.k8s.io/v1beta1
   kind: ClusterRoleBinding
@@ -58,7 +58,7 @@ objects:
   subjects:
   - kind: ServiceAccount
     name: asb
-    namespace: ansible-service-broker
+    namespace: "${NAMESPACE}"
 
 - apiVersion: rbac.authorization.k8s.io/v1beta1
   kind: ClusterRole
@@ -101,7 +101,7 @@ objects:
   subjects:
   - kind: ServiceAccount
     name: asb
-    namespace: ansible-service-broker
+    namespace: "${NAMESPACE}"
   roleRef:
     kind: ClusterRole
     name: asb-auth
@@ -112,14 +112,14 @@ objects:
   metadata:
     name: access-asb-role
   rules:
-  - nonResourceURLs: ["${BROKER_URL_PREFIX}", "${BROKER_URL_PREFIX}/*"]
+  - nonResourceURLs: ["/${BROKER_URL_PREFIX}", "/${BROKER_URL_PREFIX}/*"]
     verbs: ["get", "post", "put", "patch", "delete"]
 
 - apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
     name: etcd
-    namespace: ansible-service-broker
+    namespace: "${NAMESPACE}"
   spec:
     accessModes:
       - ReadWriteOnce
@@ -262,7 +262,7 @@ objects:
   kind: Secret
   metadata:
     name: asb-auth-secret
-    namespace: ansible-service-broker
+    namespace: "${NAMESPACE}"
   data:
     username: ${BROKER_USER}
     password: ${BROKER_PASS}
@@ -271,7 +271,7 @@ objects:
   kind: Secret
   metadata:
     name: ${REGISTRY_SECRET_NAME}
-    namespace: ansible-service-broker
+    namespace: "${NAMESPACE}"
   data:
     username: ${DOCKERHUB_USER}
     password: ${DOCKERHUB_PASS}
@@ -280,7 +280,7 @@ objects:
   kind: Secret
   metadata:
     name: etcd-auth-secret
-    namespace: ansible-service-broker
+    namespace: "${NAMESPACE}"
   data:
     ca.crt: ${ETCD_TRUSTED_CA}
 
@@ -288,7 +288,7 @@ objects:
   kind: Secret
   metadata:
     name: broker-etcd-auth-secret
-    namespace: ansible-service-broker
+    namespace: "${NAMESPACE}"
   data:
     client.crt: ${BROKER_CLIENT_CERT}
     client.key: ${BROKER_CLIENT_KEY}
@@ -297,7 +297,7 @@ objects:
   kind: ConfigMap
   metadata:
     name: broker-config
-    namespace: ansible-service-broker
+    namespace: "${NAMESPACE}"
     labels:
       app: ansible-service-broker
   data:
@@ -332,7 +332,7 @@ objects:
         bearer_token_file: "${BEARER_TOKEN_FILE}"
         image_pull_policy: "${IMAGE_PULL_POLICY}"
         sandbox_role: "${SANDBOX_ROLE}"
-        namespace: ansible-service-broker
+        namespace: "${NAMESPACE}"
         keep_namespace: ${KEEP_NAMESPACE}
         keep_namespace_on_error: ${KEEP_NAMESPACE_ON_ERROR}
       broker:
@@ -345,6 +345,7 @@ objects:
         ssl_cert_key: /etc/tls/private/tls.key
         ssl_cert: /etc/tls/private/tls.crt
         auto_escalate: ${AUTO_ESCALATE}
+        cluster_url: "${BROKER_URL_PREFIX}"
         auth:
           - type: basic
             enabled: ${ENABLE_BASIC_AUTH}
@@ -353,7 +354,7 @@ objects:
   kind: ServiceAccount
   metadata:
     name: ansibleservicebroker-client
-    namespace: ansible-service-broker
+    namespace: "${NAMESPACE}"
 
 - apiVersion: rbac.authorization.k8s.io/v1beta1
   kind: ClusterRoleBinding
@@ -362,7 +363,7 @@ objects:
   subjects:
   - kind: ServiceAccount
     name: ansibleservicebroker-client
-    namespace: ansible-service-broker
+    namespace: "${NAMESPACE}"
   roleRef:
     kind: ClusterRole
     name: access-asb-role
@@ -397,7 +398,7 @@ objects:
   metadata:
     name: ansible-service-broker
   spec:
-    url: https://asb.ansible-service-broker.svc:1338${BROKER_URL_PREFIX}/
+    url: https://asb.${NAMESPACE}.svc:1338/${BROKER_URL_PREFIX}/
     authInfo:
       ${{BROKER_AUTH}}
     caBundle: ${BROKER_CA_CERT}


### PR DESCRIPTION
Parameterize the ASB namespace in the deployment template and changed the run_latest_build script so that it would be easier to update AWS broker templates and scripts

Changes proposed in this pull request
 - replaced 'ansible-service-broker' with ${NAMESPACE} in the deployment template where appropriate
 - created a 'deploy_broker.sh' script to launch the broker in an existing cluster
 - modified the 'run_latest_build.sh' script to utilize the 'deploy_broker.sh' script

To test the run script BEFORE merging this PR, the TEMPLATE_URL should be defined:
$ TEMPLATE_URL=<link-to-updated-template-file> ./run_latest_build.sh