### PR TITLE
Default to an open localregistry policy

### DIFF
--- a/templates/deploy-ansible-service-broker.template.yaml
+++ b/templates/deploy-ansible-service-broker.template.yaml
@@ -317,8 +317,11 @@ objects:
         - type: local_openshift
           name: localregistry
           namespaces: ['openshift']
+          # NOTE TO ADMINS: The default whitelist policy here will pass *all* APBs
+          # found in the local openshift registry. If this is not desired,
+          # manipulate the following regex to only match APBs you wish to be made available.
           white_list:
-            - ".*-apb$"
+            - ".*"
       dao:
         type: "${DAO_TYPE}"
         etcd_host: asb-etcd.${NAMESPACE}.svc


### PR DESCRIPTION
Having a default policy of only allowing APBs with a name suffixed by "-apb" has been confusing our development community. This change removes the above restriction by default. The justification for this change is that the deployment environments that use this template from the github repo include catasb, minishift, and `run_latest_build.sh`. These are all specifically development environments. `openshift-ansible`, which is likely used for production deployments, carries its own production deployment template. 

fixes #823 