### PR TITLE
Add breadcrumbs to release notes

### DIFF
--- a/scripts/release_notes.sh
+++ b/scripts/release_notes.sh
@@ -31,6 +31,8 @@ generate_notes () {
     local start=$1
     local end=HEAD
     local commits=$(git --no-pager log --reverse --pretty=format:"%s" "$start".."$end")
+    local first_commit=$(git rev-parse "$start")
+    local last_commit=$(git rev-parse "$end")
     local date=$(date +%Y%m%d)
     local notes_file=$(mktemp)
     local bug_file=$(mktemp)
@@ -38,6 +40,10 @@ generate_notes () {
 
     cat <<EOF >> $notes_file
 # Release notes for $date
+
+* First Commit: $first_commit
+* Last Commit: $last_commit
+
 EOF
 
     cat <<EOF >> $bug_file


### PR DESCRIPTION
When a Sprint is over and I need to create release notes, I want to know what was the last commit I looked at for the previous Sprint. This adds breadcrumbs to make that easier.