### PR TITLE
Use test playbook to test broker in ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,11 +62,5 @@ script:
   # Setup cluster
   - setup_cluster
 
-  # Provision Broker
-  - BROKER_IMAGE=$broker_image APB_IMAGE=$apb_name make deploy
-
   # Run CI
   - BROKER_IMAGE=$broker_image APB_IMAGE=$apb_name make ci
-
-  # Deprovision Broker
-  - BROKER_IMAGE=$broker_image APB_IMAGE=$apb_name make undeploy

--- a/Makefile
+++ b/Makefile
@@ -105,12 +105,7 @@ undeploy: build-apb ## Uninstall a deployed broker from a running cluster
 
 ## Continuous integration stuff
 ci: ##Run the broker ci
-	@go get github.com/rthallisey/service-broker-ci/cmd/ci
-ifdef KUBERNETES_VERSION
-	@KUBERNETES="k8s" ci --cluster kubernetes
-else
-	@ci
-endif
+	APB_IMAGE=${APB_IMAGE} BROKER_IMAGE=${BROKER_IMAGE} ACTION="test" ./scripts/deploy.sh
 
 help: ## Show this help screen
 	@echo 'Usage: make <OPTIONS> ... <TARGETS>'

--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ undeploy: build-apb ## Uninstall a deployed broker from a running cluster
 	APB_IMAGE=${APB_IMAGE} BROKER_IMAGE=${BROKER_IMAGE} ACTION="deprovision" ./scripts/deploy.sh
 
 ## Continuous integration stuff
-ci: ##Run the broker ci
+ci: build-image build-apb ##Run the broker ci
 	APB_IMAGE=${APB_IMAGE} BROKER_IMAGE=${BROKER_IMAGE} ACTION="test" ./scripts/deploy.sh
 
 help: ## Show this help screen

--- a/apb/playbooks/test.yml
+++ b/apb/playbooks/test.yml
@@ -4,6 +4,46 @@
   hosts: localhost
   gather_facts: false
   connection: local
+  vars:
+    ready_status_query: "status.conditions[?type == 'Ready'].status"
+    available_status_query: "status.conditions[?type == 'Available'].status"
+    mediawiki_query: "{{
+      lookup(
+        'k8s',
+        api_version='servicecatalog.k8s.io/v1beta1',
+        kind='ServiceInstance',
+        namespace='broker-test',
+        resource_name='mediawiki'
+      ) | json_query(ready_status_query)
+    }}"
+    postgresql_query: "{{
+      lookup(
+        'k8s',
+        api_version='servicecatalog.k8s.io/v1beta1',
+        kind='ServiceInstance',
+        namespace='broker-test',
+        resource_name='postgresql'
+      ) | json_query(ready_status_query)
+    }}"
+    binding_query: "{{
+      lookup(
+        'k8s',
+        api_version='servicecatalog.k8s.io/v1beta1',
+        kind='ServiceBinding',
+        namespace='broker-test',
+        resource_name='mediawiki-postgresql-binding'
+      ) | json_query(ready_status_query)
+    }}"
+    mediawiki_deployment_query: "{{
+      lookup(
+        'k8s',
+        api_version='apps/v1' if cluster == 'kubernetes' else 'apps.openshift.io/v1',
+        kind='Deployment' if cluster == 'kubernetes' else 'DeploymentConfig',
+        namespace='broker-test',
+        resource_name='mediawiki'
+      ) | json_query(available_status_query)
+    }}"
+
   tasks:
     # Test crd
     - name: Provision test with CRDs
@@ -15,17 +55,199 @@
         wait_for_broker: true
         broker_dao_type: crd
 
-    - name: Deprovision test with CRDs
-      include_role:
-        name: automation-broker-apb
-      vars:
-        apb_action: deprovision
-        create_broker_namespace: true
-        broker_dao_type: crd
+    - name: Create test namespace
+      k8s:
+        state: present
+        definition:
+          apiVersion: "{{ 'v1' if cluster == 'kubernetes' else 'project.openshift.io/v1' }}"
+          kind: "{{ 'Namespace' if cluster == 'kubernetes' else 'ProjectRequest' }}"
+          metadata:
+            name: broker-test
 
-    - name: Wait for namespace to be destroyed
+    - name: Provision mediawiki
+      k8s:
+        state: present
+        definition:
+          apiVersion: servicecatalog.k8s.io/v1beta1
+          kind: ServiceInstance
+          metadata:
+            name: mediawiki
+            namespace: broker-test
+          spec:
+            clusterServiceClassExternalName: dh-mediawiki-apb
+            clusterServicePlanExternalName: default
+            parameters:
+              app_name: mediawiki
+              mediawiki_db_schema: "mediawiki"
+              mediawiki_site_name: "Mediawiki-CI"
+              mediawiki_site_lang: "en"
+              mediawiki_admin_user: "ci-user"
+          mediawiki_admin_pass: "admin"
+
+    - name: Wait for mediawiki service instance
+      debug:
+        msg: "Instance ready status: {{ mediawiki_query }}"
+      retries: 10
+      delay: 10
+      until: mediawiki_query | length > 0 and mediawiki_query | first == "True"
+
+    - name: Provision postgresql
+      k8s:
+        state: present
+        definition:
+          apiVersion: servicecatalog.k8s.io/v1beta1
+          kind: ServiceInstance
+          metadata:
+            name: postgresql
+            namespace: broker-test
+          spec:
+            clusterServiceClassExternalName: dh-postgresql-apb
+            clusterServicePlanExternalName: dev
+            parameters:
+              app_name: "postgresql"
+              postgresql_database: "admin"
+              postgresql_password: "admin"
+              postgresql_user: "admin"
+          postgresql_version: "9.6"
+
+    - name: Wait for postgresql service instance
+      debug:
+        msg: "Instance ready status: {{ postgresql_query }}"
+      retries: 10
+      delay: 10
+      until: postgresql_query | length > 0 and postgresql_query | first == "True"
+
+    - name: Create binding
+      k8s:
+        state: present
+        definition:
+          apiVersion: servicecatalog.k8s.io/v1beta1
+          kind: ServiceBinding
+          metadata:
+            name: mediawiki-postgresql-binding
+            namespace: broker-test
+          spec:
+            instanceRef:
+              name: postgresql
+          secretName: mediawiki-postgresql-binding
+
+    - name: Wait for mediawiki-postgresql binding instance
+      debug:
+        msg: "Binding ready status: {{ binding_query }}"
+      retries: 10
+      delay: 10
+      until: binding_query | length > 0 and binding_query | first == "True"
+
+    - name: Update mediawiki deployment(config)
+      k8s:
+        state: present
+        definition:
+          apiVersion: "{{ 'apps/v1' if cluster == 'kubernetes' else 'apps.openshift.io/v1' }}"
+          kind: "{{ 'Deployment' if cluster == 'kubernetes' else 'DeploymentConfig' }}"
+          metadata:
+            name: mediawiki
+            namespace: broker-test
+          spec:
+            template:
+              spec:
+                containers:
+                  - name: mediawiki
+                    envFrom:
+                      - secretRef:
+                          name: mediawiki-postgresql-binding
+
+    - name: Wait for mediawiki deployment(config)
+      debug:
+        msg: "Deployment(config) ready status: {{ mediawiki_deployment_query }}"
+      retries: 10
+      delay: 10
+      until: mediawiki_deployment_query | length > 0 and mediawiki_deployment_query | first == "True"
+
+    - set_fact:
+        mediawiki_url: "{{
+          lookup(
+            'k8s',
+            api_version='v1',
+            kind='Endpoints',
+            namespace='broker-test',
+            resource_name='mediawiki'
+          )
+        }}"
+
+    - name: "Verify mediawiki"
+      uri:
+        url: "http://{{ mediawiki_url | json_query('subsets[0].addresses[0].ip') }}:{{ mediawiki_url | json_query('subsets[0].ports[0].port') }}"
+        return_content: yes
+      retries: 10
+      delay: 10
+      register: webpage
+      until:
+        - webpage.status == 200
+        - "'MediaWiki has been installed.' in webpage.content"
+
+    - name: Delete binding
+      k8s:
+        state: absent
+        definition:
+          apiVersion: servicecatalog.k8s.io/v1beta1
+          kind: ServiceBinding
+          metadata:
+            name: mediawiki-postgresql-binding
+            namespace: broker-test
+
+    - name: Wait for mediawiki-postgresql binding instance to be removed
+      debug:
+        msg: "Binding ready status: {{ binding_query }}"
+      retries: 10
+      delay: 10
+      until: not binding_query
+
+    - name: Deprovision postgresql
+      k8s:
+        state: absent
+        definition:
+          apiVersion: servicecatalog.k8s.io/v1beta1
+          kind: ServiceInstance
+          metadata:
+            name: postgresql
+            namespace: broker-test
+
+    - name: Wait for postgresql service instance to be removed
+      debug:
+        msg: "Instance ready status: {{ postgresql_query }}"
+      retries: 10
+      delay: 10
+      until: not postgresql_query
+
+    - name: Deprovision mediawiki
+      k8s:
+        state: absent
+        definition:
+          apiVersion: servicecatalog.k8s.io/v1beta1
+          kind: ServiceInstance
+          metadata:
+            name: mediawiki
+            namespace: broker-test
+
+    - name: Wait for mediawiki service instance to be removed
+      debug:
+        msg: "Instance ready status: {{ mediawiki_query }}"
+      retries: 10
+      delay: 10
+      until: not mediawiki_query
+
+    - name: Delete test namespace
+      k8s:
+        state: absent
+        definition:
+          apiVersion: "{{ 'v1' if cluster == 'kubernetes' else 'project.openshift.io/v1' }}"
+          kind: "{{ 'Namespace' if cluster == 'kubernetes' else 'Project' }}"
+          metadata:
+            name: broker-test
+
+    - name: Wait for test namespace to be destroyed
       vars:
-        namespace_lookup: "{{ lookup('k8s', kind='Namespace', resource_name='automation-broker') }}"
+        namespace_lookup: "{{ lookup('k8s', kind='Namespace', resource_name='broker-test') }}"
       set_fact:
         _namespace_status: "{{ namespace_lookup }}"
       retries: 10
@@ -33,23 +255,13 @@
       until:
         - not namespace_lookup
 
-    # Test etcd
-    - name: Provision test with ETCD
-      include_role:
-        name: automation-broker-apb
-      vars:
-        apb_action: provision
-        create_broker_namespace: true
-        wait_for_broker: true
-        broker_dao_type: etcd
-
-    - name: Deprovision test with ETCD
+    - name: Deprovision test with CRDs
       include_role:
         name: automation-broker-apb
       vars:
         apb_action: deprovision
         create_broker_namespace: true
-        broker_dao_type: etcd
+        broker_dao_type: crd
 
     - name: Wait for namespace to be destroyed
       vars:

--- a/apb/tasks/main.yml
+++ b/apb/tasks/main.yml
@@ -65,7 +65,6 @@
 - name: Wait for clusterservicebroker to become ready
   debug:
     msg: "Broker ready status: {{ cluster_service_broker_query }}"
-  vars:
   retries: 60
   delay: 10
   until: cluster_service_broker_query | length > 0 and cluster_service_broker_query | first == "True"

--- a/apb/vars/main.yaml
+++ b/apb/vars/main.yaml
@@ -24,5 +24,5 @@ cluster_service_broker_query: "{{
     api_version='servicecatalog.k8s.io/v1beta1',
     kind='ClusterServiceBroker',
     resource_name=broker_name
-  ) | json_query(ready_status_query) 
+  ) | json_query(ready_status_query)
 }}"


### PR DESCRIPTION
Update travis to use the broker-apb to test the broker via the `test` playbook.
