### PR TITLE
Display Custom Error Message for the APB via termination-log

### DIFF
--- a/pkg/apb/watch_pod.go
+++ b/pkg/apb/watch_pod.go
@@ -36,7 +36,7 @@ var (
 
 type updateDescriptionFn func(string)
 
-// ErrorCustomMsg - custom termination msg from pod's 'terminationMessagePath'
+// ErrorCustomMsg - An error to propagate the custom error message to the callers
 type ErrorCustomMsg struct {
 	msg string
 }

--- a/pkg/apb/watch_pod.go
+++ b/pkg/apb/watch_pod.go
@@ -36,6 +36,22 @@ var (
 
 type updateDescriptionFn func(string)
 
+// ErrorCustomMsg - custom termination msg from pod's 'terminationMessagePath'
+type ErrorCustomMsg struct {
+	msg string
+}
+
+func (e ErrorCustomMsg) Error() string {
+	// returns an Error with a custom message
+	return e.msg
+}
+
+// IsErrorCustomMsg - true if it's a custom message error
+func IsErrorCustomMsg(err error) bool {
+	_, ok := err.(ErrorCustomMsg)
+	return ok
+}
+
 func watchPod(
 	podName string, namespace string, podClient v1.PodInterface,
 	updateDescription updateDescriptionFn,
@@ -123,6 +139,11 @@ func translateExitStatus(podName string, podStatus apiv1.PodStatus) error {
 	status := conds[0].State.Terminated
 	if status == nil {
 		return fmt.Errorf("Pod [ %s ] failed. Unable to determine status - %v", podName, podStatus.Message)
+	}
+
+	// return the termination message if it's not empty
+	if status.Message != "" {
+		return ErrorCustomMsg{msg: status.Message}
 	}
 
 	if status.ExitCode == 8 {

--- a/pkg/broker/jobs.go
+++ b/pkg/broker/jobs.go
@@ -83,6 +83,8 @@ func (j *apbJob) Run(token string, msgBuffer chan<- JobMsg) {
 
 		if err == apb.ErrorPodPullErr {
 			errMsg = err.Error()
+		} else if apb.IsErrorCustomMsg(err) {
+			errMsg = err.Error()
 		}
 
 		jobMsg.State.State = apb.StateFailed


### PR DESCRIPTION
#### Describe what this PR does and why we need it:
If the APB provision fails, this PR will check for a non-empty termination message, and will display it in the WebUI, instead of the generic error message.

#### Which issue this PR fixes (This will close that issue when PR gets merged)
fixes [#675](https://github.com/openshift/ansible-service-broker/issues/675)
