### PR TITLE
Remind the user to give the developer cluster-admin

### DIFF
--- a/scripts/run_latest_build.sh
+++ b/scripts/run_latest_build.sh
@@ -131,3 +131,5 @@ fi
 #
 
 echo 'NOTE: You are currently logged in as "system:admin", if you intend to use the apb tool, is is required you log in as a user with a token. "developer" is recommended.'
+echo '    oc adm policy add-cluster-role-to-user cluster-admin developer'
+echo '    oc login -u developer'


### PR DESCRIPTION
#### Describe what this PR does and why we need it:
Lots of folks use ```run_latest_build.sh``` with the apb tool.  But, when ```run_latest_build.sh``` completes, the script suggests the user login to the developer user in order to use the apb tool.  The developer user by default doesn't have permission to contact the broker in the ansible-service-broker namespace so the apb tool isn't going to work.

#### Changes proposed in this pull request

 - Print a command to give the developer user cluster-admin
