### PR TITLE
adds docs and plumbing for the skip_verify_tls setting on the rhcc adapter

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -143,7 +143,10 @@ registry:
     url: <rhcc url>
     white_list:
       - ".*-apb$"
+    skip_verify_tls: false
 ```
+
+If `skip_verify_tls` is `true`, the TLS certificate of the remote registry will not be verified. Defaults to `false`.
 
 ### OpenShift Registry
 Using the OpenShift registry will allow you to load APBs that are published to this type of [registry](http://www.projectatomic.io/registry/).

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -195,21 +195,22 @@ func CreateApp(args Args, regs []registries.Registry) App {
 		log.Debug("Connecting Registry")
 		for _, config := range app.config.GetSubConfigArray("registry") {
 			c := registries.Config{
-				URL:        config.GetString("url"),
-				User:       config.GetString("user"),
-				Pass:       config.GetString("pass"),
-				Org:        config.GetString("org"),
-				Tag:        config.GetString("tag"),
-				Type:       config.GetString("type"),
-				Name:       config.GetString("name"),
-				Images:     config.GetSliceOfStrings("images"),
-				Namespaces: config.GetSliceOfStrings("namespaces"),
-				Fail:       config.GetBool("fail_on_error"),
-				WhiteList:  config.GetSliceOfStrings("white_list"),
-				BlackList:  config.GetSliceOfStrings("black_list"),
-				AuthType:   config.GetString("auth_type"),
-				AuthName:   config.GetString("auth_name"),
-				Runner:     config.GetString("runner"),
+				URL:           config.GetString("url"),
+				User:          config.GetString("user"),
+				Pass:          config.GetString("pass"),
+				Org:           config.GetString("org"),
+				Tag:           config.GetString("tag"),
+				Type:          config.GetString("type"),
+				Name:          config.GetString("name"),
+				Images:        config.GetSliceOfStrings("images"),
+				Namespaces:    config.GetSliceOfStrings("namespaces"),
+				Fail:          config.GetBool("fail_on_error"),
+				WhiteList:     config.GetSliceOfStrings("white_list"),
+				BlackList:     config.GetSliceOfStrings("black_list"),
+				AuthType:      config.GetString("auth_type"),
+				AuthName:      config.GetString("auth_name"),
+				Runner:        config.GetString("runner"),
+				SkipVerifyTLS: config.GetBool("skip_verify_tls"),
 			}
 
 			reg, err := registries.NewRegistry(c, app.config.GetString("openshift.namespace"))


### PR DESCRIPTION
#### Describe what this PR does and why we need it:

This enables testing the broker with stage registries that use a self-signed CA. It could also be useful for other scenarios. It is a companion PR to https://github.com/automationbroker/bundle-lib/pull/98

#### Changes proposed in this pull request

 - surfaces a setting that exposes a feature of bundle-lib that can skip TLS cert verification
