### PR TITLE
make username available for APB in the serviceInstance

### DIFF
--- a/docs/service-bundle.md
+++ b/docs/service-bundle.md
@@ -131,7 +131,7 @@ Example of JSON document passed to __bind__:
 
 #### Last Request User
 
-The requesting username of the [actions](#actions) _provision_, _deprovision_, _bind_, _unbind_, and _update_ is available in the `_apb_last_requesting_user` parameter. The parameter is set to the `UID` if the requesting `username` is empty (e.g. auto escalation). However, this parameter may be completely empty as it's not a requirement to send the requesting user information. Also, the user info of the latest request will always overwrite the existing value.
+The requesting username of the [actions](#actions) _provision_, _deprovision_, _bind_, _unbind_, and _update_ is available in the `_apb_last_requesting_user` parameter. The parameter is set to the `UID` if the  `username` of the action is empty (e.g. auto escalation). However, this parameter may be completely empty as it's not a requirement to send the requesting user information. The user for the current action may be different from the users that initiated any previous actions on the same resource. The _apb_last_requesting_user will always reflect the username of this current action.
 
 This field was introduced in version 1.2
 

--- a/docs/service-bundle.md
+++ b/docs/service-bundle.md
@@ -131,9 +131,9 @@ Example of JSON document passed to __bind__:
 
 #### Last Request User
 
-The requesting username of the [actions](#actions) _provision_, _deprovision_, _bind_, _unbind_, and _update_ will available in the `_apb_last_requesting_user` parameter. The parameter value will be the `UID` of the requesting user if the `username` is not available (e.g. auto escalation). Also, the user info of the latest request will always overwrite the existing value.
+The requesting username of the [actions](#actions) _provision_, _deprovision_, _bind_, _unbind_, and _update_ is available in the `_apb_last_requesting_user` parameter. The parameter is set to the `UID` if the requesting `username` is empty (e.g. auto escalation). Also, the user info of the latest request will always overwrite the existing value.
 
-This feature will be available in v3.10
+This field was introduced in version 1.2
 
 ### Environment Variables
 

--- a/docs/service-bundle.md
+++ b/docs/service-bundle.md
@@ -17,11 +17,11 @@ name: example-apb   # The name of the Service Bundle
 description:        # A short description of the Service Bundle
 bindable: True      # Whether this Service Bundle can be bound to other services
 async: optional     # Does this Service Bundle support asynchronous provision
-metadata: 
+metadata:
   documentationUrl: <link to documentation>
   imageUrl: <link to URL of image>
   dependencies:
-  - '<registry>/<organization>/<dependency-name-1>'   
+  - '<registry>/<organization>/<dependency-name-1>'
   - '<registry>/<organization>/<dependency-name-2>'
   displayName: Example App (APB)
   longDescription: A longer description of what this APB does
@@ -79,6 +79,7 @@ Example of JSON document passed to __provision__:
     "_apb_plan_id": "default",
     "_apb_service_class_id": "c23ec213bb8dea1577230c5ce005b9c2",
     "_apb_service_instance_id": "54636ad3-0378-49a1-a494-f97d0a0daf8e",
+    "_apb_last_requesting_user": "admin",
     "mediawiki_admin_pass": "pass",
     "mediawiki_admin_user": "admin",
     "mediawiki_db_schema": "mediawiki",
@@ -118,6 +119,7 @@ Example of JSON document passed to __bind__:
     },
     "_apb_service_class_id": "1dda1477cace09730bd8ed7a6505607e",
     "_apb_service_instance_id": "d6ac6b10-fbff-4944-8e6b-3478313e20d1",
+    "_apb_last_requesting_user": "admin",
     "cluster": "kubernetes",
     "namespace": "default"
 }
@@ -127,12 +129,18 @@ Example of JSON document passed to __bind__:
   provision action for this service instance. Details are below in the Output
   section.
 
+#### Last Request User
+
+The requesting username of the [actions](#actions) _provision_, _deprovision_, _bind_, _unbind_, and _update_ will available in the `_apb_last_requesting_user` parameter. The parameter value will be the `UID` of the requesting user if the `username` is not available (e.g. auto escalation). Also, the user info of the latest request will always overwrite the existing value.
+
+This feature will be available in v3.10
+
 ### Environment Variables
 
 The following environment variables are set by the broker:
 
 * __POD_NAMESPACE__: the namespace in which the service bundle is being run
-* __POD_NAME__: the name of the pod 
+* __POD_NAME__: the name of the pod
 
 ## Output
 
@@ -242,4 +250,3 @@ users:
   user:
     tokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
 ```
-

--- a/docs/service-bundle.md
+++ b/docs/service-bundle.md
@@ -131,7 +131,7 @@ Example of JSON document passed to __bind__:
 
 #### Last Request User
 
-The requesting username of the [actions](#actions) _provision_, _deprovision_, _bind_, _unbind_, and _update_ is available in the `_apb_last_requesting_user` parameter. The parameter is set to the `UID` if the requesting `username` is empty (e.g. auto escalation). Also, the user info of the latest request will always overwrite the existing value.
+The requesting username of the [actions](#actions) _provision_, _deprovision_, _bind_, _unbind_, and _update_ is available in the `_apb_last_requesting_user` parameter. The parameter is set to the `UID` if the requesting `username` is empty (e.g. auto escalation). However, this parameter may be completely empty as it's not a requirement to send the requesting user information. Also, the user info of the latest request will always overwrite the existing value.
 
 This field was introduced in version 1.2
 

--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -713,9 +713,7 @@ func (a AnsibleBroker) Deprovision(
 
 	// Override the lastRequestingUserKey value in the instance.Parameters
 	if instance.Parameters != nil {
-		params := *instance.Parameters
-		params[lastRequestingUserKey] = getLastRequestingUser(userInfo)
-		instance.Parameters = &params
+		(*instance.Parameters)[lastRequestingUserKey] = getLastRequestingUser(userInfo)
 	}
 
 	var token = a.engine.Token()
@@ -1019,9 +1017,7 @@ func (a AnsibleBroker) Unbind(
 
 	// Override the lastRequestingUserKey value in the instance.Parameters
 	if instance.Parameters != nil {
-		params := *instance.Parameters
-		params[lastRequestingUserKey] = getLastRequestingUser(userInfo)
-		instance.Parameters = &params
+		(*instance.Parameters)[lastRequestingUserKey] = getLastRequestingUser(userInfo)
 	}
 
 	params := make(apb.Parameters)

--- a/pkg/broker/types.go
+++ b/pkg/broker/types.go
@@ -31,10 +31,10 @@ const (
 )
 
 const (
-	planParameterKey  = "_apb_plan_id"
-	serviceClassIDKey = "_apb_service_class_id"
-	serviceInstIDKey  = "_apb_service_instance_id"
-	requestingUserKey = "_apb_requesting_user"
+	planParameterKey      = "_apb_plan_id"
+	serviceClassIDKey     = "_apb_service_class_id"
+	serviceInstIDKey      = "_apb_service_instance_id"
+	lastRequestingUserKey = "_apb_last_requesting_user"
 )
 
 // WorkTopic - Topic jobs can publish messages to, and subscribers can listen to

--- a/pkg/broker/types.go
+++ b/pkg/broker/types.go
@@ -34,6 +34,7 @@ const (
 	planParameterKey  = "_apb_plan_id"
 	serviceClassIDKey = "_apb_service_class_id"
 	serviceInstIDKey  = "_apb_service_instance_id"
+	requestingUserKey = "_apb_requesting_user"
 )
 
 // WorkTopic - Topic jobs can publish messages to, and subscribers can listen to

--- a/pkg/broker/util.go
+++ b/pkg/broker/util.go
@@ -434,8 +434,8 @@ func StateToLastOperation(state apb.State) LastOperationState {
 	}
 }
 
-// getRequestingUser - return the UID if the username is ""
-func getRequestingUser(user UserInfo) string {
+// getLastRequestingUser - return the UID if the username is ""
+func getLastRequestingUser(user UserInfo) string {
 	if user.Username == "" {
 		return user.UID
 	}

--- a/pkg/broker/util.go
+++ b/pkg/broker/util.go
@@ -433,3 +433,11 @@ func StateToLastOperation(state apb.State) LastOperationState {
 		return LastOperationStateFailed
 	}
 }
+
+// getRequestingUser - return the UID if the username is ""
+func getRequestingUser(user UserInfo) string {
+	if user.Username == "" {
+		return user.UID
+	}
+	return user.Username
+}

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -274,8 +274,8 @@ func (h handler) provision(w http.ResponseWriter, r *http.Request, params map[st
 		return
 	}
 
+	userInfo, ok := r.Context().Value(UserInfoContext).(broker.UserInfo)
 	if !h.brokerConfig.GetBool("broker.auto_escalate") {
-		userInfo, ok := r.Context().Value(UserInfoContext).(broker.UserInfo)
 		if !ok {
 			log.Debugf("unable to retrieve user info from request context")
 			// if no user, we should error out with bad request.
@@ -293,7 +293,7 @@ func (h handler) provision(w http.ResponseWriter, r *http.Request, params map[st
 		log.Debugf("Auto Escalate has been set to true, we are escalating permissions")
 	}
 	// Ok let's provision this bad boy
-	resp, err := h.broker.Provision(instanceUUID, req, async)
+	resp, err := h.broker.Provision(instanceUUID, req, async, userInfo)
 
 	if err != nil {
 		log.Errorf("provision error %+v", err)
@@ -336,8 +336,8 @@ func (h handler) update(w http.ResponseWriter, r *http.Request, params map[strin
 	// ignore the error, if async can't be parsed it will be false
 	async, _ := strconv.ParseBool(r.FormValue("accepts_incomplete"))
 
+	userInfo, ok := r.Context().Value(UserInfoContext).(broker.UserInfo)
 	if !h.brokerConfig.GetBool("broker.auto_escalate") {
-		userInfo, ok := r.Context().Value(UserInfoContext).(broker.UserInfo)
 		if !ok {
 			log.Debugf("unable to retrieve user info from request context")
 			// if no user, we should error out with bad request.
@@ -355,7 +355,7 @@ func (h handler) update(w http.ResponseWriter, r *http.Request, params map[strin
 		log.Debugf("Auto Escalate has been set to true, we are escalating permissions")
 	}
 
-	resp, err := h.broker.Update(instanceUUID, req, async)
+	resp, err := h.broker.Update(instanceUUID, req, async, userInfo)
 
 	if err != nil {
 		switch err {
@@ -419,8 +419,8 @@ func (h handler) deprovision(w http.ResponseWriter, r *http.Request, params map[
 		return
 	}
 
+	userInfo, ok := r.Context().Value(UserInfoContext).(broker.UserInfo)
 	if !h.brokerConfig.GetBool("broker.auto_escalate") {
-		userInfo, ok := r.Context().Value(UserInfoContext).(broker.UserInfo)
 		if !ok {
 			log.Debugf("unable to retrieve user info from request context")
 			// if no user, we should error out with bad request.
@@ -441,7 +441,7 @@ func (h handler) deprovision(w http.ResponseWriter, r *http.Request, params map[
 		log.Debugf("Auto Escalate has been set to true, we are escalating permissions")
 	}
 
-	resp, err := h.broker.Deprovision(serviceInstance, planID, nsDeleted, async)
+	resp, err := h.broker.Deprovision(serviceInstance, planID, nsDeleted, async, userInfo)
 
 	if err != nil {
 		switch err {
@@ -549,8 +549,8 @@ func (h handler) bind(w http.ResponseWriter, r *http.Request, params map[string]
 		return
 	}
 
+	userInfo, ok := r.Context().Value(UserInfoContext).(broker.UserInfo)
 	if !h.brokerConfig.GetBool("broker.auto_escalate") {
-		userInfo, ok := r.Context().Value(UserInfoContext).(broker.UserInfo)
 		if !ok {
 			log.Debugf("unable to retrieve user info from request context")
 			// if no user, we should error out with bad request.
@@ -569,7 +569,7 @@ func (h handler) bind(w http.ResponseWriter, r *http.Request, params map[string]
 	}
 
 	// process binding request
-	resp, ranAsync, err := h.broker.Bind(serviceInstance, bindingUUID, req, async)
+	resp, ranAsync, err := h.broker.Bind(serviceInstance, bindingUUID, req, async, userInfo)
 
 	if err != nil {
 		switch err {
@@ -646,8 +646,8 @@ func (h handler) unbind(w http.ResponseWriter, r *http.Request, params map[strin
 		return
 	}
 
+	userInfo, ok := r.Context().Value(UserInfoContext).(broker.UserInfo)
 	if !h.brokerConfig.GetBool("broker.auto_escalate") {
-		userInfo, ok := r.Context().Value(UserInfoContext).(broker.UserInfo)
 		if !ok {
 			log.Debugf("unable to retrieve user info from request context")
 			// if no user, we should error out with bad request.
@@ -666,7 +666,7 @@ func (h handler) unbind(w http.ResponseWriter, r *http.Request, params map[strin
 		log.Debugf("Auto Escalate has been set to true, we are escalating permissions")
 	}
 
-	resp, ranAsync, err := h.broker.Unbind(serviceInstance, bindInstance, planID, nsDeleted, async)
+	resp, ranAsync, err := h.broker.Unbind(serviceInstance, bindInstance, planID, nsDeleted, async, userInfo)
 
 	switch {
 	case err == broker.ErrorNotFound: // return 404

--- a/pkg/handler/handler_test.go
+++ b/pkg/handler/handler_test.go
@@ -79,7 +79,7 @@ func (m MockBroker) Catalog() (*broker.CatalogResponse, error) {
 	m.called("catalog", true)
 	return nil, m.Err
 }
-func (m MockBroker) Provision(uuid.UUID, *broker.ProvisionRequest, bool) (*broker.ProvisionResponse, error) {
+func (m MockBroker) Provision(uuid.UUID, *broker.ProvisionRequest, bool, broker.UserInfo) (*broker.ProvisionResponse, error) {
 	m.called("provision", true)
 	fmt.Println("provision called")
 	fmt.Println(m.Operation)
@@ -89,11 +89,11 @@ func (m MockBroker) Update(uuid.UUID, *broker.UpdateRequest, bool) (*broker.Upda
 	m.called("update", true)
 	return nil, m.Err
 }
-func (m MockBroker) Deprovision(apb.ServiceInstance, string, bool, bool) (*broker.DeprovisionResponse, error) {
+func (m MockBroker) Deprovision(apb.ServiceInstance, string, bool, bool, broker.UserInfo) (*broker.DeprovisionResponse, error) {
 	m.called("deprovision", true)
 	return nil, m.Err
 }
-func (m MockBroker) Bind(apb.ServiceInstance, uuid.UUID, *broker.BindRequest, bool) (*broker.BindResponse, bool, error) {
+func (m MockBroker) Bind(apb.ServiceInstance, uuid.UUID, *broker.BindRequest, bool, broker.UserInfo) (*broker.BindResponse, bool, error) {
 	m.called("bind", true)
 	return nil, false, m.Err
 }


### PR DESCRIPTION
#### Describe what this PR does and why we need it:
username information was requested to be available for APBs

#### Changes proposed in this pull request
 - pass the username info from the broker to the APB during it's executions as a parameter in extra_vars

#### Addresses the following Issue
* [Issue #674](https://github.com/openshift/ansible-service-broker/issues/674)