### PR TITLE
Bug 1585951 - Delete provision credentials on deprovision from ASB namespace

### DIFF
--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -865,7 +865,15 @@ func (a AnsibleBroker) Deprovision(
 		if err := a.engine.StartNewSyncJob(token, dpjob, DeprovisionTopic); err != nil {
 			return nil, err
 		}
+
+		// Attempt to delete extracted credentials created from provision. The creds
+		// should only be deleted if the instance was successfully deleted, otherwise
+		// we will end up in a corrupt state.
+		if err := bundle.DeleteExtractedCredentials(instance.ID.String()); err != nil {
+			log.Infof("Attempted to delete extracted credentials from a provision but could not: %s", err.Error())
+		}
 	}
+
 	return &DeprovisionResponse{}, nil
 }
 

--- a/pkg/broker/job_state_subscriber.go
+++ b/pkg/broker/job_state_subscriber.go
@@ -110,6 +110,13 @@ func (jss *JobStateSubscriber) cleanupAfterDeprovision(msg JobMsg) error {
 		}
 		return deleteErr
 	}
+
+	// Attempt to delete extracted credentials created from provision. The creds
+	// should only be deleted if the instance was successfully deleted, otherwise
+	// we will end up in a corrupt state.
+	if err := bundle.DeleteExtractedCredentials(msg.InstanceUUID); err != nil {
+		log.Infof("Attempted to delete extracted credentials from a provision but could not: %s", err.Error())
+	}
 	return nil
 }
 


### PR DESCRIPTION
#### Describe what this PR does and why we need it:
If credentials are extracted from a provision, a secret is created with their contents in the ASB namespace. This secret is not being cleaned up when the corresponding instance is deprovisioned.

#### Changes proposed in this pull request
Delete the secret containing provision credentials if it exists during a deprovision.
