### PR TITLE
Tie broker apb

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ branches:
   only:
   - master
   - /^release-.*$/
+  - /^ansible-service-broker-([0-9.-]+)$/
 
 env:
   #- OPENSHIFT_VERSION=v3.10.0
@@ -32,6 +33,7 @@ stages:
   - lint
   - build
   - test
+  - deploy
 
 jobs:
   include:
@@ -49,6 +51,12 @@ jobs:
         - make build
         - go get github.com/mattn/goveralls
         - make ci-test-coverage
+    - stage: deploy
+      if: repo=openshift/ansible-service-broker
+      script:
+        - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+        - if [ $TRAVIS_BRANCH == "master" ]; then export TAG="canary"; else TAG=$TRAVIS_BRANCH; fi
+        - PUBLISH=1 make publish
 
 script:
   - export apb_name="automation-broker-apb:${TRAVIS_BUILD_ID}"

--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ clean: ## Clean up your working environment
 really-clean: clean cleanup-ci ## Really clean up the working environment
 	@rm -f $(KUBERNETES_FILES)
 
-deploy: build-image build-apb ## Deploy a built broker docker image to a running cluster
+deploy: build-dev build-apb ## Deploy a built broker docker image to a running cluster
 	APB_IMAGE=${APB_IMAGE} BROKER_IMAGE=${BROKER_IMAGE} ACTION="provision" ./scripts/deploy.sh
 
 undeploy: build-apb ## Uninstall a deployed broker from a running cluster

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ ORG              ?= ansibleplaybookbundle
 TAG              ?= latest
 BROKER_IMAGE     ?= $(REGISTRY)/$(ORG)/origin-ansible-service-broker:${TAG}
 APB_DIR          ?= apb
-APB_IMAGE        ?= ${REGISTRY}/${ORG}/automation-broker-apb:${TAG}
+APB_IMAGE        ?= ${REGISTRY}/automationbroker/automation-broker-apb:${TAG}
 VARS             ?= ""
 BUILD_DIR        = "${GOPATH}/src/github.com/openshift/ansible-service-broker/build"
 PREFIX           ?= /usr/local
@@ -75,7 +75,7 @@ run: broker
 prep-local: ## Prepares the local dev environment
 	@./scripts/prep_local_devel_env.sh
 
-build-image: ## Build a docker image with the broker binary
+build-dev: ## Build a docker image with the broker binary for development
 	env GOOS=linux go build -i -ldflags="-s -s" -o ${BUILD_DIR}/broker ./cmd/broker
 	env GOOS=linux go build -i -ldflags="-s -s" -o ${BUILD_DIR}/migration ./cmd/migration
 	env GOOS=linux go build -i -ldflags="-s -s" -o ${BUILD_DIR}/dashboard-redirector ./cmd/dashboard-redirector
@@ -84,8 +84,23 @@ build-image: ## Build a docker image with the broker binary
 	@echo "Remember you need to push your image before calling make deploy"
 	@echo "    docker push ${BROKER_IMAGE}"
 
+build-image: ## Build the broker (from canary)
+	docker build -f ${BUILD_DIR}/Dockerfile-canary --build-arg VERSION=${TAG} -t ${BROKER_IMAGE} ${BUILD_DIR}
+
 build-apb: ## Build the broker apb
-	docker build -f ${APB_DIR}/Dockerfile -t ${APB_IMAGE} ${APB_DIR}
+ifeq ($(TAG),canary)
+	docker build -f ${APB_DIR}/Dockerfile --build-arg VERSION=${TAG} --build-arg APB=${TAG} -t ${APB_IMAGE} ${APB_DIR}
+else
+	docker build -f ${APB_DIR}/Dockerfile --build-arg VERSION=${TAG} -t ${APB_IMAGE} ${APB_DIR}
+endif
+
+publish: build-image build-apb
+ifdef PUBLISH
+	docker push ${BROKER_IMAGE}
+	docker push ${APB_IMAGE}
+else
+	@echo "Must set PUBLISH, here be dragons"
+endif
 
 clean: ## Clean up your working environment
 	@rm -f broker

--- a/apb/Dockerfile
+++ b/apb/Dockerfile
@@ -20,11 +20,20 @@ Q29udGFpbmVyIGltYWdlIGZvciB0aGUgYnJva2VyCiAgICAgICAgdHlwZTogc3RyaW5nCiAgICAg\
 ICAgZGVmYXVsdDogYW5zaWJsZXBsYXlib29rYnVuZGxlL29yaWdpbi1hbnNpYmxlLXNlcnZpY2Ut\
 YnJva2VyOmxhdGVzdAo="
 
+ARG VERSION=latest
+ARG APB=latest
+
 RUN yum -y install epel-release openssl && yum clean all
 
 # Add our role into the ansible roles dir
 ADD playbooks /opt/apb/actions
 ADD . /opt/ansible/roles/automation-broker-apb
+
+# Replace the broker version and apb tag
+RUN sed -i "s/\(broker_image_tag:\).*/\1 ${VERSION}/" \
+    /opt/ansible/roles/automation-broker-apb/defaults/main.yml
+RUN sed -i "s/\(broker_dockerhub_tag:\).*/\1 ${APB}/" \
+    /opt/ansible/roles/automation-broker-apb/defaults/main.yml
 
 RUN chmod -R g=u /opt/{ansible,apb}
 


### PR DESCRIPTION
This automates the process of building an APB that is tied directly to a specific version of the broker. This should allow for automated publishing of `master`, `release-`, and `ansible-service-broker-` branches to dockerhub of 1) the broker 2) broker-apb that were built at the same time.

Assuming this PR is acceptable, the consequences are:

1. A merge to `master` will create a new build of `docker.io/ansibleplaybookbundle/origin-ansible-service-broker:canary` and `docker.io/automationbroker/automation-broker-apb:canary`
1. A merge to `release-1.3` (future) will create a build of `docker.io/ansibleplaybookbundle/origin-ansible-service-broker:release-1.3` and `docker.io/automationbroker/automation-broker-apb:release-1.3` (NOTE: the dockerhub registry will be configured to look at `latest`)
1. A merge to `ansible-service-broker-1.3.2-1` (future) will create a build of `docker.io/ansibleplaybookbundle/origin-ansible-service-broker:ansible-service-broker-1.3.2-1` and `docker.io/automationbroker/automation-broker-apb:ansible-service-broker-1.3.2-1` (NOTE: the dockerhub registry will be configured to look at `latest`)