### PR TITLE
Allow Automation Broker to be useful when used as a dependency

### DIFF
--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -16,9 +16,39 @@
 
 package main
 
-import "github.com/openshift/ansible-service-broker/pkg/app"
+import (
+	"fmt"
+	"os"
+
+	"github.com/automationbroker/bundle-lib/registries"
+	flags "github.com/jessevdk/go-flags"
+	"github.com/openshift/ansible-service-broker/pkg/app"
+	"github.com/openshift/ansible-service-broker/pkg/version"
+)
 
 func main() {
-	app := app.CreateApp()
+
+	var args app.Args
+	var err error
+
+	// Writing directly to stderr because log has not been bootstrapped
+	if args, err = app.CreateArgs(); err != nil {
+		if flagsErr, ok := err.(*flags.Error); ok && flagsErr.Type == flags.ErrHelp {
+			os.Exit(0)
+		} else {
+			os.Exit(1)
+		}
+	}
+
+	if args.Version {
+		fmt.Println(version.Version)
+		os.Exit(0)
+	}
+
+	// To add your custom registries, define an entry in this array.
+	regs := []registries.Registry{}
+
+	// CreateApp passing in the args and registries
+	app := app.CreateApp(args, regs)
 	app.Start()
 }

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -185,33 +185,42 @@ func CreateApp(args Args, regs []registries.Registry) App {
 		os.Exit(1)
 	}
 
-	log.Debug("Connecting Registry")
-	for _, config := range app.config.GetSubConfigArray("registry") {
-		c := registries.Config{
-			URL:        config.GetString("url"),
-			User:       config.GetString("user"),
-			Pass:       config.GetString("pass"),
-			Org:        config.GetString("org"),
-			Tag:        config.GetString("tag"),
-			Type:       config.GetString("type"),
-			Name:       config.GetString("name"),
-			Images:     config.GetSliceOfStrings("images"),
-			Namespaces: config.GetSliceOfStrings("namespaces"),
-			Fail:       config.GetBool("fail_on_error"),
-			WhiteList:  config.GetSliceOfStrings("white_list"),
-			BlackList:  config.GetSliceOfStrings("black_list"),
-			AuthType:   config.GetString("auth_type"),
-			AuthName:   config.GetString("auth_name"),
-			Runner:     config.GetString("runner"),
+	// if we have custom registries, use those instead of those configured in
+	// the configmap
+	if len(regs) > 0 {
+		log.Info("Using the supplied custom registries.")
+		for _, reg := range regs {
+			app.registry = append(app.registry, reg)
 		}
+	} else {
+		log.Debug("Connecting Registry")
+		for _, config := range app.config.GetSubConfigArray("registry") {
+			c := registries.Config{
+				URL:        config.GetString("url"),
+				User:       config.GetString("user"),
+				Pass:       config.GetString("pass"),
+				Org:        config.GetString("org"),
+				Tag:        config.GetString("tag"),
+				Type:       config.GetString("type"),
+				Name:       config.GetString("name"),
+				Images:     config.GetSliceOfStrings("images"),
+				Namespaces: config.GetSliceOfStrings("namespaces"),
+				Fail:       config.GetBool("fail_on_error"),
+				WhiteList:  config.GetSliceOfStrings("white_list"),
+				BlackList:  config.GetSliceOfStrings("black_list"),
+				AuthType:   config.GetString("auth_type"),
+				AuthName:   config.GetString("auth_name"),
+				Runner:     config.GetString("runner"),
+			}
 
-		reg, err := registries.NewRegistry(c, app.config.GetString("openshift.namespace"))
-		if err != nil {
-			log.Errorf(
-				"Failed to initialize %v Registry err - %v \n", config.GetString("name"), err)
-			os.Exit(1)
+			reg, err := registries.NewRegistry(c, app.config.GetString("openshift.namespace"))
+			if err != nil {
+				log.Errorf(
+					"Failed to initialize %v Registry err - %v \n", config.GetString("name"), err)
+				os.Exit(1)
+			}
+			app.registry = append(app.registry, reg)
 		}
-		app.registry = append(app.registry, reg)
 	}
 
 	validateRegistryNames(app.registry)


### PR DESCRIPTION
#### Describe what this PR does and why we need it:
Allows users to pass in their own custom registries into the Automation Broker. This means you can create a custom adapter and have the Automation Broker use it. You can also create your own broker without needing to write a ton of code. See https://github.com/jmrodri/samplebroker 

#### Does this PR depend on another PR (Use this to track when PRs should be merged)
depends-on https://github.com/automationbroker/bundle-lib/pull/72

