### PR TITLE
Add galaxy adapter

### DIFF
--- a/apb/defaults/main.yml
+++ b/apb/defaults/main.yml
@@ -53,8 +53,6 @@ broker_basic_auth_username: "admin"
 broker_basic_auth_password: "admin"
 
 # Broker dockerhub registry options
-# TODO: Support multiple dockerhub registries
-# https://github.com/automationbroker/automation-broker-apb/issues/2
 broker_dockerhub_enabled: true
 broker_dockerhub_name: dh
 broker_dockerhub_url: https://registry.hub.docker.com
@@ -63,8 +61,6 @@ broker_dockerhub_tag: latest
 broker_dockerhub_white_list: [ ".*-apb$" ]
 
 # Broker local openshift registry options
-# TODO: Support multiple local openshift registries
-# https://github.com/automationbroker/automation-broker-apb/issues/2
 broker_local_openshift_enabled: ""
 broker_local_openshift_name: localregistry
 broker_local_openshift_namespaces: [ "openshift" ]
@@ -74,10 +70,15 @@ broker_local_openshift_namespaces: [ "openshift" ]
 broker_local_openshift_white_list: [ ".*" ]
 
 # Broker helm registry options
-# TODO: Support multiple helm type registries
-# https://github.com/automationbroker/automation-broker-apb/issues/2
 broker_helm_enabled: false
 broker_helm_name: stable
 broker_helm_url: https://kubernetes-charts.storage.googleapis.com
 broker_helm_runner: docker.io/automationbroker/helm-runner:latest
 broker_helm_white_list: [ ".*" ]
+
+# Broker galaxy registry options
+broker_galaxy_enabled: true
+broker_galaxy_name: galaxy
+broker_galaxy_url: https://galaxy.ansible.com
+broker_galaxy_runner: docker.io/ansibleplaybookbundle/apb-base:latest
+broker_galaxy_white_list: [ ".*" ]

--- a/apb/defaults/main.yml
+++ b/apb/defaults/main.yml
@@ -80,5 +80,6 @@ broker_helm_white_list: [ ".*" ]
 broker_galaxy_enabled: true
 broker_galaxy_name: galaxy
 broker_galaxy_url: https://galaxy.ansible.com
+broker_galaxy_org: ansibleplaybookbundle
 broker_galaxy_runner: docker.io/ansibleplaybookbundle/apb-base:latest
 broker_galaxy_white_list: [ ".*" ]

--- a/apb/tasks/main.yml
+++ b/apb/tasks/main.yml
@@ -59,7 +59,6 @@
     - name: broker-access.clusterrole.yaml
     - name: broker-auth.secret.yaml
       apply: "{{ True if broker_basic_auth_enabled else False }}"
-    - name: broker-user-auth.clusterrole.yaml
     - name: broker.deployment.yaml
     - name: broker.servicecatalog.yaml
 

--- a/apb/templates/broker.configmap.yaml
+++ b/apb/templates/broker.configmap.yaml
@@ -43,6 +43,16 @@ data:
           - {{ item | quote }}
 {%     endfor %}
 {% endif %}
+{% if broker_galaxy_enabled | bool %}
+      - type: galaxy
+        name: {{ broker_galaxy_name }}
+{# url: {{ broker_galaxy_url }} #}
+        runner: {{ broker_galaxy_runner }}
+        white_list:
+{%     for item in broker_galaxy_white_list %}
+          - {{ item | quote }}
+{%     endfor %}
+{% endif %}
     dao:
       type: {{ broker_dao_type | quote }}
 {% if broker_dao_type == 'etcd' %}

--- a/apb/templates/broker.configmap.yaml
+++ b/apb/templates/broker.configmap.yaml
@@ -47,6 +47,7 @@ data:
       - type: galaxy
         name: {{ broker_galaxy_name }}
         url: {{ broker_galaxy_url }}
+        org: {{ broker_galaxy_org | quote }}
         runner: {{ broker_galaxy_runner }}
         white_list:
 {%     for item in broker_galaxy_white_list %}

--- a/apb/templates/broker.configmap.yaml
+++ b/apb/templates/broker.configmap.yaml
@@ -46,7 +46,7 @@ data:
 {% if broker_galaxy_enabled | bool %}
       - type: galaxy
         name: {{ broker_galaxy_name }}
-{# url: {{ broker_galaxy_url }} #}
+        url: {{ broker_galaxy_url }}
         runner: {{ broker_galaxy_runner }}
         white_list:
 {%     for item in broker_galaxy_white_list %}

--- a/docs/config.md
+++ b/docs/config.md
@@ -153,6 +153,23 @@ registry:
 well suited for OpenShift. For more information see
 [here](https://github.com/ansibleplaybookbundle/helm2bundle/wiki/Known-Issues).
 
+### Ansible Galaxy Registry
+
+Using the [Ansible Galaxy](https://galaxy.ansible.com) will allow you to
+consume APB roles in Galaxy. The configuration would look like:
+
+```yaml
+registry:
+  - type: galaxy
+    name: galaxy
+    url: https://galaxy.ansible.com
+    # Optional:
+    # org: ansibleplaybookbundle
+    runner: docker.io/ansibleplaybookbundle/apb-base:latest
+    white_list:
+      - ".*"
+```
+
 ### Red Hat Container Catalog (RHCC) Registry
 Using the RHCC (Red Hat Container Catalog) registry will allow you to load APBs that are published to this type of [registry](https://access.redhat.com/containers).
 


### PR DESCRIPTION
Update the Broker's APB to support configuring the Ansible Galaxy registry adapter as well as our config doc.