### PR TITLE
Simple ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,8 +65,8 @@ jobs:
         - PUBLISH=1 make publish
 
 script:
-  - export apb_name="automation-broker-apb:${TRAVIS_BUILD_ID}"
-  - export broker_image="ansible-service-broker:${TRAVIS_BUILD_ID}"
+  - export BROKER_IMAGE="ansible-service-broker:${TRAVIS_BUILD_ID}"
+  - export APB_IMAGE="automation-broker-apb:${TRAVIS_BUILD_ID}"
 
   # Download test shim.
   - wget -O ${PWD}/apb-test.sh https://raw.githubusercontent.com/ansibleplaybookbundle/apb-test-shim/master/apb-test.sh
@@ -76,5 +76,9 @@ script:
   # Setup cluster
   - setup_cluster
 
+  # Build the broker + broker-apb
+  - make build-image
+  - make build-apb
+
   # Run CI
-  - BROKER_IMAGE=$broker_image APB_IMAGE=$apb_name make ci
+  - make ci

--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ undeploy: build-apb ## Uninstall a deployed broker from a running cluster
 	APB_IMAGE=${APB_IMAGE} BROKER_IMAGE=${BROKER_IMAGE} ACTION="deprovision" ./scripts/deploy.sh
 
 ## Continuous integration stuff
-ci: build-image build-apb ##Run the broker ci
+ci: ## Run the broker ci
 	APB_IMAGE=${APB_IMAGE} BROKER_IMAGE=${BROKER_IMAGE} ACTION="test" ./scripts/deploy.sh
 
 help: ## Show this help screen

--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,8 @@ build-image: ## Build the broker (from canary)
 build-apb: ## Build the broker apb
 ifeq ($(TAG),canary)
 	docker build -f ${APB_DIR}/Dockerfile --build-arg VERSION=${TAG} --build-arg APB=${TAG} -t ${APB_IMAGE} ${APB_DIR}
+else ifeq ($(TAG),nightly)
+	docker build -f ${APB_DIR}/Dockerfile --build-arg VERSION=${TAG} --build-arg APB=${TAG} -t ${APB_IMAGE} ${APB_DIR}
 else ifneq (,$(findstring release,$(TAG)))
 	docker build -f ${APB_DIR}/Dockerfile --build-arg VERSION=${TAG} --build-arg APB=${TAG} -t ${APB_IMAGE} ${APB_DIR}
 else


### PR DESCRIPTION
Makes it possible for us, in Jenkins, to run ci without building the apb and broker image. Also makes it possible for us to tie the broker|broker-apb nightly tags.