### PR TITLE
Bug 1550418 - Return op token on depro in progress

### DIFF
--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -452,7 +452,7 @@ func (h handler) deprovision(w http.ResponseWriter, r *http.Request, params map[
 			writeResponse(w, http.StatusBadRequest, broker.DeprovisionResponse{})
 			return
 		case broker.ErrorDeprovisionInProgress:
-			writeResponse(w, http.StatusAccepted, broker.DeprovisionResponse{})
+			writeResponse(w, http.StatusAccepted, resp)
 			return
 		default:
 			writeResponse(w, http.StatusInternalServerError, broker.ErrorResponse{Description: err.Error()})


### PR DESCRIPTION
Deprovision requests that returned an "already in progress" response
were failing to return the relevant operation token. This ensures the
correct token is returned so the catalog can continue to track.