### PR TITLE
Warn in the logs that a spec failed to load and continue

### DIFF
--- a/pkg/dao/crd/dao.go
+++ b/pkg/dao/crd/dao.go
@@ -102,10 +102,10 @@ func (d *Dao) BatchSetSpecs(specs apb.SpecManifest) error {
 	for id, spec := range specs {
 		err := d.SetSpec(id, spec)
 		if err != nil {
-			return err
+			log.Warningf("Error loading SPEC '%v'", spec.FQName)
+			log.Debugf("SPEC '%v' error: %v", spec.FQName, err)
 		}
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
#### Describe what this PR does and why we need it:
Instead of failing when a spec fails to load, warn there was and error and output to debug the error.


#### Changes proposed in this pull request
 - No longer fail when we find a bad spec using crds

