### PR TITLE
Gather BROKER_CA_CERT more reliably

### DIFF
--- a/scripts/run_latest_build.sh
+++ b/scripts/run_latest_build.sh
@@ -87,7 +87,7 @@ oc new-project ansible-service-broker
 TEMPLATE_URL=${TEMPLATE_URL:-"https://raw.githubusercontent.com/openshift/ansible-service-broker/master/templates/deploy-ansible-service-broker.template.yaml"}
 DOCKERHUB_ORG=${DOCKERHUB_ORG:-"ansibleplaybookbundle"} # DocherHub org where APBs can be found, default 'ansibleplaybookbundle'
 ENABLE_BASIC_AUTH="false"
-VARS="-p BROKER_CA_CERT=$(oc get secret -n kube-service-catalog -o go-template='{{ range .items }}{{ if eq .type "kubernetes.io/service-account-token" }}{{ index .data "service-ca.crt" }}{{end}}{{"\n"}}{{end}}' | tail -n 1)"
+VARS="-p BROKER_CA_CERT=$(oc get secret -n kube-service-catalog | grep service-account-token | awk '{print $1}' | grep service-catalog-apiserver-token | tail -1 | xargs oc get secret -n kube-service-catalog -o jsonpath='{.data.service-ca\.crt}')"
 
 curl -s $TEMPLATE_URL \
   | oc process \


### PR DESCRIPTION
#### Describe what this PR does and why we need it:
Some cnv folks are launching the broker after they create an openshift cluster with run_latest_build.sh.  The script works fine since oc cluster up sees an already running cluster, but gathering the BROKER_CA_CERT comes up empty.  I'm not sure why the go-template filter comes up empty, but this new command has been more reliable.