### PR TITLE
Travis should run only for master/release branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,11 @@ go:
 dist: trusty
 sudo: required
 group: edge
+branches:
+  only:
+  - master
+  - /^release-.*$/
+
 env:
   #- OPENSHIFT_VERSION=v3.10.0
   - OPENSHIFT_VERSION=v3.9.0


### PR DESCRIPTION
Want to make it possible for travis to run against Pull Requests, as well as on merges to our master + release branches. This + some travis configuration should allow that.