### PR TITLE
Update galaxy-adapter to include galaxy URL

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,60 +3,47 @@
 
 [[projects]]
   branch = "default"
-  digest = "1:c0164b6d52877372590085b45f53a160f47c24e8a2312bb815489223044f5914"
   name = "bitbucket.org/ww/goautoneg"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "75cd24fc2f2c2a2088577d12123ddee5f54e0675"
 
 [[projects]]
-  digest = "1:a26f8da48b22e6176c1c6a2459904bb30bd0c49ada04b2963c2c3a203e81a620"
   name = "github.com/Masterminds/semver"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "c7af12943936e8c39859482e61f0574c2fd7fc75"
   version = "v1.4.2"
 
 [[projects]]
-  digest = "1:76939b72b6b2012e9aca613f33d947099178c9f0d3be5522485701031ebf3e49"
   name = "github.com/NYTimes/gziphandler"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "2600fb119af974220d3916a5916d6e31176aac1b"
   version = "v1.0.1"
 
 [[projects]]
-  digest = "1:d8ebbd207f3d3266d4423ce4860c9f3794956306ded6c7ba312ecc69cdfbf04c"
   name = "github.com/PuerkitoBio/purell"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "0bcb03f4b4d0a9428594752bd2a3b9aa0a9d4bd4"
   version = "v1.1.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:8098cd40cd09879efbf12e33bcd51ead4a66006ac802cd563a66c4f3373b9727"
   name = "github.com/PuerkitoBio/urlesc"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "de5bf2ad457846296e2031421a34e2568e304e35"
 
 [[projects]]
   branch = "master"
-  digest = "1:778a8a63e28851c6976939c8bd37d7061b95030973ce41b6ded178e56984110d"
   name = "github.com/automationbroker/broker-client-go"
   packages = [
     "client/clientset/versioned",
     "client/clientset/versioned/scheme",
     "client/clientset/versioned/typed/automationbroker/v1alpha1",
     "pkg/apis/automationbroker",
-    "pkg/apis/automationbroker/v1alpha1",
+    "pkg/apis/automationbroker/v1alpha1"
   ]
-  pruneopts = "NUT"
   revision = "bf1c2b52e55d67b4c3a917daaadee9b86a6c66e0"
 
 [[projects]]
-  digest = "1:f866ae3545470b0dccd066519cdc72c4ceca10218aae305eb1b540e068884fa7"
   name = "github.com/automationbroker/bundle-lib"
   packages = [
     "authorization",
@@ -67,30 +54,24 @@
     "registries",
     "registries/adapters",
     "registries/adapters/oauth",
-    "runtime",
+    "runtime"
   ]
-  pruneopts = "NUT"
-  revision = "95ef30a81838c87bc4aa946caa467fc9a2a9fddf"
-  version = "0.2.5"
+  revision = "83761f23d620069d21edd1055b03653b35986e5f"
+  version = "0.2.7"
 
 [[projects]]
   branch = "master"
-  digest = "1:6f097fd1de095de4e7cc814b1314b4ef8e008c06872e235569e51a28cfc8f772"
   name = "github.com/automationbroker/config"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "fc81cc0361e7e51a9f6f1fd8bb9e703e81c1a56f"
 
 [[projects]]
   branch = "master"
-  digest = "1:707ebe952a8b3d00b343c01536c79c73771d100f63ec6babeaed5c79e2b8a8dd"
   name = "github.com/beorn7/perks"
   packages = ["quantile"]
-  pruneopts = "NUT"
   revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
 
 [[projects]]
-  digest = "1:fd665f1c55093c2ffdbce78034d1037076554fd23ec152654ab515f7afa6d9c4"
   name = "github.com/coreos/etcd"
   packages = [
     "auth/authpb",
@@ -104,361 +85,281 @@
     "pkg/tlsutil",
     "pkg/transport",
     "pkg/types",
-    "version",
+    "version"
   ]
-  pruneopts = "NUT"
   revision = "33245c6b5b49130ca99280408fadfab01aac0e48"
   version = "v3.3.8"
 
 [[projects]]
-  digest = "1:0ef770954bca104ee99b3b6b7f9b240605ac03517d9f98cbc1893daa03f3c038"
   name = "github.com/coreos/go-semver"
   packages = ["semver"]
-  pruneopts = "NUT"
   revision = "8ab6407b697782a06568d4b7f1db25550ec2e4c6"
   version = "v0.2.0"
 
 [[projects]]
-  digest = "1:1da3a221f0bc090792d3a2a080ff09008427c0e0f0533a4ed6abd8994421da73"
   name = "github.com/coreos/go-systemd"
   packages = ["daemon"]
-  pruneopts = "NUT"
   revision = "39ca1b05acc7ad1220e09f133283b8859a8b71ab"
   version = "v17"
 
 [[projects]]
-  digest = "1:a2c1d0e43bd3baaa071d1b9ed72c27d78169b2b269f71c105ac4ba34b1be4a39"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
-  pruneopts = "NUT"
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
   version = "v1.1.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:ff6b9b62a30f2237a6f4f8fbe5e89ec522db652998b00f9ded76bd63c1f284fb"
   name = "github.com/docker/spdystream"
   packages = [
     ".",
-    "spdy",
+    "spdy"
   ]
-  pruneopts = "NUT"
   revision = "bc6354cbbc295e925e4c611ffe90c1f287ee54db"
 
 [[projects]]
-  digest = "1:d612f023556888f38ccbaf22cde164f88a23619d5877fcd34a707c6b021ae6da"
   name = "github.com/elazarl/go-bindata-assetfs"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:feff0d85bf72d3f1c5955338bceb2533e33733c5c72e643c990db9f28abe5a61"
   name = "github.com/emicklei/go-restful"
   packages = [
     ".",
-    "log",
+    "log"
   ]
-  pruneopts = "NUT"
   revision = "3eb9738c1697594ea6e71a7156a9bb32ed216cf0"
   version = "v2.8.0"
 
 [[projects]]
-  digest = "1:27e00683ae7700cf7b286011dcd6ace672d542d236590dcc51bd10669cfb3366"
   name = "github.com/emicklei/go-restful-swagger12"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "dcef7f55730566d41eae5db10e7d6981829720f6"
   version = "1.0.1"
 
 [[projects]]
-  digest = "1:ad32dc29f37281bacb5dcedff17c9461dc1739dc8a5f63a71ab491c6e92edf8d"
   name = "github.com/evanphx/json-patch"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "afac545df32f2287a079e2dfb7ba2745a643747e"
   version = "v3.0.0"
 
 [[projects]]
-  digest = "1:81466b4218bf6adddac2572a30ac733a9255919bc2f470b4827a317bd4ee1756"
   name = "github.com/ghodss/yaml"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "0ca9ea5df5451ffdf184b4428c902747c2c11cd7"
   version = "v1.0.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:260f7ebefc63024c8dfe2c9f1a2935a89fa4213637a1f522f592f80c001cc441"
   name = "github.com/go-openapi/jsonpointer"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "3a0015ad55fa9873f41605d3e8f28cd279c32ab2"
 
 [[projects]]
   branch = "master"
-  digest = "1:98abd61947ff5c7c6fcfec5473d02a4821ed3a2dd99a4fbfdb7925b0dd745546"
   name = "github.com/go-openapi/jsonreference"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "3fb327e6747da3043567ee86abd02bb6376b6be2"
 
 [[projects]]
   branch = "master"
-  digest = "1:87216dc20d985010c4cbe3301b4f9d4c81eaea407a289bd6338d2ac66d61b5a4"
   name = "github.com/go-openapi/spec"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "bce47c9386f9ecd6b86f450478a80103c3fe1402"
 
 [[projects]]
   branch = "master"
-  digest = "1:d6dca21942524b423bf8d3e273c61874f7cd5511c2797e67685c33f4ab971f57"
   name = "github.com/go-openapi/swag"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "2b0bd4f193d011c203529df626a65d63cb8a79e8"
 
 [[projects]]
-  digest = "1:fd0bb2c9190193f2fac39a1c7331e191fe765a13f3abd05293e3dc17f8718bd8"
   name = "github.com/gogo/protobuf"
   packages = [
     "gogoproto",
     "proto",
     "protoc-gen-gogo/descriptor",
-    "sortkeys",
+    "sortkeys"
   ]
-  pruneopts = "NUT"
   revision = "1adfc126b41513cc696b209667c8656ea7aac67c"
   version = "v1.0.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:e2b86e41f3d669fc36b50d31d32d22c8ac656c75aa5ea89717ce7177e134ff2a"
   name = "github.com/golang/glog"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
 
 [[projects]]
-  digest = "1:713cc7628304d027a7e9edcb52da888a8912d6405250a8d9c8eff6f41dd54398"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
     "ptypes",
     "ptypes/any",
     "ptypes/duration",
-    "ptypes/timestamp",
+    "ptypes/timestamp"
   ]
-  pruneopts = "NUT"
   revision = "b4deda0973fb4c70b50d226b1af49f3da59f5265"
   version = "v1.1.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:245bd4eb633039cd66106a5d340ae826d87f4e36a8602fcc940e14176fd26ea7"
   name = "github.com/google/btree"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "e89373fe6b4a7413d7acd6da1725b83ef713e6e4"
 
 [[projects]]
   branch = "master"
-  digest = "1:52c5834e2bebac9030c97cc0798ac11c3aa8a39f098aeb419f142533da6cd3cc"
   name = "github.com/google/gofuzz"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "24818f796faf91cd76ec7bddd72458fbced7a6c1"
 
 [[projects]]
-  digest = "1:add738701bd5b2b985c0c37011092c57218bdc46caf1e682a73dc210ad36b03f"
   name = "github.com/googleapis/gnostic"
   packages = [
     "OpenAPIv2",
     "compiler",
-    "extensions",
+    "extensions"
   ]
-  pruneopts = "NUT"
   revision = "7c663266750e7d82587642f65e60bc4083f1f84e"
   version = "v0.2.0"
 
 [[projects]]
-  digest = "1:c01767916c59f084bb7c41a7d5877c0f3099b1595cfa066e84ec6ad6b084dd89"
   name = "github.com/gorilla/context"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "08b5f424b9271eedf6f9f0ce86cb9396ed337a42"
   version = "v1.1.1"
 
 [[projects]]
-  digest = "1:b54ca99db94a9478cdc17346c82fe6433ba9e553c9b1382018a1a98995ce910f"
   name = "github.com/gorilla/handlers"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "a4043c62cc2329bacda331d33fc908ab11ef0ec3"
   version = "v1.2.1"
 
 [[projects]]
-  digest = "1:3b5781a3491b9cf4cf2032b61a5c0589adfff63eb3dad88237aec6adc41e89f4"
   name = "github.com/gorilla/mux"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "bcd8bc72b08df0f70df986b97f95590779502d31"
   version = "v1.4.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:a1db0214936912602a7a8cedc09a2e3211f5c097dc89189fb4b3bc86346c9e89"
   name = "github.com/gregjones/httpcache"
   packages = [
     ".",
-    "diskcache",
+    "diskcache"
   ]
-  pruneopts = "NUT"
   revision = "9cad4c3443a7200dd6400aef47183728de563a38"
 
 [[projects]]
   branch = "master"
-  digest = "1:13e2fa5735a82a5fb044f290cfd0dba633d1c5e516b27da0509e0dbb3515a18e"
   name = "github.com/hashicorp/golang-lru"
   packages = [
     ".",
-    "simplelru",
+    "simplelru"
   ]
-  pruneopts = "NUT"
   revision = "0fb14efe8c47ae851c0034ed7a448854d3d34cf3"
 
 [[projects]]
   branch = "master"
-  digest = "1:b7f860847a1d71f925ba9385ed95f1ebc0abfeb418a78e219ab61f48fdfeffad"
   name = "github.com/howeyc/gopass"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "bf9dde6d0d2c004a008c27aaee91170c786f6db8"
 
 [[projects]]
-  digest = "1:65300ccc4bcb38b107b868155c303312978981e56bca707c81efec57575b5e06"
   name = "github.com/imdario/mergo"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "9316a62528ac99aaecb4e47eadd6dc8aa6533d58"
   version = "v0.3.5"
 
 [[projects]]
-  digest = "1:914f8eaa63b88fe6bcd656d81b3f3ccd2e8422df1787a6abe32554e4b75c0556"
   name = "github.com/jessevdk/go-flags"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "96dc06278ce32a0e9d957d590bb987c81ee66407"
   version = "v1.3.0"
 
 [[projects]]
-  digest = "1:0243cffa4a3410f161ee613dfdd903a636d07e838a42d341da95d81f42cd1d41"
   name = "github.com/json-iterator/go"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "ab8a2e0c74be9d3be70b3184d9acc634935ded82"
   version = "1.1.4"
 
 [[projects]]
-  digest = "1:8b3234b10eacd5edea45bf0c13a585b608749da23f94aaf29b46d9ef8a8babf4"
   name = "github.com/juju/ratelimit"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "59fac5042749a5afb9af70e813da1dd5474f0167"
   version = "1.0.1"
 
 [[projects]]
   branch = "master"
-  digest = "1:b8cf5656a24c0db92b6244691e35186d9108598fa5f8b59a73953d56ee5971ea"
   name = "github.com/lestrrat/go-jspointer"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "d5f7c71bfd03c8e9489a636874cd106c22d3a47c"
 
 [[projects]]
   branch = "master"
-  digest = "1:658f2ea33d9fe1b61305210b23ba4cc7727b610a75abe63e71b73cb98b2fd384"
   name = "github.com/lestrrat/go-jsref"
   packages = [
     ".",
-    "provider",
+    "provider"
   ]
-  pruneopts = "NUT"
   revision = "50df7b2d07d799426a9ac43fa24bdb4785f72a54"
 
 [[projects]]
   branch = "master"
-  digest = "1:80721a2f5e7799834c14fa1823f3dcec7b9592646bab18ef37036defbafd4eb8"
   name = "github.com/lestrrat/go-jsschema"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "a6a42341b50d8d7e2a733db922eefaa756321021"
 
 [[projects]]
   branch = "master"
-  digest = "1:b9c8c629d0a86a2a1e59620e4e85d1e1f6e5ffe1deb3b140c7bafcfea3b62ce5"
   name = "github.com/lestrrat/go-pdebug"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "569c97477ae8837e053e5a50bc739e15172b8ebe"
 
 [[projects]]
   branch = "master"
-  digest = "1:0cc5ccca5dbd33e4f88fc78ac2cc0e3801df445348066272186628de25878ba8"
   name = "github.com/lestrrat/go-structinfo"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "8204d40bbcd79eb7603cd4c2c998e60eb2479ded"
 
 [[projects]]
   branch = "master"
-  digest = "1:7a259d4e4da6adc969dc948121ddce023eae8e38ca152ea97ea51123dc8ac0d4"
   name = "github.com/mailru/easyjson"
   packages = [
     "buffer",
     "jlexer",
-    "jwriter",
+    "jwriter"
   ]
-  pruneopts = "NUT"
   revision = "3fdea8d05856a0c8df22ed4bc71b3219245e4485"
 
 [[projects]]
-  digest = "1:5985ef4caf91ece5d54817c11ea25f182697534f8ae6521eadcd628c142ac4b6"
   name = "github.com/matttproud/golang_protobuf_extensions"
   packages = ["pbutil"]
-  pruneopts = "NUT"
   revision = "c12348ce28de40eed0136aa2b644d0ee0650e56c"
   version = "v1.0.1"
 
 [[projects]]
-  digest = "1:2f42fa12d6911c7b7659738758631bec870b7e9b4c6be5444f963cdcfccc191f"
   name = "github.com/modern-go/concurrent"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94"
   version = "1.0.3"
 
 [[projects]]
-  digest = "1:c6aca19413b13dc59c220ad7430329e2ec454cc310bc6d8de2c7e2b93c18a0f6"
   name = "github.com/modern-go/reflect2"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "4b7aa43c6742a2c18fdef89dd197aaae7dac7ccd"
   version = "1.0.1"
 
 [[projects]]
   branch = "master"
-  digest = "1:a6156889b651cc0bf3d9bef82b6ba8fbb9eb19aefd7bc5718357c38b67297cbc"
   name = "github.com/mxk/go-flowrate"
   packages = ["flowrate"]
-  pruneopts = "NUT"
   revision = "cca7078d478f8520f85629ad7c68962d31ed7682"
 
 [[projects]]
   branch = "release-3.9"
-  digest = "1:7678962929d58d1b973694dd38f28ce04e3c0e4b925e3528bb8195046d7b76f1"
   name = "github.com/openshift/api"
   packages = [
     "authorization/v1",
@@ -467,13 +368,11 @@
     "image/v1",
     "network/v1",
     "pkg/serialization",
-    "route/v1",
+    "route/v1"
   ]
-  pruneopts = "NUT"
   revision = "0d921e363e951d89f583292c60d013c318df64dc"
 
 [[projects]]
-  digest = "1:08cedf2ff82b9f584ca20308f4030326254b430eb8fa77f562b5dba0435cd0b1"
   name = "github.com/openshift/client-go"
   packages = [
     "authorization/clientset/versioned/scheme",
@@ -483,147 +382,115 @@
     "network/clientset/versioned/scheme",
     "network/clientset/versioned/typed/network/v1",
     "route/clientset/versioned/scheme",
-    "route/clientset/versioned/typed/route/v1",
+    "route/clientset/versioned/typed/route/v1"
   ]
-  pruneopts = "NUT"
   revision = "1fa528d3be060e4c7178eb69e76d37cf7e699e3c"
   version = "v3.9.0"
 
 [[projects]]
-  digest = "1:cce3a18fb0b96b5015cd8ca03a57d20a662679de03c4dc4b6ff5f17ea2050fa6"
   name = "github.com/pborman/uuid"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "e790cca94e6cc75c7064b1332e63811d4aae1a53"
   version = "v1.1"
 
 [[projects]]
   branch = "master"
-  digest = "1:3bf17a6e6eaa6ad24152148a631d18662f7212e21637c2699bff3369b7f00fa2"
   name = "github.com/petar/GoLLRB"
   packages = ["llrb"]
-  pruneopts = "NUT"
   revision = "53be0d36a84c2a886ca057d34b6aa4468df9ccb4"
 
 [[projects]]
-  digest = "1:6c6d91dc326ed6778783cff869c49fb2f61303cdd2ebbcf90abe53505793f3b6"
   name = "github.com/peterbourgon/diskv"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "5f041e8faa004a95c88a202771f4cc3e991971e6"
   version = "v2.0.1"
 
 [[projects]]
-  digest = "1:5cf3f025cbee5951a4ee961de067c8a89fc95a5adabead774f82822efabab121"
   name = "github.com/pkg/errors"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
   version = "v0.8.0"
 
 [[projects]]
-  digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
-  pruneopts = "NUT"
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:3e5fd795ebf6a9e13e67d644da76130af7a6003286531f9573f8074c228b66a3"
   name = "github.com/prometheus/client_golang"
   packages = ["prometheus"]
-  pruneopts = "NUT"
   revision = "c5b7fccd204277076155f10851dad72b76a49317"
   version = "v0.8.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:53a76eb11bdc815fcf0c757a9648fda0ab6887da13f07587181ff2223b67956c"
   name = "github.com/prometheus/client_model"
   packages = ["go"]
-  pruneopts = "NUT"
   revision = "99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c"
 
 [[projects]]
   branch = "master"
-  digest = "1:3bbebf77a04cda10bd07834d1686141608aca01c1aeb400d504d8aa026793b5a"
   name = "github.com/prometheus/common"
   packages = [
     "expfmt",
     "internal/bitbucket.org/ww/goautoneg",
-    "model",
+    "model"
   ]
-  pruneopts = "NUT"
   revision = "7600349dcfe1abd18d72d3a1770870d9800a7801"
 
 [[projects]]
   branch = "master"
-  digest = "1:37e418257b05a9e9fabbf836df2d8f3613313e80a909da6b9597b759ebca61cd"
   name = "github.com/prometheus/procfs"
   packages = [
     ".",
     "internal/util",
     "nfs",
-    "xfs",
+    "xfs"
   ]
-  pruneopts = "NUT"
   revision = "ae68e2d4c00fed4943b5f6698d504a5fe083da8a"
 
 [[projects]]
-  digest = "1:6989062eb7ccf25cf38bf4fe3dba097ee209f896cda42cefdca3927047bef7b6"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "c155da19408a8799da419ed3eeb0cb5db0ad5dbc"
   version = "v1.0.5"
 
 [[projects]]
-  digest = "1:15e5c398fbd9d2c439b635a08ac161b13d04f0c2aa587fe256b65dc0c3efe8b7"
   name = "github.com/spf13/pflag"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "583c0c0531f06d5278b7d917446061adc344b5cd"
   version = "v1.0.1"
 
 [[projects]]
-  digest = "1:60a46e2410edbf02b419f833372dd1d24d7aa1b916a990a7370e792fada1eadd"
   name = "github.com/stretchr/objx"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "477a77ecc69700c7cdeb1fa9e129548e1c1c393c"
   version = "v0.1.1"
 
 [[projects]]
-  digest = "1:aa844d56b9832b9717d4b18ce20029795eae169a37f319ac6bc7c9c12a56a669"
   name = "github.com/stretchr/testify"
   packages = [
     "assert",
-    "mock",
+    "mock"
   ]
-  pruneopts = "NUT"
   revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
   version = "v1.2.2"
 
 [[projects]]
-  digest = "1:919fc2a81add8ac4a7a236dceaf3e4c29ba4df96d13c3f2ce13a4d0132ebefb8"
   name = "github.com/ugorji/go"
   packages = ["codec"]
-  pruneopts = "NUT"
   revision = "b4c50a2b199d93b13dc15e78929cfb23bfdf21ab"
   version = "v1.1.1"
 
 [[projects]]
   branch = "master"
-  digest = "1:3f3a05ae0b95893d90b9b3b5afdb79a9b3d96e4e36e099d841ae602e4aca0da8"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
-  pruneopts = "NUT"
   revision = "a49355c7e3f8fe157a85be2f77e6e269a0f89602"
 
 [[projects]]
   branch = "master"
-  digest = "1:cac3849a137434cd0183b369a1f66cdbb499de8fc8c6d2e5136172975005de81"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -635,24 +502,20 @@
     "idna",
     "internal/timeseries",
     "trace",
-    "websocket",
+    "websocket"
   ]
-  pruneopts = "NUT"
   revision = "039a4258aec0ad3c79b905677cceeab13b296a77"
 
 [[projects]]
   branch = "master"
-  digest = "1:64107e3c8f52f341891a565d117bf263ed396fe0c16bad19634b25be25debfaa"
   name = "golang.org/x/sys"
   packages = [
     "unix",
-    "windows",
+    "windows"
   ]
-  pruneopts = "NUT"
   revision = "1b2967e3c290b7c545b3db0deeda16e9be4f98a2"
 
 [[projects]]
-  digest = "1:4e48d0d8df75f1bd0a0afe837599fc9ad96b59eecdd1900fc0dcceccaa5fdffc"
   name = "golang.org/x/text"
   packages = [
     "collate",
@@ -669,22 +532,18 @@
     "unicode/cldr",
     "unicode/norm",
     "unicode/rangetable",
-    "width",
+    "width"
   ]
-  pruneopts = "NUT"
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:601e63e7d4577f907118bec825902505291918859d223bce015539e79f1160e3"
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
-  pruneopts = "NUT"
   revision = "e92b116572682a5b432ddd840aeaba2a559eeff1"
 
 [[projects]]
-  digest = "1:f496ffe4a0d4ff9a1470c1956851b69ba66709be3d756bd9a09e745b3860b55d"
   name = "google.golang.org/grpc"
   packages = [
     ".",
@@ -712,46 +571,36 @@
     "stats",
     "status",
     "tap",
-    "transport",
+    "transport"
   ]
-  pruneopts = "NUT"
   revision = "168a6198bcb0ef175f7dacec0b8691fc141dc9b8"
   version = "v1.13.0"
 
 [[projects]]
-  digest = "1:2d1fbdc6777e5408cabeb02bf336305e724b925ff4546ded0fa8715a7267922a"
   name = "gopkg.in/inf.v0"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "d2d2541c53f18d2a059457998ce2876cc8e67cbf"
   version = "v0.9.1"
 
 [[projects]]
-  digest = "1:80c34337e8a734e190f2d1b716cae774cca74db98315166f92074434e9af0227"
   name = "gopkg.in/natefinch/lumberjack.v2"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "a96e63847dc3c67d17befa69c303767e2f84e54f"
   version = "v2.1"
 
 [[projects]]
   branch = "v1"
-  digest = "1:52ffb9db0286de37253a5098607cfbcfcdc94e51e8c226da120513df82adab0c"
   name = "gopkg.in/yaml.v1"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "9f9df34309c04878acc86042b16630b0f696e1de"
 
 [[projects]]
-  digest = "1:7c95b35057a0ff2e19f707173cc1a947fa43a6eb5c4d300d196ece0334046082"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
   version = "v2.2.1"
 
 [[projects]]
-  digest = "1:b4f3da58641ad88a75296edc85012ac9f810dcaa3fa0f6b3adb088fe0d9907a1"
   name = "k8s.io/api"
   packages = [
     "admission/v1beta1",
@@ -782,15 +631,13 @@
     "settings/v1alpha1",
     "storage/v1",
     "storage/v1alpha1",
-    "storage/v1beta1",
+    "storage/v1beta1"
   ]
-  pruneopts = "NUT"
   revision = "006a217681ae70cbacdd66a5e2fca1a61a8ff28e"
   version = "kubernetes-1.9.1"
 
 [[projects]]
   branch = "release-1.9"
-  digest = "1:ea9b6d2679fb8fc21b6c9ee356e9eb48c53d422b5b9fac11b9f5241264ca8f3a"
   name = "k8s.io/apimachinery"
   packages = [
     "pkg/api/equality",
@@ -848,13 +695,11 @@
     "pkg/watch",
     "third_party/forked/golang/json",
     "third_party/forked/golang/netutil",
-    "third_party/forked/golang/reflect",
+    "third_party/forked/golang/reflect"
   ]
-  pruneopts = "NUT"
   revision = "fb40df2b502912cbe3a93aa61c2b2487f39cb42f"
 
 [[projects]]
-  digest = "1:a85492ddbdeab36935f766faeb1754e61603cb92aea50f572995d3dcc985be81"
   name = "k8s.io/apiserver"
   packages = [
     "pkg/admission",
@@ -940,15 +785,13 @@
     "plugin/pkg/audit/log",
     "plugin/pkg/audit/webhook",
     "plugin/pkg/authenticator/token/webhook",
-    "plugin/pkg/authorizer/webhook",
+    "plugin/pkg/authorizer/webhook"
   ]
-  pruneopts = "NUT"
   revision = "d0762227e2dd234c2db8efc3946c33ad2453c9e8"
   version = "kubernetes-1.9.1"
 
 [[projects]]
   branch = "release-6.0"
-  digest = "1:3de2f8d26b2bb72935d8b9d82b100d4e9ce3259ff74bd5eb9d77fa92aa563296"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -1066,63 +909,25 @@
     "util/exec",
     "util/flowcontrol",
     "util/homedir",
-    "util/integer",
+    "util/integer"
   ]
-  pruneopts = "NUT"
   revision = "e2680bfa771859c129bc5c8413fdb565af2b3dcd"
 
 [[projects]]
   branch = "master"
-  digest = "1:14acf39a31679e8c6497b5e82479e777185d79eb1b369af09f26bbadc65a1e9b"
   name = "k8s.io/kube-openapi"
   packages = [
     "pkg/builder",
     "pkg/common",
     "pkg/handler",
     "pkg/util",
-    "pkg/util/proto",
+    "pkg/util/proto"
   ]
-  pruneopts = "NUT"
   revision = "0cf8f7e6ed1d2e3d47d02e3b6e559369af24d803"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  input-imports = [
-    "github.com/automationbroker/broker-client-go/client/clientset/versioned/typed/automationbroker/v1alpha1",
-    "github.com/automationbroker/broker-client-go/pkg/apis/automationbroker/v1alpha1",
-    "github.com/automationbroker/bundle-lib/authorization",
-    "github.com/automationbroker/bundle-lib/authorization/k8s",
-    "github.com/automationbroker/bundle-lib/bundle",
-    "github.com/automationbroker/bundle-lib/clients",
-    "github.com/automationbroker/bundle-lib/crd",
-    "github.com/automationbroker/bundle-lib/registries",
-    "github.com/automationbroker/bundle-lib/runtime",
-    "github.com/automationbroker/config",
-    "github.com/coreos/etcd/client",
-    "github.com/gorilla/handlers",
-    "github.com/gorilla/mux",
-    "github.com/jessevdk/go-flags",
-    "github.com/lestrrat/go-jsschema",
-    "github.com/pborman/uuid",
-    "github.com/prometheus/client_golang/prometheus",
-    "github.com/sirupsen/logrus",
-    "github.com/stretchr/testify/mock",
-    "gopkg.in/yaml.v1",
-    "gopkg.in/yaml.v2",
-    "k8s.io/api/authentication/v1",
-    "k8s.io/api/core/v1",
-    "k8s.io/apimachinery/pkg/api/errors",
-    "k8s.io/apimachinery/pkg/apis/meta/v1",
-    "k8s.io/apimachinery/pkg/runtime",
-    "k8s.io/apimachinery/pkg/runtime/serializer",
-    "k8s.io/apimachinery/pkg/util/wait",
-    "k8s.io/apiserver/pkg/authentication/authenticatorfactory",
-    "k8s.io/apiserver/pkg/server",
-    "k8s.io/apiserver/pkg/server/options",
-    "k8s.io/apiserver/pkg/server/routes",
-    "k8s.io/client-go/informers",
-    "k8s.io/client-go/kubernetes/typed/authentication/v1beta1",
-  ]
+  inputs-digest = "da10a92d047c6f2f4003bb6e652ed41af97c59be13f0b03062d4e4eaa4f00489"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -37,7 +37,7 @@
   version = "~1.3.0"
 
 [[constraint]]
-  version = "~0.2.5"
+  version = "~0.2.7"
   name = "github.com/automationbroker/bundle-lib"
 
 [[constraint]]

--- a/apb/defaults/main.yml
+++ b/apb/defaults/main.yml
@@ -77,7 +77,7 @@ broker_helm_runner: docker.io/automationbroker/helm-runner:latest
 broker_helm_white_list: [ ".*" ]
 
 # Broker galaxy registry options
-broker_galaxy_enabled: true
+broker_galaxy_enabled: false
 broker_galaxy_name: galaxy
 broker_galaxy_url: https://galaxy.ansible.com
 broker_galaxy_org: ansibleplaybookbundle

--- a/vendor/github.com/automationbroker/bundle-lib/bundle/types.go
+++ b/vendor/github.com/automationbroker/bundle-lib/bundle/types.go
@@ -291,7 +291,7 @@ func SpecLogDump(spec *Spec) {
 	for _, plan := range spec.Plans {
 		log.Debugf("Plan: %s", plan.Name)
 		for _, param := range plan.Parameters {
-			log.Debugf("  Name: %#v", param.Name)
+			log.Debugf("  Name: %s", param.Name)
 			log.Debugf("  Title: %s", param.Title)
 			log.Debugf("  Type: %s", param.Type)
 			log.Debugf("  Description: %s", param.Description)
@@ -300,12 +300,12 @@ func SpecLogDump(spec *Spec) {
 			log.Debugf("  MaxLength: %d", param.MaxLength)
 			log.Debugf("  MinLength: %d", param.MinLength)
 			log.Debugf("  Pattern: %s", param.Pattern)
-			log.Debugf("  MultipleOf: %d", param.MultipleOf)
+			log.Debugf("  MultipleOf: %f", param.MultipleOf)
 			log.Debugf("  Minimum: %#v", param.Minimum)
 			log.Debugf("  Maximum: %#v", param.Maximum)
 			log.Debugf("  ExclusiveMinimum: %#v", param.ExclusiveMinimum)
 			log.Debugf("  ExclusiveMaximum: %#v", param.ExclusiveMaximum)
-			log.Debugf("  Required: %s", param.Required)
+			log.Debugf("  Required: %t", param.Required)
 			log.Debugf("  Enum: %v", param.Enum)
 		}
 	}

--- a/vendor/github.com/automationbroker/bundle-lib/registries/adapters/adapter.go
+++ b/vendor/github.com/automationbroker/bundle-lib/registries/adapters/adapter.go
@@ -163,7 +163,6 @@ func configToSpec(config []byte, image string) (*bundle.Spec, error) {
 	// image name to be pulled during provision
 	spec.Image = image
 
-	log.Debugf("adapter::configToSpec -> Got plans %+v", spec.Plans)
 	log.Debugf("Successfully converted Image %s into Spec", spec.Image)
 	log.Infof("adapter::configToSpec -> Image %s runtime is %d", spec.Image, spec.Runtime)
 

--- a/vendor/github.com/automationbroker/bundle-lib/registries/adapters/quay_adapter.go
+++ b/vendor/github.com/automationbroker/bundle-lib/registries/adapters/quay_adapter.go
@@ -53,7 +53,7 @@ type quayImageResponse struct {
 }
 
 // NewQuayAdapter - creates and returns a QuayAdapter ready to use.
-func NewQuayAdapter(config Configuration) (QuayAdapter, error) {
+func NewQuayAdapter(config Configuration) QuayAdapter {
 	a := QuayAdapter{
 		config: config,
 	}
@@ -63,7 +63,7 @@ func NewQuayAdapter(config Configuration) (QuayAdapter, error) {
 		a.config.Tag = "latest"
 	}
 
-	return a, nil
+	return a
 }
 
 // RegistryName - Retrieve the registry name

--- a/vendor/github.com/automationbroker/bundle-lib/registries/registry.go
+++ b/vendor/github.com/automationbroker/bundle-lib/registries/registry.go
@@ -78,12 +78,17 @@ func (c Config) Validate() bool {
 			return false
 		}
 	case "config":
-		if c.Type == "quay" && c.Token == "" {
-			return false
+		if c.Type == "quay" {
+			// quay requires a token
+			return c.Token != ""
 		} else if c.User == "" || c.Pass == "" {
 			return false
 		}
 	case "":
+		if c.Type == "quay" {
+			// no auth is okay for quay
+			return true
+		}
 		if c.AuthName != "" {
 			return false
 		}
@@ -123,9 +128,9 @@ func (r Registry) LoadSpecs() ([]*bundle.Spec, int, error) {
 
 	if len(filteredNames) != 0 {
 		var buffer bytes.Buffer
-		buffer.WriteString("Bundles filtered by white/blacklist filter:")
+		buffer.WriteString("Bundles filtered by white/blacklist filter:\n")
 		for _, name := range filteredNames {
-			buffer.WriteString(fmt.Sprintf("-> %s", name))
+			buffer.WriteString(fmt.Sprintf("\t-> %s\n", name))
 		}
 		log.Infof(buffer.String())
 	}
@@ -227,7 +232,7 @@ func NewCustomRegistry(configuration Config, adapter adapters.Adapter, asbNamesp
 		case "apiv2":
 			adapter, err = adapters.NewAPIV2Adapter(c)
 		case "quay":
-			adapter, err = adapters.NewQuayAdapter(c)
+			adapter = adapters.NewQuayAdapter(c)
 		case "galaxy":
 			adapter = &adapters.GalaxyAdapter{Config: c}
 		default:


### PR DESCRIPTION
This PR updates the broker to pass the Galaxy URL to the APB at runtime when acting on `*serviceclasses` that come from Galaxy. This is important because the APB needs this information in order to properly install the role from Galaxy.