### PR TITLE
Fix RBAC and CRDs in k8s template

### DIFF
--- a/templates/k8s-ansible-service-broker.yaml.j2
+++ b/templates/k8s-ansible-service-broker.yaml.j2
@@ -29,7 +29,7 @@ rules:
   verbs: ["create", "delete"]
 - apiGroups: ["automationbroker.io"]
   attributeRestrictions: null
-  resources: ["bundles", "bundlebindings", "bundleinstances"]
+  resources: ["bundles", "bundlebindings", "bundleinstances", "jobstates"]
   verbs: ["*"]
 
 ---
@@ -257,9 +257,9 @@ spec:
   version: v1alpha1
   scope: Namespaced
   names:
-    plural: servicebindings
-    singular: servicebinding
-    kind: ServiceBinding
+    plural: bundlebindings
+    singular: bundlebinding
+    kind: BundleBinding
 
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -271,6 +271,6 @@ spec:
   version: v1alpha1
   scope: Namespaced
   names:
-    plural: serviceinstances
-    singular: serviceinstance
-    kind: ServiceInstance
+    plural: bundleinstances
+    singular: bundleinstance
+    kind: BundleInstance


### PR DESCRIPTION
#### Describe what this PR does and why we need it:

This PR fixes two issues with the K8s template:
 * it adds the `jobstates` resource to the `asb-auth` ClusterRole
 * it fixes the copy&paste error in the `bundlebindings` and `bundleinstances` CRDs
