### PR TITLE
Bug 1572470 - use binding id as instance, do not error on conflict

### DIFF
--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -1005,17 +1005,7 @@ func (a AnsibleBroker) Bind(instance apb.ServiceInstance, bindingUUID uuid.UUID,
 			return nil, false, err
 		}
 
-		stateKey, err := a.dao.SetState(bindingUUID.String(), apb.JobState{
-			Token:  token,
-			State:  apb.StateInProgress,
-			Method: apb.JobMethodBind,
-		})
-		if err != nil {
-			log.Errorf("failed to set initial jobstate for %v, %v", token, err.Error())
-			return nil, false, err
-		}
-
-		bindingInstance.CreateJobKey = stateKey
+		bindingInstance.CreateJobKey = fmt.Sprintf("/state/%s/job/%s", bindingUUID.String(), token)
 		if err := a.dao.SetBindInstance(bindingUUID.String(), bindingInstance); err != nil {
 			return nil, false, err
 		}

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -729,6 +729,11 @@ func (h handler) lastoperation(w http.ResponseWriter, r *http.Request, params ma
 			}
 			return
 		}
+
+		//
+		// Since we have a binding, let's use the binding id as the instance id
+		//
+		instanceUUID = bindingUUID
 	}
 
 	req := broker.LastOperationRequest{}


### PR DESCRIPTION
* CRDs use the binding id alone switched to using binding id.
* Generate the statekey for use in etcd in the broker.go
* Make logs informative, some now include the k8s reason
* A conflicting update is now simply logged and skipped