### PR TITLE
Add ns broker support to the broker's apb

### DIFF
--- a/apb/tasks/main.yml
+++ b/apb/tasks/main.yml
@@ -7,7 +7,6 @@
     cluster: "{{ _cluster_type }}"
     broker_auto_escalate: "{{ 'true' if _cluster_type == 'kubernetes' else 'false' }}"
     broker_local_openshift_enabled: "{{ 'true' if _cluster_type == 'openshift' else 'false' }}"
-    broker_ready_query: "{{ service_broker_query if broker_kind == 'ServiceBroker' else cluster_service_broker_query }}"
   vars:
     _cluster_type: '{{ "openshift" if "openshift" in lookup("k8s", cluster_info="version") else "kubernetes" }}'
 
@@ -64,10 +63,18 @@
     - name: broker.deployment.yaml
     - name: broker.servicecatalog.yaml
 
-- name: Wait for broker to become ready
+- name: Wait for clusterservicebroker to become ready
   debug:
-    msg: "Broker ready status: {{ broker_ready_query }}"
+    msg: "Broker ready status: {{ cluster_service_broker_query }}"
   retries: 60
   delay: 10
-  until: broker_ready_query | length > 0 and broker_ready_query | first == "True"
-  when: state == 'present' and wait_for_broker
+  until: cluster_service_broker_query | length > 0 and cluster_service_broker_query | first == "True"
+  when: broker_kind == 'ClusterServiceBroker' and state == 'present' and wait_for_broker
+
+- name: Wait for servicebroker to become ready
+  debug:
+    msg: "Broker ready status: {{ service_broker_query }}"
+  retries: 60
+  delay: 10
+  until: service_broker_query | length > 0 and service_broker_query | first == "True"
+  when: broker_kind == 'ServiceBroker' and state == 'present' and wait_for_broker

--- a/apb/tasks/main.yml
+++ b/apb/tasks/main.yml
@@ -7,6 +7,7 @@
     cluster: "{{ _cluster_type }}"
     broker_auto_escalate: "{{ 'true' if _cluster_type == 'kubernetes' else 'false' }}"
     broker_local_openshift_enabled: "{{ 'true' if _cluster_type == 'openshift' else 'false' }}"
+    broker_ready_query: "{{ service_broker_query if broker_kind == 'ServiceBroker' else cluster_service_broker_query }}"
   vars:
     _cluster_type: '{{ "openshift" if "openshift" in lookup("k8s", cluster_info="version") else "kubernetes" }}'
 
@@ -63,10 +64,10 @@
     - name: broker.deployment.yaml
     - name: broker.servicecatalog.yaml
 
-- name: Wait for clusterservicebroker to become ready
+- name: Wait for broker to become ready
   debug:
-    msg: "Broker ready status: {{ cluster_service_broker_query }}"
+    msg: "Broker ready status: {{ broker_ready_query }}"
   retries: 60
   delay: 10
-  until: cluster_service_broker_query | length > 0 and cluster_service_broker_query | first == "True"
+  until: broker_ready_query | length > 0 and broker_ready_query | first == "True"
   when: state == 'present' and wait_for_broker

--- a/apb/templates/broker-access.clusterrole.yaml
+++ b/apb/templates/broker-access.clusterrole.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: access-{{ broker_namespace }}-role
+  name: access-{{ broker_name }}-role
 rules:
 - nonResourceURLs:
     - "/{{ broker_namespace }}"

--- a/apb/templates/broker-access.clusterrole.yaml
+++ b/apb/templates/broker-access.clusterrole.yaml
@@ -3,11 +3,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: access-{{ broker_name }}-role
+  name: access-{{ broker_namespace }}-role
 rules:
 - nonResourceURLs:
-    - "/{{ broker_name }}"
-    - "/{{ broker_name }}/*"
+    - "/{{ broker_namespace }}"
+    - "/{{ broker_namespace }}/*"
   verbs:
     - "get"
     - "post"

--- a/apb/templates/broker-client.clusterrolebinding.yaml
+++ b/apb/templates/broker-client.clusterrolebinding.yaml
@@ -10,5 +10,5 @@ subjects:
   namespace: {{ broker_namespace }}
 roleRef:
   kind: ClusterRole
-  name: access-{{ broker_name }}-role
+  name: access-{{ broker_namespace }}-role
   apiGroup: rbac.authorization.k8s.io

--- a/apb/templates/broker-client.clusterrolebinding.yaml
+++ b/apb/templates/broker-client.clusterrolebinding.yaml
@@ -10,5 +10,5 @@ subjects:
   namespace: {{ broker_namespace }}
 roleRef:
   kind: ClusterRole
-  name: access-{{ broker_namespace }}-role
+  name: access-{{ broker_name }}-role
   apiGroup: rbac.authorization.k8s.io

--- a/apb/templates/broker.servicecatalog.yaml
+++ b/apb/templates/broker.servicecatalog.yaml
@@ -4,9 +4,12 @@ apiVersion: servicecatalog.k8s.io/v1beta1
 kind: {{ broker_kind }}
 metadata:
   name: {{ broker_name }}
+{% if broker_kind == 'ServiceBroker' %}
+  namespace: {{ broker_namespace }}
+{% endif %}
 {% if state == 'present' %}
 spec:
-  url: https://{{ broker_name }}.{{ broker_namespace }}.svc:1338/{{ broker_name }}/
+  url: https://{{ broker_name }}.{{ broker_namespace }}.svc:1338/{{ broker_namespace }}/
   authInfo:
     bearer:
       secretRef:

--- a/apb/vars/main.yaml
+++ b/apb/vars/main.yaml
@@ -26,3 +26,12 @@ cluster_service_broker_query: "{{
     resource_name=broker_name
   ) | json_query(ready_status_query)
 }}"
+service_broker_query: "{{
+  lookup(
+    'k8s',
+    api_version='servicecatalog.k8s.io/v1beta1',
+    kind='ServiceBroker',
+    resource_name=broker_name,
+    namespace=broker_namespace
+  ) | json_query(ready_status_query)
+}}"


### PR DESCRIPTION
#### Describe what this PR does and why we need it:
Adds a switch that will install the broker as a namespaced broker into the `broker_namespace` specified. This will only function if the catalog running has the feature gate `NamespacedServiceBroker` set to true.