### PR TITLE
Use git clone for canary

### DIFF
--- a/build/Dockerfile-canary
+++ b/build/Dockerfile-canary
@@ -38,7 +38,7 @@ ENV GOPATH=/go
 ENV BROKER_PATH=${GOPATH}/src/github.com/openshift/ansible-service-broker
 
 RUN mkdir -p ${BROKER_PATH}
-ADD . ${BROKER_PATH}
+RUN git clone -b $VERSION https://github.com/openshift/ansible-service-broker ${BROKER_PATH}/ansible-service-broker
 WORKDIR ${BROKER_PATH}
 
 RUN go build -i -ldflags="-s -w" ./cmd/broker && mv broker /usr/bin/asbd
@@ -49,7 +49,7 @@ RUN go build -i -ldflags="-s -w" ./cmd/dashboard-redirector && mv dashboard-redi
 # BUILD BROKER SOURCE
 ######################
 
-COPY build/entrypoint.sh /usr/bin/
+COPY entrypoint.sh /usr/bin/
 
 RUN chown -R ${USER_NAME}:0 /var/log/ansible-service-broker \
  && chown -R ${USER_NAME}:0 /etc/ansible-service-broker \


### PR DESCRIPTION
Turns out that dockerhub doesn't allow you to configure the
build-context (unlike cloud.docker). However, since this is an openshift
repository, it isn't straightforward how to configure automated builds
for cloud.docker. Instead of wasting time trying to figure that out.
Just revert back to the git clone method for now.