### PR TITLE
Bug 1567004 - Delete extracted credentials secret during synchronous unbind

### DIFF
--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -1096,7 +1096,11 @@ func (a AnsibleBroker) Unbind(
 	} else {
 		log.Warning("Broker configured to *NOT* launch and run APB unbind")
 		if err := a.dao.DeleteBinding(bindInstance, serviceInstance); err != nil {
-			log.Errorf("failed to delete binding when launch_apb_on_bind is false: %v", err)
+			log.Errorf("Failed to delete binding when launch_apb_on_bind is false: %v", err)
+			return nil, false, err
+		}
+		if err := apb.DeleteExtractedCredentials(bindInstance.ID.String()); err != nil {
+			log.Errorf("Failed to delete extracted credentials secret when launch_apb_on_bind is false: %v", err)
 			return nil, false, err
 		}
 	}


### PR DESCRIPTION

#### Describe what this PR does and why we need it:
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1567004

Without this, each synchronous bind operation (not using `launch_apb_on_bind`) creates a secret in broker namespace that will never get deleted. 

This appears to only be an issue with synchronous bind, as bundle-lib handles this in [unbind.go](https://github.com/automationbroker/bundle-lib/blob/master/bundle/unbind.go#L62).
#### Changes proposed in this pull request

 - Add `apb.DeleteExtractedCredentials` call to the synchronous unbind code path