### PR TITLE
[wip] Use run_latest_build with existing clusters

### DIFF
--- a/scripts/run_latest_build.sh
+++ b/scripts/run_latest_build.sh
@@ -70,10 +70,7 @@ else
         --public-hostname=${HOSTNAME}
 fi
 
-if [ "$?" -ne 0 ]; then
-    echo "Error starting cluster"
-    exit
-fi
+set -e
 
 #
 # Logging in as system:admin so we can create a clusterrolebinding and


### PR DESCRIPTION
#### Describe what this PR does and why we need it:
Remove the check on a failed oc cluster up so that folks can run this script on a pre-existing cluster.