### PR TITLE
Add fix for get si npe

### DIFF
--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -153,11 +153,6 @@ func NewAnsibleBroker(dao dao.Dao,
 func (a AnsibleBroker) GetServiceInstance(instanceUUID uuid.UUID) (apb.ServiceInstance, error) {
 	instance, err := a.dao.GetServiceInstance(instanceUUID.String())
 
-	dashboardURL := a.getDashboardURL(instance)
-	if dashboardURL != "" {
-		instance.DashboardURL = dashboardURL
-	}
-
 	if err != nil {
 		if a.dao.IsNotFoundError(err) {
 			log.Infof("Could not find a service instance in dao - %v", err)
@@ -166,6 +161,12 @@ func (a AnsibleBroker) GetServiceInstance(instanceUUID uuid.UUID) (apb.ServiceIn
 		log.Info("Couldn't find a service instance: ", err)
 		return apb.ServiceInstance{}, err
 	}
+
+	dashboardURL := a.getDashboardURL(instance)
+	if dashboardURL != "" {
+		instance.DashboardURL = dashboardURL
+	}
+
 	return *instance, nil
 
 }


### PR DESCRIPTION
@shawn-hurley and I discovered a panic this morning. If for some reason the catalog has a bunch of instances that the broker is unaware of, the broker will try to lookup the instance, fail to find it, and panic when trying to deref the spec off a nil value. This correctly checks the error.