### PR TITLE
Bug 1554239 - overwriting job state that has been finished.

### DIFF
--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -730,11 +730,13 @@ func (a AnsibleBroker) Deprovision(
 
 		// HACK: there might be a delay between the first time the state in etcd
 		// is set and the job was already started. But I need the token.
-		a.dao.SetState(instance.ID.String(), apb.JobState{
-			Token:  token,
-			State:  apb.StateInProgress,
-			Method: apb.JobMethodDeprovision,
-		})
+		if !skipApbExecution {
+			a.dao.SetState(instance.ID.String(), apb.JobState{
+				Token:  token,
+				State:  apb.StateInProgress,
+				Method: apb.JobMethodDeprovision,
+			})
+		}
 		return &DeprovisionResponse{Operation: token}, nil
 	}
 


### PR DESCRIPTION
#### Describe what this PR does and why we need it:
removes the overwriting of the job state.

**Race condition**:
Skip APB run -> send a successful message -> then broker code sets status to in progress.
Making the job run forever.


#### Changes proposed in this pull request
 - Don't set the state to in progress if we are skipping the APB run.

#### Which issue this PR fixes (This will close that issue when PR gets merged)
fixes 1554239
