### PR TITLE
Run the apb in a different project

### DIFF
--- a/apb/install.yaml
+++ b/apb/install.yaml
@@ -2,14 +2,14 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: automation-broker
+  name: automation-broker-apb
 
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: automation-broker-apb
-  namespace: automation-broker
+  namespace: automation-broker-apb
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -23,14 +23,14 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: automation-broker-apb
-  namespace: automation-broker
+  namespace: automation-broker-apb
 
 ---
 apiVersion: batch/v1
 kind: Job
 metadata:
   name: install-automation-broker-apb
-  namespace: automation-broker
+  namespace: automation-broker-apb
 spec:
   template:
     spec:
@@ -38,6 +38,6 @@ spec:
       containers:
         - name: apb
           image: docker.io/automationbroker/automation-broker-apb:latest
-          args: [ "provision" ]
+          args: [ "provision", "-e create_broker_namespace=true" ]
       restartPolicy: Never
   backoffLimit: 4


### PR DESCRIPTION
Turns out that I had already worked around the problem the project vs. namespace problem in the apb. If I let the apb create the project then there are no issues.