### PR TITLE
Bug 1565648 - expose _apb_service_binding_id to bind role

### DIFF
--- a/docs/service-bundle.md
+++ b/docs/service-bundle.md
@@ -119,6 +119,7 @@ Example of JSON document passed to __bind__:
     },
     "_apb_service_class_id": "1dda1477cace09730bd8ed7a6505607e",
     "_apb_service_instance_id": "d6ac6b10-fbff-4944-8e6b-3478313e20d1",
+    "_apb_service_binding_id": "54636ad3-0378-49a1-a494-f97d0a0daf8e",
     "_apb_last_requesting_user": "admin",
     "cluster": "kubernetes",
     "namespace": "default"

--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -835,18 +835,22 @@ func (a AnsibleBroker) Bind(instance apb.ServiceInstance, bindingUUID uuid.UUID,
 		planParameterKey, plan.Name)
 
 	params[planParameterKey] = plan.Name
+
 	log.Debugf("Injecting ServiceClassID as parameter: { %s: %s }",
 		serviceClassIDKey, req.ServiceID)
-
 	params[serviceClassIDKey] = req.ServiceID
+
 	log.Debugf("Injecting ServiceInstanceID as parameter: { %s: %s }",
 		serviceInstIDKey, instance.ID.String())
-
 	params[serviceInstIDKey] = instance.ID.String()
 
 	log.Debugf("Injecting lastRequestingUserKey as parameter: { %s: %s }",
 		lastRequestingUserKey, getLastRequestingUser(userInfo))
 	params[lastRequestingUserKey] = getLastRequestingUser(userInfo)
+
+	log.Debugf("Injecting ServiceBindingID as parameter: { %s: %s }",
+		serviceBindingIDKey, bindingUUID.String())
+	params[serviceBindingIDKey] = bindingUUID.String()
 
 	// Create a BindingInstance with a reference to the serviceinstance.
 	bindingInstance := &apb.BindInstance{

--- a/pkg/broker/types.go
+++ b/pkg/broker/types.go
@@ -35,6 +35,7 @@ const (
 	serviceClassIDKey     = "_apb_service_class_id"
 	serviceInstIDKey      = "_apb_service_instance_id"
 	lastRequestingUserKey = "_apb_last_requesting_user"
+	serviceBindingIDKey   = "_apb_service_binding_id"
 )
 
 // WorkTopic - Topic jobs can publish messages to, and subscribers can listen to


### PR DESCRIPTION
#### Describe what this PR does and why we need it:

This PR exposes a new parameter `_apb_service_binding_id` to the bind role that contains the externalId of the associated service binding. This is useful in cases where you want to trigger `unbind` by deleting the service instance.


#### Changes proposed in this pull request

- Add `_apb_service_binding_id` to the injected parameters for the `Bind` action.

#### Does this PR depend on another PR (Use this to track when PRs should be merged)
No

#### Which issue this PR fixes (This will close that issue when PR gets merged)
fixes https://bugzilla.redhat.com/show_bug.cgi?id=1565648

ping @maleck13 @shawn-hurley 