### PR TITLE
Lock version in template

### DIFF
--- a/templates/simple-broker-template.yaml
+++ b/templates/simple-broker-template.yaml
@@ -130,7 +130,7 @@ objects:
       spec:
         serviceAccount: asb
         containers:
-        - image: ansibleplaybookbundle/origin-ansible-service-broker:latest
+        - image: ansibleplaybookbundle/origin-ansible-service-broker:release-1.1
           name: asb
           imagePullPolicy: IfNotPresent
           volumeMounts:
@@ -373,7 +373,7 @@ parameters:
 - description: APB Image Tag
   displayname: APB Image Tag
   name: TAG
-  value: latest
+  value: release-1.1
 
 - description: OpenShift User Password
   displayname: OpenShift User Password


### PR DESCRIPTION
Not super important, but this makes it so that the simple-broker-template on the `release-1.1` branch is using the correct container images.
