### PR TITLE
Bug 1533425 - protect against simultaneous updates

### DIFF
--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -951,7 +951,7 @@ func (a AnsibleBroker) Bind(instance apb.ServiceInstance, bindingUUID uuid.UUID,
 			return nil, false, err
 		}
 
-		stateKey, err := a.dao.SetState(instance.ID.String(), apb.JobState{
+		stateKey, err := a.dao.SetState(bindingUUID.String(), apb.JobState{
 			Token:  token,
 			State:  apb.StateInProgress,
 			Method: apb.JobMethodBind,
@@ -960,6 +960,7 @@ func (a AnsibleBroker) Bind(instance apb.ServiceInstance, bindingUUID uuid.UUID,
 			log.Errorf("failed to set initial jobstate for %v, %v", token, err.Error())
 			return nil, false, err
 		}
+
 		bindingInstance.CreateJobKey = stateKey
 		if err := a.dao.SetBindInstance(bindingUUID.String(), bindingInstance); err != nil {
 			return nil, false, err
@@ -1073,13 +1074,13 @@ func (a AnsibleBroker) Unbind(
 			return nil, false, jerr
 		}
 
-		if _, err := a.dao.SetState(serviceInstance.ID.String(), apb.JobState{
-			Token:  token,
-			State:  apb.StateInProgress,
-			Method: apb.JobMethodUnbind,
-		}); err != nil {
-			log.Errorf("failed to set initial jobstate for %v, %v", token, err.Error())
-		}
+		// if _, err := a.dao.SetState(bindInstance.ID.String(), apb.JobState{
+		//     Token:  token,
+		//     State:  apb.StateInProgress,
+		//     Method: apb.JobMethodUnbind,
+		// }); err != nil {
+		//     log.Errorf("failed to set initial jobstate for %v, %v", token, err.Error())
+		// }
 		return &UnbindResponse{Operation: token}, true, nil
 
 	} else if a.brokerConfig.LaunchApbOnBind {

--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -1074,13 +1074,6 @@ func (a AnsibleBroker) Unbind(
 			return nil, false, jerr
 		}
 
-		// if _, err := a.dao.SetState(bindInstance.ID.String(), apb.JobState{
-		//     Token:  token,
-		//     State:  apb.StateInProgress,
-		//     Method: apb.JobMethodUnbind,
-		// }); err != nil {
-		//     log.Errorf("failed to set initial jobstate for %v, %v", token, err.Error())
-		// }
 		return &UnbindResponse{Operation: token}, true, nil
 
 	} else if a.brokerConfig.LaunchApbOnBind {

--- a/pkg/broker/types.go
+++ b/pkg/broker/types.go
@@ -118,7 +118,7 @@ type ServiceInstance struct {
 	Update map[string]*schema.Schema `json:"update"`
 }
 
-// ServiceBinding - Schema definitions for creating a service binidng.
+// ServiceBinding - Schema definitions for creating a service binding.
 type ServiceBinding struct {
 	Create map[string]*schema.Schema `json:"create"`
 }

--- a/pkg/dao/crd/dao.go
+++ b/pkg/dao/crd/dao.go
@@ -200,7 +200,7 @@ func (d *Dao) DeleteServiceInstance(id string) error {
 
 // GetBindInstance - Retrieve a specific bind instance from the kvp API
 func (d *Dao) GetBindInstance(id string) (*apb.BindInstance, error) {
-	log.Debugf("get binidng instance: %v", id)
+	log.Debugf("get binding instance: %v", id)
 	bi, err := d.client.ServiceBindings(d.namespace).Get(id, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
@@ -223,7 +223,18 @@ func (d *Dao) SetBindInstance(id string, bindInstance *apb.BindInstance) error {
 		Spec: b,
 	}
 	_, err = d.client.ServiceBindings(d.namespace).Create(&bi)
-	if err != nil {
+	if err != nil && apierrors.IsAlreadyExists(err) {
+		// looks like we already have this state, probably created by
+		// another goroutine. Let's try to update the existing one instead.
+		if binding, err := d.client.ServiceBindings(d.namespace).Get(id, metav1.GetOptions{}); err == nil {
+			binding.Spec = b
+			_, err := d.client.ServiceBindings(d.namespace).Update(binding)
+			if err != nil {
+				log.Errorf("Unable to update the service binding, after a failed creation: %v - %v", id, err)
+				return err
+			}
+		}
+	} else if err != nil {
 		log.Errorf("unable to save service binding - %v", err)
 		return err
 	}
@@ -240,10 +251,12 @@ func (d *Dao) DeleteBindInstance(id string) error {
 // SetState - Set the Job State in the kvp API for id.
 func (d *Dao) SetState(instanceID string, state apb.JobState) (string, error) {
 	log.Debugf("set job state for instance: %v token: %v", instanceID, state.Token)
+
 	j, err := crd.ConvertJobStateToCRD(&state)
 	if err != nil {
 		return "", err
 	}
+
 	if js, err := d.client.JobStates(d.namespace).Get(state.Token, metav1.GetOptions{}); err == nil {
 		js.Spec = j
 		js.ObjectMeta.Labels[jobStateLabel] = fmt.Sprintf("%v", crd.ConvertStateToCRD(state.State))
@@ -255,6 +268,7 @@ func (d *Dao) SetState(instanceID string, state apb.JobState) (string, error) {
 		return state.Token, nil
 	}
 
+	// We didn't find an existing JobState, so let's create a new one
 	js := v1.JobState{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      state.Token,
@@ -266,11 +280,27 @@ func (d *Dao) SetState(instanceID string, state apb.JobState) (string, error) {
 		Spec: j,
 	}
 
+	// Create the actual JobState CRD
 	_, err = d.client.JobStates(d.namespace).Create(&js)
-	if err != nil {
+	if err != nil && apierrors.IsAlreadyExists(err) {
+		// looks like we already have this state, probably created by
+		// another goroutine. Let's try to update the existing one instead.
+		if js, err := d.client.JobStates(d.namespace).Get(state.Token, metav1.GetOptions{}); err == nil {
+			js.Spec = j
+			js.ObjectMeta.Labels[jobStateLabel] = fmt.Sprintf("%v", crd.ConvertStateToCRD(state.State))
+			_, err := d.client.JobStates(d.namespace).Update(js)
+			if err != nil {
+				log.Errorf("Unable to update the job state, after a failed creation: %v - %v", state.Token, err)
+				return state.Token, err
+			}
+		}
+	} else if err != nil {
+		// something else happened, bailing
 		log.Errorf("unable to create the job state - %v", err)
 		return "", err
 	}
+
+	// looks like we're good
 	return state.Token, nil
 }
 


### PR DESCRIPTION
protect against simultaneous updates

Simultaneous calls to SetState or SetBindingInstance would fail with an already exists error instead of graciously updating the existing instances.

Also, the broker.Bind was incorrectly trying to set the state of a binding job using the instance id as the key, vs use bindingid for state in bindings
