### PR TITLE
Bump version for next release

### DIFF
--- a/.tito/releasers.conf
+++ b/.tito/releasers.conf
@@ -15,4 +15,4 @@ builder.test = 1
 
 [asb-brew]
 releaser = tito.release.DistGitReleaser
-branches = rhaos-3.10-asb-rhel-7
+branches = rhaos-3.11-asb-rhel-7

--- a/ansible-service-broker.spec
+++ b/ansible-service-broker.spec
@@ -37,7 +37,7 @@
 %define modulename ansible-service-broker
 
 Name: %{repo}
-Version: 1.2.11
+Version: 1.3.0
 Release: 1%{build_timestamp}%{?dist}
 Summary: Ansible Service Broker
 License: ASL 2.0


### PR DESCRIPTION
Update our RPM version for release `1.3.z` of the broker. Also, make sure our tito releasers file is pointing to 3.11, for when those branches exist.