### PR TITLE
Removing links to older fusor GH org

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Ansible Service Broker
 [![Licensed under Apache License version 2.0](https://img.shields.io/github/license/openshift/origin.svg?maxAge=2592000)](https://www.apache.org/licenses/LICENSE-2.0)
 
 Ansible Service Broker is an implementation of the [Open Service Broker API](https://github.com/openservicebrokerapi/servicebroker)
-that manages applications defined in [Ansible Playbook Bundles](https://github.com/fusor/ansible-playbook-bundle).
+that manages applications defined in [Ansible Playbook Bundles](https://github.com/ansibleplaybookbundle/ansible-playbook-bundle).
 Ansible Playbook Bundles (APB) are a method of defining applications via a collection of Ansible Playbooks built into a container
 with an Ansible runtime with the playbooks corresponding to a type of request specified in the
 [Open Service Broker API Specification](https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#api-overview).
@@ -18,10 +18,10 @@ Check out the [Keynote Demo from Red Hat Summit 2017](https://youtu.be/8MCbJmZQM
 
 **Features**
 
-- Easily define, distribute, and provision microservice(s), like [RocketChat](https://github.com/fusor/apb-examples/tree/master/rocketchat-apb)
+- Easily define, distribute, and provision microservice(s), like [RocketChat](https://github.com/ansibleplaybookbundle/rocketchat-apb)
   and [PostgreSQL](https://github.com/ansibleplaybookbundle/postgresql-apb), via ansible playbooks packaged in
-  [Ansible Playbook Bundles](https://github.com/fusor/ansible-playbook-bundle).
-- Easily bind microservice(s) provisioned through [Ansible Playbook Bundles](https://github.com/fusor/ansible-playbook-bundle),
+  [Ansible Playbook Bundles](https://github.com/ansibleplaybookbundle/ansible-playbook-bundle).
+- Easily bind microservice(s) provisioned through [Ansible Playbook Bundles](https://github.com/ansibleplaybookbundle/ansible-playbook-bundle),
   for example: [Using the Service Catalog to Bind a PostgreSQL APB to a Python Web App](https://www.youtube.com/watch?v=xmd52NhEjCk).
 
 **Learn More:**
@@ -34,7 +34,7 @@ Check out the [Keynote Demo from Red Hat Summit 2017](https://youtu.be/8MCbJmZQM
 - Our [YouTube Channel](https://www.youtube.com/channel/UC04eOMIMiV06_RSZPb4OOBw)
 
 **Important Links**
-- Check out the [ansible playbook bundle](https://github.com/fusor/ansible-playbook-bundle) project
+- Check out the [ansible playbook bundle](https://github.com/ansibleplaybookbundle/ansible-playbook-bundle) project
    and our [library of example APBs](https://github.com/fusor/apb-examples)
 - [catasb](https://github.com/fusor/catasb) gives you more control over your development environment
 - [Amazon Web Services deployed into OpenShift via Ansible Service Broker](https://www.youtube.com/watch?v=EKo3khfmhi8&index=2&list=PLZ7osZ-J70IaVc0NVyLs7tLO1hbhBdxHe)

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@
   * [Troubleshooting](troubleshooting.md)
   * [Running behind a proxy](proxy.md)
 * Ansible Playbook Bundle
-  * [Design](https://github.com/fusor/ansible-playbook-bundle/blob/master/docs/design.md)
+  * [Design](https://github.com/ansibleplaybookbundle/ansible-playbook-bundle/blob/master/docs/design.md)
 * Bind Operation
   * [Data Transmission](bind-data-transmission.md)
   * [Use Cases](usecases.md)

--- a/docs/apb_integration.md
+++ b/docs/apb_integration.md
@@ -9,7 +9,7 @@ Ansible Playbook Bundles (APB) should be executed by the broker via the docker c
 > TODO: Document the docker client API code used to create and run these containers.
 > For now, we are running the docker cli tool via scripts until this can be sorted.
 
-See [APB design](#https://github.com/fusor/ansible-playbook-bundle/blob/master/docs/design.md)
+See [APB design](https://github.com/ansibleplaybookbundle/ansible-playbook-bundle/blob/master/docs/design.md)
 for details for argument requirements and expectations
 
 ## Targeting a cluster for APB deployment
@@ -18,7 +18,7 @@ for details for argument requirements and expectations
 
 ![Integration0.1](images/apb_integration.png)
 
-Seen in the [APB design](#https://github.com/fusor/ansible-playbook-bundle/blob/master/docs/design.md), an `ArgumentsObject` requires a `ClusterObject`
+Seen in the [APB design](https://github.com/ansibleplaybookbundle/ansible-playbook-bundle/blob/master/docs/design.md), an `ArgumentsObject` requires a `ClusterObject`
 intended to provide details for connecting and authenticating with a targeted
 cluster.
 


### PR DESCRIPTION
Updating Markdown files, where the links were pointing to the older `fusor` org. on Github.

Changes proposed in this pull request
 - fixing broken links (e.g. the rocketchat-apb link)
 - updating links to point to the newer ansibleplaybookbundle GH org

This PR is independent, and has no link/relationship to any other PR - it's mainly for updating (slightly) outdated markdown filez