### PR TITLE
Use the correct versions

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -918,6 +918,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "9bd8094990b524a64a33fd66716011369f0cb4731e5b8c62ccf0088db502b482"
+  inputs-digest = "4838a53e2d816870cec2f5fe8cfad4c024eed72fa6f8043d871093013c7670c1"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -22,6 +22,7 @@
 
 [[constraint]]
   name = "github.com/coreos/etcd"
+  version = "~3.3.0"
 
 [[constraint]]
   name = "github.com/gorilla/handlers"
@@ -36,7 +37,7 @@
   version = "~1.3.0"
 
 [[constraint]]
-  branch = "master"
+  version = "~0.1.0"
   name = "github.com/automationbroker/bundle-lib"
 
 [[constraint]]


### PR DESCRIPTION
#### Describe what this PR does and why we need it:
Make sure that a dep ensure does not cause broker developer to get a newer version of bundle-lib than we expect. 
