### PR TITLE
Issue 882 - Simple broker template should use release-1.1 instead of a sprint tag

### DIFF
--- a/templates/simple-broker-template.yaml
+++ b/templates/simple-broker-template.yaml
@@ -146,7 +146,7 @@ objects:
       spec:
         serviceAccount: asb
         containers:
-        - image: ansibleplaybookbundle/origin-ansible-service-broker:sprint142
+        - image: ansibleplaybookbundle/origin-ansible-service-broker:release-1.1
           name: asb
           imagePullPolicy: IfNotPresent
           volumeMounts:
@@ -389,7 +389,7 @@ parameters:
 - description: APB Image Tag
   displayname: APB Image Tag
   name: TAG
-  value: sprint142 
+  value: release-1.1
 
 - description: OpenShift User Password
   displayname: OpenShift User Password


### PR DESCRIPTION
#### Describe what this PR does and why we need it:

Update the images used by the simple-broker-template to be release-1.1 branch.

```
$ docker run -it --entrypoint asbd docker.io/ansibleplaybookbundle/origin-ansible-service-broker:sprint142 --version
1.1.3

$ docker run -it --entrypoint asbd docker.io/ansibleplaybookbundle/origin-ansible-service-broker:release-1.1 --version
1.1.15
```

#### Which issue this PR fixes (This will close that issue when PR gets merged)
fixes #882 
