### PR TITLE
Pass in namespace to runtime

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -170,7 +170,8 @@ func CreateApp(args Args, regs []registries.Registry) App {
 
 	// Initialize Runtime
 	log.Debug("Connecting to Cluster")
-	agnosticruntime.NewRuntime(agnosticruntime.Configuration{})
+	brokerNS := app.config.GetString("openshift.namespace")
+	agnosticruntime.NewRuntime(agnosticruntime.Configuration{StateMasterNamespace: brokerNS})
 	agnosticruntime.Provider.ValidateRuntime()
 	if err != nil {
 		log.Error(err.Error())
@@ -277,12 +278,12 @@ func CreateApp(args Args, regs []registries.Registry) App {
 	clusterConfig := bundle.ClusterConfig{
 		PullPolicy:           app.config.GetString("openshift.image_pull_policy"),
 		SandboxRole:          app.config.GetString("openshift.sandbox_role"),
-		Namespace:            app.config.GetString("openshift.namespace"),
+		Namespace:            brokerNS,
 		KeepNamespace:        app.config.GetBool("openshift.keep_namespace"),
 		KeepNamespaceOnError: app.config.GetBool("openshift.keep_namespace_on_error"),
 	}
 	bundle.InitializeClusterConfig(clusterConfig)
-	brokerNS := app.config.GetString("openshift.namespace")
+
 	// initialize the work factory
 	workFactory := broker.NewWorkFactory()
 	if app.broker, err = broker.NewAnsibleBroker(

--- a/pkg/broker/broker_test.go
+++ b/pkg/broker/broker_test.go
@@ -47,7 +47,7 @@ func TestAddIdForPlan(t *testing.T) {
 }
 
 func TestNewAnsibleBroker(t *testing.T) {
-	_, err := NewAnsibleBroker(&mocks.Dao{}, []registries.Registry{}, *NewWorkEngine(20, 2*time.Minute), &config.Config{}, "new-space")
+	_, err := NewAnsibleBroker(&mocks.Dao{}, []registries.Registry{}, *NewWorkEngine(20, 2*time.Minute, &mocks.Dao{}), &config.Config{}, "new-space", NewWorkFactory())
 	if err != nil {
 		t.Fail()
 	}
@@ -203,7 +203,7 @@ func TestGetServiceInstance(t *testing.T) {
 				brokerConfig: tc.config,
 				registry:     nil,
 				namespace:    "test1",
-				engine:       NewWorkEngine(20, 2*time.Minute),
+				engine:       NewWorkEngine(20, 2*time.Minute, mockDao),
 				dao:          tc.dao,
 			}
 


### PR DESCRIPTION
#### Describe what this PR does and why we need it:
the namespace for the broker can change. So ensure it is passed through to the runtime package at startup.

While testing some state changes, I noticed state was not being saved this was due to the fact it was expecting to save to the ns ansible-service-broker.

While running make check I noticed that several tests were failing due to compilation errors so I fixed these also.