### PR TITLE
pass ROUTING_SUFFIX parameter

### DIFF
--- a/scripts/run_latest_build.sh
+++ b/scripts/run_latest_build.sh
@@ -95,6 +95,7 @@ curl -s $TEMPLATE_URL \
   -p DOCKERHUB_ORG="$DOCKERHUB_ORG" \
   -p ENABLE_BASIC_AUTH="$ENABLE_BASIC_AUTH" \
   -p NAMESPACE=ansible-service-broker \
+  -p ROUTING_SUFFIX="$ROUTING_SUFFIX" \
   $VARS -f - | oc create -f -
 if [ "$?" -ne 0 ]; then
   echo "Error processing template and creating deployment"


### PR DESCRIPTION
pass ROUTING_SUFFIX parameter to deploy-ansible-service-broker template

#### Describe what this PR does and why we need it:
ROUTING_SUFFIX is having default value in deploy-ansible-service-broker template.
It may have different value if user wishes.

So, pass the same as parameter.

#### Changes proposed in this pull request

 - Pass ROUTING_SUFFIX as a parameter to deploy-ansible-service-broker template
 
 


