### PR TITLE
update obj form definition

### DIFF
--- a/pkg/broker/util.go
+++ b/pkg/broker/util.go
@@ -138,9 +138,8 @@ func initMetadataCopy(original map[string]interface{}) (map[string]interface{}, 
 	return dst, nil
 }
 
-
-func createUpdateFormDefinition(params []apb.ParameterDescriptor) []interface{} {
-	var updateParams []apb.ParameterDescriptor
+func createUpdateFormDefinition(params []bundle.ParameterDescriptor) []interface{} {
+	var updateParams []bundle.ParameterDescriptor
 
 	for _, param := range params {
 		if param.Updatable {
@@ -151,7 +150,7 @@ func createUpdateFormDefinition(params []apb.ParameterDescriptor) []interface{} 
 	return createFormDefinition(updateParams)
 }
 
-func createFormDefinition(params []apb.ParameterDescriptor) []interface{} {
+func createFormDefinition(params []bundle.ParameterDescriptor) []interface{} {
 	formDefinition := make([]interface{}, 0)
 
 	if params == nil || len(params) == 0 {

--- a/pkg/broker/util.go
+++ b/pkg/broker/util.go
@@ -100,13 +100,16 @@ func extractBrokerPlanMetadata(apbPlan bundle.Plan) map[string]interface{} {
 
 	instanceFormDefn := createFormDefinition(apbPlan.Parameters)
 	bindingFormDefn := createFormDefinition(apbPlan.BindParameters)
+	updateFormDefn := createUpdateFormDefinition(apbPlan.Parameters)
 
 	metadata["schemas"] = map[string]interface{}{
 		"service_instance": map[string]interface{}{
 			"create": map[string]interface{}{
 				"openshift_form_definition": instanceFormDefn,
 			},
-			"update": map[string]interface{}{},
+			"update": map[string]interface{}{
+				"openshift_form_definition": updateFormDefn,
+			},
 		},
 		"service_binding": map[string]interface{}{
 			"create": map[string]interface{}{
@@ -135,7 +138,20 @@ func initMetadataCopy(original map[string]interface{}) (map[string]interface{}, 
 	return dst, nil
 }
 
-func createFormDefinition(params []bundle.ParameterDescriptor) []interface{} {
+
+func createUpdateFormDefinition(params []apb.ParameterDescriptor) []interface{} {
+	var updateParams []apb.ParameterDescriptor
+
+	for _, param := range params {
+		if param.Updatable {
+			updateParams = append(updateParams, param)
+		}
+	}
+
+	return createFormDefinition(updateParams)
+}
+
+func createFormDefinition(params []apb.ParameterDescriptor) []interface{} {
 	formDefinition := make([]interface{}, 0)
 
 	if params == nil || len(params) == 0 {
@@ -156,6 +172,7 @@ func createFormDefinition(params []bundle.ParameterDescriptor) []interface{} {
 
 		formDefinition = append(formDefinition, item)
 	}
+
 	return formDefinition
 }
 

--- a/pkg/broker/util_test.go
+++ b/pkg/broker/util_test.go
@@ -177,7 +177,7 @@ func TestUpdateMetadata(t *testing.T) {
 	verifyInstanceFormDefinition(t, planMetadata, []string{"schemas", "service_instance", "create"})
 
 	updateFormDefnMap := verifyMapPath(t, planMetadata, []string{"schemas", "service_instance", "update"})
-	ft.AssertEqual(t, len(updateFormDefnMap), 0, "schemas.service_instance.update is not empty")
+	ft.AssertEqual(t, len(updateFormDefnMap), 1, "schemas.service_instance.update is not empty")
 
 	verifyBindingFormDefinition(t, planMetadata, []string{"schemas", "service_binding", "create"})
 }

--- a/pkg/broker/util_test.go
+++ b/pkg/broker/util_test.go
@@ -100,6 +100,38 @@ var PlanBindParams = []apb.ParameterDescriptor{
 	},
 }
 
+var PlanParamsNoUpdate = []apb.ParameterDescriptor{
+	{
+		Name:        "email_address",
+		Title:       "Email Address",
+		Type:        "enum",
+		Description: "example enum parameter",
+		Enum:        []string{"google@gmail.com", "redhat@redhat.com"},
+		Default:     float64(9001),
+	},
+	{
+		Name:        "password",
+		Title:       "Password",
+		Type:        "string",
+		Description: "example string parameter with a display type",
+		DisplayType: "password",
+	},
+	{
+		Name:         "first_name",
+		Title:        "First Name",
+		Type:         "string",
+		Description:  "example grouped string parameter",
+		DisplayGroup: "User Information",
+	},
+	{
+		Name:         "last_name",
+		Title:        "Last Name",
+		Type:         "string",
+		Description:  "example grouped string parameter",
+		DisplayGroup: "User Information",
+	},
+}
+
 var p = apb.Plan{
 	ID:             "55822a921d2c4858fe6e58f5522429c2", // md5(dh-sns-apb-dev)
 	Name:           PlanName,
@@ -108,6 +140,17 @@ var p = apb.Plan{
 	Free:           PlanFree,
 	Bindable:       PlanBindable,
 	Parameters:     PlanParams,
+	BindParameters: PlanBindParams,
+}
+
+var pNotUpdatable = apb.Plan{
+	ID:             "55822a921d2c4858fe6e58f5522429c2", // md5(dh-sns-apb-dev)
+	Name:           PlanName,
+	Description:    PlanDescription,
+	Metadata:       PlanMetadata,
+	Free:           PlanFree,
+	Bindable:       PlanBindable,
+	Parameters:     PlanParamsNoUpdate,
 	BindParameters: PlanBindParams,
 }
 
@@ -177,7 +220,25 @@ func TestUpdateMetadata(t *testing.T) {
 	verifyInstanceFormDefinition(t, planMetadata, []string{"schemas", "service_instance", "create"})
 
 	updateFormDefnMap := verifyMapPath(t, planMetadata, []string{"schemas", "service_instance", "update"})
+	ft.AssertEqual(t, len(updateFormDefnMap), 1, "schemas.service_instance.update is empty")
+
+	formDefnMetadata, _ := updateFormDefnMap["openshift_form_definition"].([]interface{})
+	ft.AssertEqual(t, len(formDefnMetadata), 1, "schemas.service_instance.update is not empty")
+
+	verifyBindingFormDefinition(t, planMetadata, []string{"schemas", "service_binding", "create"})
+}
+
+func TestNotUpdatableMetadata(t *testing.T) {
+	planMetadata := extractBrokerPlanMetadata(pNotUpdatable)
+	ft.AssertNotNil(t, planMetadata, "plan metadata is empty")
+
+	verifyInstanceFormDefinition(t, planMetadata, []string{"schemas", "service_instance", "create"})
+
+	updateFormDefnMap := verifyMapPath(t, planMetadata, []string{"schemas", "service_instance", "update"})
 	ft.AssertEqual(t, len(updateFormDefnMap), 1, "schemas.service_instance.update is not empty")
+
+	formDefnMetadata, _ := updateFormDefnMap["openshift_form_definition"].([]interface{})
+	ft.AssertEqual(t, len(formDefnMetadata), 0, "schemas.service_instance.update is not empty")
 
 	verifyBindingFormDefinition(t, planMetadata, []string{"schemas", "service_binding", "create"})
 }


### PR DESCRIPTION
#### Describe what this PR does and why we need it:

I opened this issue a couple of days ago: https://github.com/openshift/origin-web-console/issues/2985 because the `update` form definition object was always empty so I made this tiny change into the service broker to include all updatable fields into the service instance object.

I am sending this PR to ask for feedback about this change, if this makes sense at all.

#### Changes proposed in this pull request

 - Fills the update form definition object up with  a list of updatable fields (if any)

#### Does this PR depend on another PR (Use this to track when PRs should be merged) 

This PR breaks the service instance ui (when listing read-only parameters) which will need a change as well if this change makes any sense.

