### PR TITLE
Support building a debuggable image for development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ build/broker
 build/migration
 /dashboard-redirector
 build/dashboard-redirector
+build/dlv
 
 # python artifacts
 .python-version

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,7 +125,7 @@ image with the broker, there are a few things worth pointing out:
   [deploy-ansible-service-broker template](templates/deploy-ansible-service-broker.template.yaml)
   shows that the `broker-config` is included as `config-volume` in the `asb` container and mounted at
   `/etc/ansible-service-broker`.
-- The entrypoint to the image is [entrypoint.sh](build/entrypoint.sh). This script is what starts
+- The entrypoint to the image is [dev-entrypoint.sh](build/dev-entrypoint.sh). This script is what starts
   the broker when deployed as a container.
 
 Once you have a built Docker image, you can [deploy broker from image](#deploy-broker-from-image)
@@ -139,6 +139,26 @@ are a couple of options for running, testing, and debugging the broker. You can
 [run the broker binary locally](#run-your-broker-locally) **or**, assuming you
 [built a Docker image](#package-your-broker-using-docker), you can
 [deploy your broker](#deploy-broker-from-image) into a running cluster.
+
+## Remotely debugging Your Broker
+
+Both the canary build and the image built via `make build-image` and `make build-dev` support remote debugging.
+To enable debugging of these containers within OpenShift, `DEBUG_ENABLED` must be set as an
+environment variable with a value of `True`.
+
+You need to enable a TCP connection to the service. The easiest way to do this is via port forwarding.
+There is a script provided to automate all required configuration to support this at `scripts/prep_debug_env.sh`.
+
+This script takes three arguments:
+* Debug port. The default value is `9000`.
+* The namespace that the broker is running in. Default value is `automation-broker`
+* The broker deployment name. Default value is `automation-broker`
+
+Running this script automates a number of steps for you:
+* Removes the readiness and liveness probes to allow the debugger to pause.
+* Patches the service object to enable TCP connection.
+* Sets `DEBUG_ENABLED=True`
+* Port forwards the provided port to localhost on the same port.
 
 ## Run Your Broker Locally
 

--- a/build/Dockerfile-canary
+++ b/build/Dockerfile-canary
@@ -2,11 +2,13 @@ FROM centos:7
 MAINTAINER Ansible Service Broker Community
 
 ARG VERSION=master
+ARG DEBUG_PORT=9000
 LABEL "com.redhat.version"=$VERSION
 
 ENV USER_NAME=ansibleservicebroker \
     USER_UID=1001 \
-    BASE_DIR=/opt/ansibleservicebroker
+    BASE_DIR=/opt/ansibleservicebroker \
+    DEBUG_PORT=${DEBUG_PORT}
 ENV HOME=${BASE_DIR}
 
 RUN mkdir -p ${BASE_DIR} ${BASE_DIR}/etc \
@@ -41,7 +43,8 @@ RUN mkdir -p ${BROKER_PATH}
 COPY . ${BROKER_PATH}
 WORKDIR ${BROKER_PATH}
 
-RUN go build -i -ldflags="-s -w" ./cmd/broker && mv broker /usr/bin/asbd
+RUN go get -u github.com/derekparker/delve/cmd/dlv && mv /go/bin/dlv /usr/bin/dlv
+RUN go build -i -gcflags="-N -l" ./cmd/broker && mv broker /usr/bin/asbd
 RUN go build -i -ldflags="-s -w" ./cmd/migration && mv migration /usr/bin/migration
 RUN go build -i -ldflags="-s -w" ./cmd/dashboard-redirector && mv dashboard-redirector /usr/bin/dashboard-redirector
 
@@ -49,7 +52,7 @@ RUN go build -i -ldflags="-s -w" ./cmd/dashboard-redirector && mv dashboard-redi
 # BUILD BROKER SOURCE
 ######################
 
-COPY build/entrypoint.sh /usr/bin/
+COPY build/dev-entrypoint.sh /usr/bin/
 
 RUN chown -R ${USER_NAME}:0 /var/log/ansible-service-broker \
  && chown -R ${USER_NAME}:0 /etc/ansible-service-broker \
@@ -58,4 +61,4 @@ RUN chown -R ${USER_NAME}:0 /var/log/ansible-service-broker \
 USER ${USER_UID}
 RUN sed "s@${USER_NAME}:x:${USER_UID}:@${USER_NAME}:x:\${USER_ID}:@g" /etc/passwd > ${BASE_DIR}/etc/passwd.template
 
-ENTRYPOINT ["entrypoint.sh"]
+ENTRYPOINT ["dev-entrypoint.sh"]

--- a/build/Dockerfile-localdev
+++ b/build/Dockerfile-localdev
@@ -1,9 +1,12 @@
 FROM centos:7
 MAINTAINER Ansible Service Broker Community
 
+ARG DEBUG_PORT=9000
+
 ENV USER_NAME=ansibleservicebroker \
     USER_UID=1001 \
-    BASE_DIR=/opt/ansibleservicebroker
+    BASE_DIR=/opt/ansibleservicebroker \
+    DEBUG_PORT=${DEBUG_PORT}
 ENV HOME=${BASE_DIR}
 
 RUN mkdir -p ${BASE_DIR} ${BASE_DIR}/etc \
@@ -21,7 +24,8 @@ RUN mkdir /var/log/ansible-service-broker \
     && touch /var/log/ansible-service-broker/asb.log \
     && mkdir /etc/ansible-service-broker
 
-COPY entrypoint.sh /usr/bin/
+COPY dev-entrypoint.sh /usr/bin/
+COPY dlv /usr/bin/dlv
 COPY broker /usr/bin/asbd
 COPY migration /usr/bin/migration
 COPY dashboard-redirector /usr/bin/dashboard-redirector
@@ -33,4 +37,6 @@ RUN chown -R ${USER_NAME}:0 /var/log/ansible-service-broker \
 USER ${USER_UID}
 RUN sed "s@${USER_NAME}:x:${USER_UID}:@${USER_NAME}:x:\${USER_ID}:@g" /etc/passwd > ${BASE_DIR}/etc/passwd.template
 
-ENTRYPOINT ["entrypoint.sh"]
+EXPOSE ${DEBUG_PORT}
+
+ENTRYPOINT ["dev-entrypoint.sh"]

--- a/build/dev-entrypoint.sh
+++ b/build/dev-entrypoint.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+USER_ID=$(id -u)
+if [ ${USER_UID} != ${USER_ID} ]; then
+  sed "s@${USER_NAME}:x:\${USER_ID}:@${USER_NAME}:x:${USER_ID}:@g" ${BASE_DIR}/etc/passwd.template > /etc/passwd
+fi
+
+if [[ -z "$BROKER_CONFIG" ]] ; then
+  echo "Broker Config environment variable not set"
+  exit 1
+fi
+
+if [ ! -f "$BROKER_CONFIG" ] ; then
+  echo "No config file mounted to $BROKER_CONFIG"
+  exit 1
+fi
+echo "Using config file mounted to $BROKER_CONFIG"
+
+if [ ${DEBUG_ENABLED:-False} == "True" ]; then
+    dlv  --listen=0.0.0.0:${DEBUG_PORT} --headless=true --api-version=2 --log=true exec asbd -- -c $BROKER_CONFIG $FLAGS
+else
+    exec asbd -c $BROKER_CONFIG $FLAGS
+fi

--- a/scripts/clean_debug_env.sh
+++ b/scripts/clean_debug_env.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+BROKER_NAMESPACE=$1
+PROJECT=${BROKER_NAMESPACE:-"automation-broker"}
+BROKER_DEPLOYMENT=$2
+DEPLOYMENT_NAME=${BROKER_DEPLOYMENT:-"automation-broker"}
+
+oc rollout pause dc/${DEPLOYMENT_NAME} -n ${PROJECT}
+oc env dc/${DEPLOYMENT_NAME} DEBUG_ENABLED=False --overwrite=true -n ${PROJECT}
+oc set probe dc/${DEPLOYMENT_NAME} --readiness --get-url=https://:1338/healthz \
+    --initial-delay-seconds=15 --success-threshold=1 --timeout-seconds=1 --period-seconds=10 --failure-threshold=3 \
+    --liveness --get-url=https://:1338/healthz \
+    --initial-delay-seconds=15 --success-threshold=1 --timeout-seconds=1 --period-seconds=10 --failure-threshold=3 \
+    -n ${PROJECT}
+oc patch -n ${PROJECT} svc ${DEPLOYMENT_NAME} --type=json -p='[
+    {"op": "test",
+     "path": "/spec/ports/0/name",
+     "value": "debug"
+    },
+    {"op": "remove",
+     "path": "/spec/ports/0"
+    }
+]'
+oc rollout resume dc/${DEPLOYMENT_NAME} -n ${PROJECT}

--- a/scripts/prep_debug_env.sh
+++ b/scripts/prep_debug_env.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+DEBUG_PORT=$1
+BROKER_NAMESPACE=$2
+BROKER_DEPLOYMENT=$3
+PROJECT=${BROKER_NAMESPACE:-"automation-broker"}
+DEPLOYMENT_NAME=${BROKER_DEPLOYMENT:-"automation-broker"}
+
+oc rollout pause dc/${DEPLOYMENT_NAME} -n ${PROJECT}
+oc set probe dc/${DEPLOYMENT_NAME} --remove --readiness --liveness -n ${PROJECT}
+oc env dc/${DEPLOYMENT_NAME} DEBUG_ENABLED=True --overwrite=true -n ${PROJECT}
+oc rollout resume dc/${DEPLOYMENT_NAME} -n ${PROJECT}
+oc patch svc ${DEPLOYMENT_NAME} --patch='{"spec":{"ports":[{"name":"debug", "port":'${DEBUG_PORT}',"targetPort":'${DEBUG_PORT}}']}}' -n ${PROJECT}
+sleep 5
+POD_NAME="$(oc get po -o jsonpath='{.items[?(@.metadata.labels.service=="'${DEPLOYMENT_NAME}'")].metadata.name}')"
+until oc get po ${POD_NAME} -o jsonpath='{.status.containerStatuses[0].ready}' | grep "true" >/dev/null 2>&1 ; do sleep 1; done
+
+oc port-forward ${POD_NAME} ${DEBUG_PORT} -n ${PROJECT}
+
+echo "To revert these changes, run ./scripts/clean_debug_env.sh ${PROJECT} ${DEPLOYMENT_NAME}"


### PR DESCRIPTION
#### Describe what this PR does and why we need it:
Change to help with the development process from a contributor point of view. Allows building of a remotely debuggable image so a debugger can be attached when needed.

Feel free to close this if it is seen to have no value but I found it useful when working on recent issues so thought I would share.

On a side note the docs to run a local broker did not work for me on OSx on either `minishift` or `oc cluster up` but perhaps I'm missing something (broker started but errors out).

