### PR TITLE
Bug 1558472 - Update openshift registry to use www-auth redirect header

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -162,7 +162,7 @@ registry:
       - ".*-apb$"
 ```
 
-There is a limitation when working with the OpenShift Registry right now. We have no capability to search the registry so we require that the user configure the broker with a list of images they would like to source from for when the broker bootstraps. The image name must be the fully qualified name without the registry URL.
+There is a limitation when working with the OpenShift Registry right now. We have no capability to search the registry so we require that the user configure the broker with a list of images they would like to source from for when the broker bootstraps. The image name must be the fully qualified name without the registry URL. The registry URL must also be prefixed with `https://` or `http://`.
 
 ### Multiple Registries Example
 You can use more then one registry to separate APBs into logical organizations and be able to manage them from the same broker. The main thing here is that the registries must have a unique non-empty name. If there is no unique name the service broker will fail to start with an error message alerting you to the problem.

--- a/pkg/registries/adapters/openshift_adapter.go
+++ b/pkg/registries/adapters/openshift_adapter.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2017 Red Hat, Inc.
+// Copyright (c) 2018 Red Hat, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,18 +18,17 @@ package adapters
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
-
-	b64 "encoding/base64"
+	"strings"
 
 	logging "github.com/op/go-logging"
 	"github.com/openshift/ansible-service-broker/pkg/apb"
 )
 
-const openShiftName = "registry.connect.redhat.com"
-const openShiftAuthURL = "https://sso.redhat.com/auth/realms/rhc4tp/protocol/docker-v2/auth?service=docker-registry"
-const openShiftManifestURL = "https://registry.connect.redhat.com/v2/%v/manifests/%v"
+const openShiftName = "openshift"
+const openShiftManifestURL = "%v/v2/%v/manifests/%v"
 
 // OpenShiftAdapter - Docker Hub Adapter
 type OpenShiftAdapter struct {
@@ -83,17 +82,43 @@ func (r OpenShiftAdapter) getOpenShiftAuthToken() (string, error) {
 	}
 	username := r.Config.User
 	password := r.Config.Pass
-	authString := fmt.Sprintf("%v:%v", username, password)
 
-	authString = b64.StdEncoding.EncodeToString([]byte(authString))
-
-	req, err := http.NewRequest("GET", openShiftAuthURL, nil)
+	req, err := http.NewRequest("GET", fmt.Sprintf("%v/v2/", r.Config.URL), nil)
 	if err != nil {
 		return "", err
 	}
-	req.Header.Set("Authorization", fmt.Sprintf("Basic %v", authString))
-
 	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	// Ensure that response holds data we expect
+	if resp.Header.Get("Www-Authenticate") == "" {
+		return "", errors.New("failed to find www-authenticate header from response")
+	}
+
+	authChallenge := resp.Header.Get("Www-Authenticate")
+	if strings.Index(authChallenge, "realm=\"") == -1 {
+		return "", errors.New("failed to find realm in www-authenticate header")
+	}
+	if strings.Index(authChallenge, ",") == -1 {
+		return "", errors.New("failed to find realm options in www-authenticate header")
+	}
+	authRealm := strings.Split(strings.Split(authChallenge, "realm=\"")[1], "\"")[0]
+	authOptions := strings.Split(authChallenge, ",")[1]
+	authURL := fmt.Sprintf("%v?%v", authRealm, authOptions)
+	// Replace any quotes that exist in header from authOptions
+	authURL = strings.Replace(authURL, "\"", "", -1)
+
+	req, err = http.NewRequest("GET", authURL, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.SetBasicAuth(username, password)
+
+	resp, err = http.DefaultClient.Do(req)
 	if err != nil {
 		return "", err
 	}
@@ -112,7 +137,7 @@ func (r OpenShiftAdapter) loadSpec(imageName string) (*apb.Spec, error) {
 	if r.Config.Tag == "" {
 		r.Config.Tag = "latest"
 	}
-	req, err := http.NewRequest("GET", fmt.Sprintf(openShiftManifestURL, imageName, r.Config.Tag), nil)
+	req, err := http.NewRequest("GET", fmt.Sprintf(openShiftManifestURL, r.Config.URL, imageName, r.Config.Tag), nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
#### Describe what this PR does and why we need it:
Updates the `openshift` registry adapter so that it uses the www-auth redirect and doesn't require us to use registry.connect.redhat.com.
#### Changes proposed in this pull request

 - Hit /v2/ to get www-authenticate header
 - Follow redirect to get Bearer token
 - Now attempt to get manifests
