### PR TITLE
Bug 1583064 - missing action causes many sandboxes

### DIFF
--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -615,7 +615,7 @@ func (a AnsibleBroker) Provision(instanceUUID uuid.UUID, req *ProvisionRequest, 
 	// away from []byte it can still be evaluated.
 	if si != nil && uuid.Equal(si.ID, serviceInstance.ID) {
 		if reflect.DeepEqual(si.Parameters, serviceInstance.Parameters) {
-			alreadyInProgress, jobToken, err := a.isJobInProgress(serviceInstance, apb.JobMethodProvision)
+			alreadyInProgress, jobToken, err := a.isJobInProgress(serviceInstance.ID.String(), apb.JobMethodProvision)
 			if err != nil {
 				return nil, fmt.Errorf("An error occurred while trying to determine if a provision job is already in progress for instance: %s", serviceInstance.ID)
 			}
@@ -733,7 +733,7 @@ func (a AnsibleBroker) Deprovision(
 		return nil, err
 	}
 
-	alreadyInProgress, jobToken, err := a.isJobInProgress(&instance, apb.JobMethodDeprovision)
+	alreadyInProgress, jobToken, err := a.isJobInProgress(instance.ID.String(), apb.JobMethodDeprovision)
 	if err != nil {
 		return nil, fmt.Errorf("An error occurred while trying to determine if a deprovision job is already in progress for instance: %s", instance.ID)
 	}
@@ -797,11 +797,11 @@ func (a AnsibleBroker) validateDeprovision(instance *apb.ServiceInstance) error 
 	return nil
 }
 
-func (a AnsibleBroker) isJobInProgress(instance *apb.ServiceInstance,
+func (a AnsibleBroker) isJobInProgress(ID string,
 	method apb.JobMethod) (bool, string, error) {
 
-	allJobs, err := a.dao.GetSvcInstJobsByState(instance.ID.String(), apb.StateInProgress)
-	log.Infof("All Jobs for instance: %v in state:  %v - \n%#v", instance.ID, apb.StateInProgress, allJobs)
+	allJobs, err := a.dao.GetSvcInstJobsByState(ID, apb.StateInProgress)
+	log.Infof("All Jobs for instance: %v in state:  %v - \n%#v", ID, apb.StateInProgress, allJobs)
 	if err != nil {
 		return false, "", err
 	}
@@ -1048,7 +1048,7 @@ func (a AnsibleBroker) Unbind(
 		return nil, false, errors.New(errMsg)
 	}
 
-	jobInProgress, jobToken, err := a.isJobInProgress(&instance, apb.JobMethodUnbind)
+	jobInProgress, jobToken, err := a.isJobInProgress(bindInstance.ID.String(), apb.JobMethodUnbind)
 	if err != nil {
 		log.Errorf("An error occurred while trying to determine if a unbind job is already in progress for instance: %s", instance.ID)
 		return nil, false, err
@@ -1249,7 +1249,7 @@ func (a AnsibleBroker) Update(instanceUUID uuid.UUID, req *UpdateRequest, async 
 	// else, add onto the back of the queue. Ensures update operations are not
 	// trying to execute concurrently.
 	////////////////////////////////////////////////////////////
-	alreadyInProgress, jobToken, err := a.isJobInProgress(si, apb.JobMethodUpdate)
+	alreadyInProgress, jobToken, err := a.isJobInProgress(si.ID.String(), apb.JobMethodUpdate)
 	if err != nil {
 		return nil, fmt.Errorf(
 			"An error occurred while trying to determine if an update job is already in progress for instance: %s", si.ID)

--- a/pkg/broker/job_state_subscriber.go
+++ b/pkg/broker/job_state_subscriber.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/automationbroker/bundle-lib/apb"
+	"github.com/automationbroker/bundle-lib/runtime"
 )
 
 // JobStateSubscriber is responsible for handling and persisting JobState changes
@@ -34,6 +35,28 @@ func (jss *JobStateSubscriber) Notify(msg JobMsg) {
 	if isBinding(msg) {
 		id = msg.BindingUUID
 	}
+
+	log.Debugf("message: method: [%v] isNotFound? [%v] state error [%v]", msg.State.Method, msg.State.Error == runtime.ErrorActionNotFound.Error(), msg.State.Error)
+
+	// Bug 1583064 - Should not launch multi unbind sandboxes frequently while
+	// unbind failed.
+	//
+	// If the unbind fails we really want to let them know it failed because it
+	// is probably something the APB developer needs to fix. But if the action
+	// is non-existent we really need to prevent the multiple sandboxes.
+	//
+	// if we can't find the action, there is no point in continuing.
+	// marking job as SUCCEEDED but setting the message to be the actual error
+	// string. This will only happen for the optional actions: bind & unbind.
+	if msg.State.Error == runtime.ErrorActionNotFound.Error() {
+		log.Debug("We have an 'action not found' error. Looking to see if this is a bind or an unbind.")
+		if msg.State.Method == apb.JobMethodBind || msg.State.Method == apb.JobMethodUnbind {
+			log.Info("bind or unbind action not found, marking as succeeded.")
+			msg.State.State = apb.StateSucceeded
+			// leave error message as not found
+		}
+	}
+
 	if _, err := jss.dao.SetState(id, msg.State); err != nil {
 		log.Errorf("Error JobStateSubscriber failed to set state after action %v completed with state %s err: %v", msg.State.Method, msg.State.State, err)
 		return

--- a/pkg/broker/job_state_subscriber.go
+++ b/pkg/broker/job_state_subscriber.go
@@ -36,8 +36,6 @@ func (jss *JobStateSubscriber) Notify(msg JobMsg) {
 		id = msg.BindingUUID
 	}
 
-	log.Debugf("message: method: [%v] isNotFound? [%v] state error [%v]", msg.State.Method, msg.State.Error == runtime.ErrorActionNotFound.Error(), msg.State.Error)
-
 	// Bug 1583064 - Should not launch multi unbind sandboxes frequently while
 	// unbind failed.
 	//


### PR DESCRIPTION
If the unbind fails we really want to let them know it failed because it
is probably something the APB developer needs to fix. But if the action
is non-existent we really need to prevent the multiple sandboxes.

If we can't find the action, there is no point in continuing.
marking job as SUCCEEDED but setting the message to be the actual error
string. This will only happen for the optional actions: bind & unbind.

Update isJobInProgress to take a string to allow the proper ID to be
passed in.