### PR TITLE
[wip] Update rbac.authorization.k8s.io to use v1 API instead of v1beta1

### DIFF
--- a/templates/deploy-ansible-service-broker.template.yaml
+++ b/templates/deploy-ansible-service-broker.template.yaml
@@ -47,7 +47,7 @@ objects:
     name: asb
     namespace: "${NAMESPACE}"
 
-- apiVersion: rbac.authorization.k8s.io/v1beta1
+- apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:
     name: asb
@@ -60,7 +60,7 @@ objects:
     name: asb
     namespace: "${NAMESPACE}"
 
-- apiVersion: rbac.authorization.k8s.io/v1beta1
+- apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRole
   metadata:
     name: asb-auth
@@ -98,7 +98,7 @@ objects:
     resources: ["bundles", "jobstates", "servicebindings", "serviceinstances"]
     verbs: ["*"]
 
-- apiVersion: rbac.authorization.k8s.io/v1beta1
+- apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:
     name: asb-auth-bind
@@ -111,7 +111,7 @@ objects:
     name: asb-auth
     apiGroup: rbac.authorization.k8s.io
 
-- apiVersion: rbac.authorization.k8s.io/v1beta1
+- apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRole
   metadata:
     name: access-asb-role
@@ -364,7 +364,7 @@ objects:
     name: ansibleservicebroker-client
     namespace: "${NAMESPACE}"
 
-- apiVersion: rbac.authorization.k8s.io/v1beta1
+- apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:
     name: ansibleservicebroker-client

--- a/templates/k8s-ansible-service-broker.yaml.j2
+++ b/templates/k8s-ansible-service-broker.yaml.j2
@@ -9,7 +9,7 @@ metadata:
   namespace: ansible-service-broker
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: asb-auth
@@ -32,7 +32,7 @@ rules:
   verbs: ["create", "delete"]
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: asb-auth-bind
@@ -46,7 +46,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: asb
@@ -60,7 +60,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: access-asb-role
@@ -298,7 +298,7 @@ metadata:
   namespace: ansible-service-broker
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: ansibleservicebroker-client
@@ -527,7 +527,7 @@ spec:
       JobToken:
         type: string
 
---- 
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/templates/simple-broker-template.yaml
+++ b/templates/simple-broker-template.yaml
@@ -45,7 +45,7 @@ objects:
     name: asb
     namespace: ansible-service-broker
 
-- apiVersion: rbac.authorization.k8s.io/v1beta1
+- apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:
     name: asb
@@ -58,7 +58,7 @@ objects:
     name: asb
     namespace: ansible-service-broker
 
-- apiVersion: rbac.authorization.k8s.io/v1beta1
+- apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRole
   metadata:
     name: asb-auth
@@ -92,7 +92,7 @@ objects:
     resources: ["networkpolicies"]
     verbs: ["create", "delete"]
 
-- apiVersion: rbac.authorization.k8s.io/v1beta1
+- apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:
     name: asb-auth-bind
@@ -105,7 +105,7 @@ objects:
     name: asb-auth
     apiGroup: rbac.authorization.k8s.io
 
-- apiVersion: rbac.authorization.k8s.io/v1beta1
+- apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRole
   metadata:
     name: access-asb-role
@@ -308,7 +308,7 @@ objects:
     name: ansibleservicebroker-client
     namespace: ansible-service-broker
 
-- apiVersion: rbac.authorization.k8s.io/v1beta1
+- apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:
     name: ansibleservicebroker-client
@@ -389,7 +389,7 @@ parameters:
 - description: APB Image Tag
   displayname: APB Image Tag
   name: TAG
-  value: sprint142 
+  value: sprint142
 
 - description: OpenShift User Password
   displayname: OpenShift User Password


### PR DESCRIPTION
#### Describe what this PR does and why we need it:
Updates the apiVersion for ClusterRoleBindings to use v1 API instead of v1beta1. Bringing up ASB in a Kubernetes cluster fails without this when using catasb in the local or EC2 env.

Changes made to three files:

- templates/deploy-ansible-service-broker.template.yaml
- templates/k8s-ansible-service-broker.yaml.j2
- templates/simple-broker-template.yaml