### PR TITLE
remove newline from version log

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -162,7 +162,7 @@ func CreateApp(args Args, regs []registries.Registry) App {
 	}
 
 	// Show version in logs for better debugging
-	log.Infof("Ansible Service Broker Version: %v\n", version.Version)
+	log.Infof("Ansible Service Broker Version: %v", version.Version)
 	// Initializing clients as soon as we have deps ready.
 	err = initClients(app.config)
 	if err != nil {


### PR DESCRIPTION
The broker log outputs the newline code in the logs which is not what
was intended. This PR removes the \n from the log string.

time="2018-08-02T17:09:26Z" level=info msg="Ansible Service Broker Version: 1.3.6\n"