### PR TITLE
Bug 1576728 - Fixes multiple requests to a CR

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -44,7 +44,6 @@
   version = "0.1.2"
 
 [[projects]]
-  branch = "bug-1576728"
   name = "github.com/automationbroker/bundle-lib"
   packages = [
     "apb",
@@ -57,8 +56,8 @@
     "registries/adapters",
     "runtime"
   ]
-  revision = "4162f5a4f0a5bac5e074b1473b738c4c20779b40"
-  source = "github.com/shawn-hurley/bundle-lib"
+  revision = "d1bf04cf29b67929313e998b83d07c807f772c33"
+  version = "0.1.6"
 
 [[projects]]
   branch = "master"
@@ -925,6 +924,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "b33df39ec11fc620bb6629c612363cae755b3e4843a7e56a8ce4545f86bd7507"
+  inputs-digest = "ec45f8aae9030f4422019e0af5f9a39793f532beb467d9953baf8e8e9316847a"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -44,6 +44,7 @@
   version = "0.1.2"
 
 [[projects]]
+  branch = "bug-1576728"
   name = "github.com/automationbroker/bundle-lib"
   packages = [
     "apb",
@@ -56,8 +57,8 @@
     "registries/adapters",
     "runtime"
   ]
-  revision = "ee4a23415a7d6356ea4072e9894c53601c66abf2"
-  version = "0.1.5"
+  revision = "4162f5a4f0a5bac5e074b1473b738c4c20779b40"
+  source = "github.com/shawn-hurley/bundle-lib"
 
 [[projects]]
   branch = "master"
@@ -924,6 +925,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "ec45f8aae9030f4422019e0af5f9a39793f532beb467d9953baf8e8e9316847a"
+  inputs-digest = "b33df39ec11fc620bb6629c612363cae755b3e4843a7e56a8ce4545f86bd7507"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -37,9 +37,7 @@
   version = "~1.3.0"
 
 [[constraint]]
-  #version = "~0.1.0"
-  branch = "bug-1576728"
-  source = "github.com/shawn-hurley/bundle-lib"
+  version = "~0.1.0"
   name = "github.com/automationbroker/bundle-lib"
 
 [[constraint]]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -37,7 +37,9 @@
   version = "~1.3.0"
 
 [[constraint]]
-  version = "~0.1.0"
+  #version = "~0.1.0"
+  branch = "bug-1576728"
+  source = "github.com/shawn-hurley/bundle-lib"
   name = "github.com/automationbroker/bundle-lib"
 
 [[constraint]]

--- a/pkg/dao/etcd/dao.go
+++ b/pkg/dao/etcd/dao.go
@@ -282,7 +282,18 @@ func (d *Dao) GetServiceInstance(id string) (*apb.ServiceInstance, error) {
 
 // SetServiceInstance - Set service instance for an id in the kvp API.
 func (d *Dao) SetServiceInstance(id string, serviceInstance *apb.ServiceInstance) error {
+	serviceInstance.BindingIDs = removeFalseBindings(serviceInstance.BindingIDs)
 	return d.setObject(serviceInstanceKey(id), serviceInstance)
+}
+
+func removeFalseBindings(bindings map[string]bool) map[string]bool {
+	newBindings := map[string]bool{}
+	for k, v := range bindings {
+		if v {
+			newBindings[k] = v
+		}
+	}
+	return newBindings
 }
 
 // DeleteServiceInstance - Delete the service instance for an service instance id.

--- a/vendor/github.com/automationbroker/bundle-lib/apb/types.go
+++ b/vendor/github.com/automationbroker/bundle-lib/apb/types.go
@@ -304,7 +304,7 @@ func (si *ServiceInstance) AddBinding(bindingUUID uuid.UUID) {
 // RemoveBinding - Remove binding ID from service instance
 func (si *ServiceInstance) RemoveBinding(bindingUUID uuid.UUID) {
 	if si.BindingIDs != nil {
-		delete(si.BindingIDs, bindingUUID.String())
+		si.BindingIDs[bindingUUID.String()] = false
 	}
 }
 

--- a/vendor/github.com/automationbroker/bundle-lib/registries/adapters/partner_rhcc_adapter_test.go
+++ b/vendor/github.com/automationbroker/bundle-lib/registries/adapters/partner_rhcc_adapter_test.go
@@ -29,7 +29,7 @@ import (
 
 var Images = []string{"satoshi/nakamoto", "foo/bar", "paul/atreides"}
 
-const OpenShiftManifestResponse = `
+const PartnerManifestResponse = `
 {
    "schemaVersion": 1,
    "name": "%v",
@@ -89,15 +89,15 @@ const AuthResponse = `
   "issued_at": "2018-03-27T19:54:19Z"
 }`
 
-func TestOpenShiftName(t *testing.T) {
-	ocpa := OpenShiftAdapter{}
-	ft.Equal(t, ocpa.RegistryName(), "openshift", "openshift name does not match `openshift`")
+func TestPartnerName(t *testing.T) {
+	partnera := PartnerRhccAdapter{}
+	ft.Equal(t, partnera.RegistryName(), "partner_rhcc", "partner_rhcc name does not match `partner_rhcc`")
 }
 
-func TestOpenShiftGetImageNames(t *testing.T) {
-	ocpa := OpenShiftAdapter{}
-	ocpa.Config.Images = Images
-	imagesFound, err := ocpa.GetImageNames()
+func TestPartnerGetImageNames(t *testing.T) {
+	partnera := PartnerRhccAdapter{}
+	partnera.Config.Images = Images
+	imagesFound, err := partnera.GetImageNames()
 	if err != nil {
 		t.Fatal("Error: ", err)
 	}
@@ -122,7 +122,7 @@ func TestOpenShiftFetchSpecs(t *testing.T) {
 		}
 		if strings.Contains(r.URL.EscapedPath(), "manifests/") {
 			name := strings.Split(r.URL.EscapedPath(), "manifests/")[1]
-			fmt.Fprintf(w, fmt.Sprintf(OpenShiftManifestResponse, name))
+			fmt.Fprintf(w, fmt.Sprintf(PartnerManifestResponse, name))
 		}
 
 	}))
@@ -131,7 +131,7 @@ func TestOpenShiftFetchSpecs(t *testing.T) {
 	if err != nil {
 		t.Fatal("Error: ", err)
 	}
-	ocpa := OpenShiftAdapter{
+	partnera := PartnerRhccAdapter{
 		Config: Configuration{
 			URL:    url,
 			User:   "satoshi",
@@ -139,8 +139,8 @@ func TestOpenShiftFetchSpecs(t *testing.T) {
 			Images: Images,
 		},
 	}
-	imageNames, err := ocpa.GetImageNames()
-	specs, err := ocpa.FetchSpecs(imageNames)
+	imageNames, err := partnera.GetImageNames()
+	specs, err := partnera.FetchSpecs(imageNames)
 	if err != nil {
 		t.Fatal("Error: ", err)
 	}

--- a/vendor/github.com/automationbroker/bundle-lib/registries/registry.go
+++ b/vendor/github.com/automationbroker/bundle-lib/registries/registry.go
@@ -212,8 +212,8 @@ func NewCustomRegistry(configuration Config, adapter adapters.Adapter, asbNamesp
 			adapter = &adapters.DockerHubAdapter{Config: c}
 		case "mock":
 			adapter = &adapters.MockAdapter{Config: c}
-		case "openshift":
-			adapter = &adapters.OpenShiftAdapter{Config: c}
+		case "partner_rhcc":
+			adapter = &adapters.PartnerRhccAdapter{Config: c}
 		case "local_openshift":
 			adapter = &adapters.LocalOpenShiftAdapter{Config: c}
 		case "helm":


### PR DESCRIPTION
#### Describe what this PR does and why we need it:
This makes the dao calls happen 1 at a time for a dao. Attempts to handle the case when two service instances are gotten with two bindings. both are deleted, but because we only remove each of one, and when we update we just set the value, we were adding back a binding.

Depends on https://github.com/automationbroker/bundle-lib/pull/80