### PR TITLE
Allow playbooks names to be something other than $action

### DIFF
--- a/pkg/apb/executor.go
+++ b/pkg/apb/executor.go
@@ -229,7 +229,7 @@ func (e *executor) executeApb(
 						"--extra-vars",
 						extraVars,
 					},
-					Env:             createPodEnv(executionContext),
+					Env:             createPodEnv(executionContext, spec.Name),
 					ImagePullPolicy: pullPolicy,
 					VolumeMounts:    volumeMounts,
 				},
@@ -321,7 +321,7 @@ func createExtraVars(context *Context, parameters *Parameters) (string, error) {
 	return string(extraVars), err
 }
 
-func createPodEnv(executionContext ExecutionContext) []v1.EnvVar {
+func createPodEnv(executionContext ExecutionContext, bundleName string) []v1.EnvVar {
 	podEnv := []v1.EnvVar{
 		v1.EnvVar{
 			Name: "POD_NAME",
@@ -338,6 +338,10 @@ func createPodEnv(executionContext ExecutionContext) []v1.EnvVar {
 					FieldPath: "metadata.namespace",
 				},
 			},
+		},
+		v1.EnvVar{
+			Name:  "BUNDLE_NAME",
+			Value: bundleName,
 		},
 	}
 

--- a/pkg/apb/types.go
+++ b/pkg/apb/types.go
@@ -90,10 +90,11 @@ func (p *Plan) GetParameter(name string) *ParameterDescriptor {
 
 // Spec - A APB spec
 type Spec struct {
+	FQName      string
+	Name        string                 `json:"name" yaml:"name"`
 	ID          string                 `json:"id"`
 	Runtime     int                    `json:"runtime"`
 	Version     string                 `json:"version"`
-	FQName      string                 `json:"name" yaml:"name"`
 	Image       string                 `json:"image" yaml:"-"`
 	Tags        []string               `json:"tags"`
 	Bindable    bool                   `json:"bindable"`

--- a/pkg/registries/adapters/adapter.go
+++ b/pkg/registries/adapters/adapter.go
@@ -138,6 +138,7 @@ func imageToSpec(log *logging.Logger, req *http.Request, image string) (*apb.Spe
 		log.Errorf("Something went wrong loading decoded spec yaml, %s", err)
 		return nil, err
 	}
+	spec.FQName = spec.Name
 
 	spec.Runtime, err = getAPBRuntimeVersion(log, conf.Config.Label.Runtime)
 	if err != nil {

--- a/pkg/registries/adapters/local_openshift_adapter.go
+++ b/pkg/registries/adapters/local_openshift_adapter.go
@@ -87,6 +87,8 @@ func (r LocalOpenShiftAdapter) FetchSpecs(imageNames []string) ([]*apb.Spec, err
 			r.Log.Errorf("Failed to load image spec")
 			continue
 		}
+		spec.FQName = spec.Name
+
 		spec.Runtime, err = getAPBRuntimeVersion(r.Log, image.Runtime)
 		if err != nil {
 			r.Log.Errorf("Failed to parse image runtime version")


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
Instead of forcing the user to have a playbook named provision, deprovision, bind, or unbind, allow the user to create a single playbook with the  ```Name``` field in apb.yml.  A single playbook would work because we also pass in ```action``` to the playbook, which will then call the ```$action``` role or tasks in the ```$name``` playbook.

Here's an example of the action being used at the task level: https://github.com/ansibleplaybookbundle/kubevirt-apb/blob/master/roles/kubevirt-apb/tasks/main.yml

Changes proposed in this pull request
 - Add BUNDLE_NAME to the apb environment

**Does this PR depend on another PR (Use this to track when PRs should be merged)**
depends-on https://github.com/ansibleplaybookbundle/apb-base/pull/20

