### PR TITLE
fix statements with formatting

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -42,7 +42,7 @@ import (
 	"github.com/automationbroker/bundle-lib/registries"
 	agnosticruntime "github.com/automationbroker/bundle-lib/runtime"
 	"github.com/automationbroker/config"
-	"github.com/jessevdk/go-flags"
+	flags "github.com/jessevdk/go-flags"
 	"github.com/openshift/ansible-service-broker/pkg/auth"
 	"github.com/openshift/ansible-service-broker/pkg/broker"
 	"github.com/openshift/ansible-service-broker/pkg/dao"
@@ -336,7 +336,7 @@ func (a *App) Start() {
 	}
 
 	interval, err := time.ParseDuration(a.config.GetString("broker.refresh_interval"))
-	log.Debug("RefreshInterval: %v", interval.String())
+	log.Debugf("RefreshInterval: %v", interval.String())
 	if err != nil {
 		log.Error(err.Error())
 		log.Error("Not using a refresh interval")
@@ -348,8 +348,8 @@ func (a *App) Start() {
 			for {
 				select {
 				case v := <-ticker.C:
-					log.Info("Broker configured to refresh specs every %v seconds", interval)
-					log.Info("Attempting bootstrap at %v", v.UTC())
+					log.Infof("Broker configured to refresh specs every %v seconds", interval)
+					log.Infof("Attempting bootstrap at %v", v.UTC())
 					if _, err := a.broker.Bootstrap(); err != nil {
 						log.Error("Failed to bootstrap")
 						log.Error(err.Error())

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -42,7 +42,7 @@ import (
 	"github.com/automationbroker/bundle-lib/registries"
 	agnosticruntime "github.com/automationbroker/bundle-lib/runtime"
 	"github.com/automationbroker/config"
-	flags "github.com/jessevdk/go-flags"
+	"github.com/jessevdk/go-flags"
 	"github.com/openshift/ansible-service-broker/pkg/auth"
 	"github.com/openshift/ansible-service-broker/pkg/broker"
 	"github.com/openshift/ansible-service-broker/pkg/dao"

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -87,12 +87,12 @@ func (d *FileUserServiceAdapter) buildDB() error {
 	passfile := path.Join(d.filedir, "password")
 	username, uerr := ioutil.ReadFile(userfile)
 	if uerr != nil {
-		log.Error("Error reading username. %v", uerr.Error())
+		log.Errorf("Error reading username. %v", uerr.Error())
 		return uerr
 	}
 	password, perr := ioutil.ReadFile(passfile)
 	if perr != nil {
-		log.Error("Error reading password. %v", perr.Error())
+		log.Errorf("Error reading password. %v", perr.Error())
 		return perr
 	}
 
@@ -158,7 +158,7 @@ func GetProviders(authConfig *config.Config) []Provider {
 		if p.GetBool("enabled") {
 			provider, err := createProvider(p.GetString("type"))
 			if err != nil {
-				log.Warning("Unable to create provider for %v. %v", p, err)
+				log.Warningf("Unable to create provider for %v. %v", p, err)
 				continue
 			}
 			providers = append(providers, provider)

--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -188,20 +188,20 @@ func (a AnsibleBroker) Bootstrap() (*BootstrapResponse, error) {
 	dir := "/spec"
 	specs, err = a.dao.BatchGetSpecs(dir)
 	if err != nil {
-		log.Error("Something went real bad trying to retrieve batch specs for deletion... - %v", err)
+		log.Errorf("Something went real bad trying to retrieve batch specs for deletion... - %v", err)
 		return nil, err
 	}
 	// Save all apb-push sourced specs
 	for _, spec := range specs {
 		if strings.HasPrefix(spec.FQName, "apb-push") {
-			log.Info("Saving apb-push sourced spec to prevent deletion: %v", spec.FQName)
+			log.Infof("Saving apb-push sourced spec to prevent deletion: %v", spec.FQName)
 			pushedSpecs = append(pushedSpecs, spec)
 		}
 	}
 
 	err = a.dao.BatchDeleteSpecs(specs)
 	if err != nil {
-		log.Error("Something went real bad trying to delete batch specs... - %v", err)
+		log.Errorf("Something went real bad trying to delete batch specs... - %v", err)
 		return nil, err
 	}
 	specs = []*apb.Spec{}
@@ -410,7 +410,7 @@ func (a AnsibleBroker) Recover() (string, error) {
 			// NO, pod failed.
 			if extErr != nil {
 				log.Error("broker::Recover error occurred.")
-				log.Error("%s", extErr.Error())
+				log.Errorf("%s", extErr.Error())
 				return "", extErr
 			}
 
@@ -426,7 +426,7 @@ func (a AnsibleBroker) Recover() (string, error) {
 				err = apb.SetExtractedCredentials(instanceID, extCreds)
 				if err != nil {
 					log.Error("Could not persist extracted credentials")
-					log.Error("%s", err.Error())
+					log.Errorf("%s", err.Error())
 					return "", err
 				}
 			}
@@ -645,7 +645,7 @@ func (a AnsibleBroker) Provision(instanceUUID uuid.UUID, req *ProvisionRequest, 
 		// asyncronously provision and return the token for the lastoperation
 		token, err = a.engine.StartNewAsyncJob(token, pjob, ProvisionTopic)
 		if err != nil {
-			log.Error("Failed to start new job for async provision\n%s", err.Error())
+			log.Errorf("Failed to start new job for async provision\n%s", err.Error())
 			return nil, err
 		}
 	} else {
@@ -723,7 +723,7 @@ func (a AnsibleBroker) Deprovision(
 
 		token, err = a.engine.StartNewAsyncJob(token, dpjob, DeprovisionTopic)
 		if err != nil {
-			log.Error("Failed to start new job for async deprovision\n%s", err.Error())
+			log.Errorf("Failed to start new job for async deprovision\n%s", err.Error())
 			return nil, err
 		}
 		return &DeprovisionResponse{Operation: token}, nil
@@ -947,7 +947,7 @@ func (a AnsibleBroker) Bind(instance apb.ServiceInstance, bindingUUID uuid.UUID,
 		log.Info("ASYNC binding in progress")
 		token, err = a.engine.StartNewAsyncJob("", bindingJob, BindingTopic)
 		if err != nil {
-			log.Error("Failed to start new job for async binding\n%s", err.Error())
+			log.Errorf("Failed to start new job for async binding\n%s", err.Error())
 			return nil, false, err
 		}
 
@@ -1069,7 +1069,7 @@ func (a AnsibleBroker) Unbind(
 
 		token, jerr = a.engine.StartNewAsyncJob("", unbindJob, UnbindingTopic)
 		if jerr != nil {
-			log.Error("Failed to start new job for async unbind\n%s", jerr.Error())
+			log.Errorf("Failed to start new job for async unbind\n%s", jerr.Error())
 			return nil, false, jerr
 		}
 
@@ -1236,7 +1236,7 @@ func (a AnsibleBroker) Update(instanceUUID uuid.UUID, req *UpdateRequest, async 
 
 	fromPlan, ok = spec.GetPlan(fromPlanName)
 	if !ok {
-		log.Error("The plan %s, specified for updating from on instance %s, does not exist.", fromPlanName, si.ID)
+		log.Errorf("The plan %s, specified for updating from on instance %s, does not exist.", fromPlanName, si.ID)
 		return nil, ErrorPlanNotFound
 	}
 
@@ -1255,7 +1255,7 @@ func (a AnsibleBroker) Update(instanceUUID uuid.UUID, req *UpdateRequest, async 
 
 		toPlan, ok = spec.GetPlanFromID(req.PlanID)
 		if !ok {
-			log.Error("Could not find requested PlanID %s in plan name lookup table", req.PlanID)
+			log.Errorf("Could not find requested PlanID %s in plan name lookup table", req.PlanID)
 			return nil, ErrorPlanNotFound
 		}
 	}
@@ -1263,9 +1263,9 @@ func (a AnsibleBroker) Update(instanceUUID uuid.UUID, req *UpdateRequest, async 
 	// If a plan transition has been requested, validate it is possible and then
 	// update the service instance with the desired next plan
 	if fromPlan.Name != toPlan.Name {
-		log.Debug("Validating plan transition from: %s, to: %s", fromPlan.Name, toPlan.Name)
+		log.Debugf("Validating plan transition from: %s, to: %s", fromPlan.Name, toPlan.Name)
 		if ok := a.isValidPlanTransition(fromPlan, toPlan.Name); !ok {
-			log.Error("The current plan, %s, cannot be updated to the requested plan, %s.", fromPlan.Name, toPlan.Name)
+			log.Errorf("The current plan, %s, cannot be updated to the requested plan, %s.", fromPlan.Name, toPlan.Name)
 			return nil, ErrorPlanUpdateNotPossible
 		}
 
@@ -1309,7 +1309,7 @@ func (a AnsibleBroker) Update(instanceUUID uuid.UUID, req *UpdateRequest, async 
 		// asyncronously provision and return the token for the lastoperation
 		token, err = a.engine.StartNewAsyncJob(token, ujob, UpdateTopic)
 		if err != nil {
-			log.Error("Failed to start new job for async update\n%s", err.Error())
+			log.Errorf("Failed to start new job for async update\n%s", err.Error())
 			return nil, err
 		}
 	} else {
@@ -1370,7 +1370,7 @@ func (a AnsibleBroker) validateRequestedUpdateParams(
 			// the v1.0 ServiceInstance. These new keys should be passed to the APB,
 			// along with any changed values to the existing parameters, so the APB
 			// can make sense of them.
-			log.Notice("Requested update parameter: [%v] with the value of [%v] was found " +
+			log.Noticef("Requested update parameter: [%v] with the value of [%v] was found " +
 				"in an update request, but it did not exist on the previous service instance.")
 		}
 	}
@@ -1457,12 +1457,12 @@ func (a AnsibleBroker) RemoveSpec(specID string) error {
 		return ErrorNotFound
 	}
 	if err != nil {
-		log.Error("Something went real bad trying to retrieve spec for deletion... - %v", err)
+		log.Errorf("Something went real bad trying to retrieve spec for deletion... - %v", err)
 		return err
 	}
 	err = a.dao.DeleteSpec(spec.ID)
 	if err != nil {
-		log.Error("Something went real bad trying to delete spec... - %v", err)
+		log.Errorf("Something went real bad trying to delete spec... - %v", err)
 		return err
 	}
 	metrics.SpecsUnloaded(apbPushRegName, 1)
@@ -1474,12 +1474,12 @@ func (a AnsibleBroker) RemoveSpecs() error {
 	dir := "/spec"
 	specs, err := a.dao.BatchGetSpecs(dir)
 	if err != nil {
-		log.Error("Something went real bad trying to retrieve batch specs for deletion... - %v", err)
+		log.Errorf("Something went real bad trying to retrieve batch specs for deletion... - %v", err)
 		return err
 	}
 	err = a.dao.BatchDeleteSpecs(specs)
 	if err != nil {
-		log.Error("Something went real bad trying to delete batch specs... - %v", err)
+		log.Errorf("Something went real bad trying to delete batch specs... - %v", err)
 		return err
 	}
 	metrics.SpecsLoadedReset()

--- a/pkg/broker/job_state_subscriber.go
+++ b/pkg/broker/job_state_subscriber.go
@@ -96,6 +96,6 @@ func (jss *JobStateSubscriber) cleanupAfterUnbind(msg JobMsg) error {
 	if err := jss.dao.DeleteBinding(*bindInstance, *svcInstance); err != nil {
 		return setFailed(fmt.Errorf("Error cleaning up binding instance [ %s ] during cleanup of unbind job : %v", bindInstance.ID.String(), err))
 	}
-	log.Info("Clean up of binding instance [ %s ] done. Unbinding successful", bindInstance.ID.String())
+	log.Infof("Clean up of binding instance [ %s ] done. Unbinding successful", bindInstance.ID.String())
 	return nil
 }

--- a/pkg/broker/work_engine.go
+++ b/pkg/broker/work_engine.go
@@ -82,7 +82,7 @@ func (engine *WorkEngine) startJob(token string, work Work, topic WorkTopic) {
 	engine.jobChannels[token] = jobChannel
 	// ensure we always clean up
 	defer func() {
-		log.Debug("closing channel for job ", token)
+		log.Debugf("closing channel for job %v", token)
 		close(jobChannel)
 		delete(engine.jobChannels, token)
 	}()

--- a/pkg/dao/crd/dao.go
+++ b/pkg/dao/crd/dao.go
@@ -93,7 +93,7 @@ func (d *Dao) SetSpec(id string, spec *apb.Spec) error {
 
 // DeleteSpec - Delete the spec for a given spec id.
 func (d *Dao) DeleteSpec(specID string) error {
-	log.Debug("Dao::DeleteSpec-> [ %s ]", specID)
+	log.Debugf("Dao::DeleteSpec-> [ %s ]", specID)
 	return d.client.Bundles(d.namespace).Delete(specID, &metav1.DeleteOptions{})
 }
 

--- a/pkg/dao/etcd/dao.go
+++ b/pkg/dao/etcd/dao.go
@@ -88,7 +88,7 @@ func (d *Dao) BatchGetRaw(dir string) (*[]string, error) {
 	specNodes := res.Node.Nodes
 	specCount := len(specNodes)
 
-	log.Debug("Successfully loaded [ %d ] objects from etcd dir [ %s ]", specCount, dir)
+	log.Debugf("Successfully loaded [ %d ] objects from etcd dir [ %s ]", specCount, dir)
 
 	payloads := make([]string, specCount)
 	for i, node := range specNodes {
@@ -146,7 +146,7 @@ func (d *Dao) BatchGetSpecs(dir string) ([]*apb.Spec, error) {
 		spec := &apb.Spec{}
 		apb.LoadJSON(payload, spec)
 		specs[i] = spec
-		log.Debug("Batch idx [ %d ] -> [ %s ]", i, spec.ID)
+		log.Debugf("Batch idx [ %d ] -> [ %s ]", i, spec.ID)
 	}
 
 	return specs, nil
@@ -178,7 +178,7 @@ func (d *Dao) FindJobStateByState(state apb.State) ([]apb.RecoverStatus, error) 
 	stateNodes := res.Node.Nodes
 	stateCount := len(stateNodes)
 
-	log.Debug("Successfully loaded [ %d ] jobstate objects from etcd dir [ /state/ ]", stateCount)
+	log.Debugf("Successfully loaded [ %d ] jobstate objects from etcd dir [ /state/ ]", stateCount)
 
 	var recoverstatus []apb.RecoverStatus
 	for _, node := range stateNodes {
@@ -256,7 +256,7 @@ func (d *Dao) getJobsForSvcInst(instanceID string) ([]apb.JobState, error) {
 		return []apb.JobState{}, nil
 	}
 
-	log.Debug("Successfully loaded [ %d ] jobs objects from [ %s ]",
+	log.Debugf("Successfully loaded [ %d ] jobs objects from [ %s ]",
 		jobsCount, lookupKey)
 
 	retJobs := []apb.JobState{}


### PR DESCRIPTION
Making broker consistent with the log statements in bundle-lib, i.e. use
the *f version when logging formatting strings. It is most important
when using logrus, go-logging seems to handle it okay. But this PR will
make it easier to move to logrus in the future.

See PR #61 from bundle-lib for more information:

https://github.com/automationbroker/bundle-lib/pull/61