### PR TITLE
make headings smaller

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,7 +1,7 @@
 **This form is for bug reports and feature requests. Major features will go through a [spec process](https://github.com/openshift/ansible-service-broker/blob/master/CONTRIBUTING.md).**
 
-> # Feature:
-> # Bug:
+## Feature:
+## Bug:
 
 **What happened**:
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,12 +1,13 @@
-**Describe what this PR does and why we need it**:
+#### Describe what this PR does and why we need it:
 
-Changes proposed in this pull request
+#### Changes proposed in this pull request
+
  -
  -
  -
 
-**Does this PR depend on another PR (Use this to track when PRs should be merged)**
+#### Does this PR depend on another PR (Use this to track when PRs should be merged)
 depends-on <PR>
 
-**Which issue this PR fixes (This will close that issue when PR gets merged)**
+#### Which issue this PR fixes (This will close that issue when PR gets merged)
 fixes <issue_number>


### PR DESCRIPTION
The Feature heading in the issue template was so large the issue text
was sometimes lost.

The pull request template had inconsistent formatting.