### PR TITLE
Standardize broker endpoints

### DIFF
--- a/apb/tasks/generate_certificate.yaml
+++ b/apb/tasks/generate_certificate.yaml
@@ -15,7 +15,7 @@
         -keyout {{ broker_tls_cert_dir }}/key.pem
         -out {{ broker_tls_cert_dir }}/cert.pem
         -days 365
-        -subj "/CN={{ broker_name }}.{{ broker_namespace }}.svc"
+        -subj "/CN=broker.{{ broker_namespace }}.svc"
       args:
         creates: "{{ broker_tls_cert_dir }}/cert.pem"
 

--- a/apb/templates/broker-access.clusterrole.yaml
+++ b/apb/templates/broker-access.clusterrole.yaml
@@ -6,8 +6,8 @@ metadata:
   name: access-{{ broker_name }}-role
 rules:
 - nonResourceURLs:
-    - "/{{ broker_namespace }}"
-    - "/{{ broker_namespace }}/*"
+    - "/osb"
+    - "/osb/*"
   verbs:
     - "get"
     - "post"

--- a/apb/templates/broker.configmap.yaml
+++ b/apb/templates/broker.configmap.yaml
@@ -102,7 +102,6 @@ data:
       ssl_cert_key: /etc/tls/private/tls.key
       ssl_cert: /etc/tls/private/tls.crt
       auto_escalate: {{ broker_auto_escalate }}
-      cluster_url: {{ broker_namespace }}
 {% if cluster == 'openshift' %}
       dashboard_redirector: http://{{
         lookup(

--- a/apb/templates/broker.service.yaml
+++ b/apb/templates/broker.service.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ broker_name }}
+  name: broker
   namespace: {{ broker_namespace }}
   labels:
     app: {{ broker_name }}

--- a/apb/templates/broker.servicecatalog.yaml
+++ b/apb/templates/broker.servicecatalog.yaml
@@ -9,7 +9,7 @@ metadata:
 {% endif %}
 {% if state == 'present' %}
 spec:
-  url: https://{{ broker_name }}.{{ broker_namespace }}.svc:1338/osb/
+  url: https://broker.{{ broker_namespace }}.svc:1338/osb/
   authInfo:
     bearer:
       secretRef:

--- a/apb/templates/broker.servicecatalog.yaml
+++ b/apb/templates/broker.servicecatalog.yaml
@@ -9,7 +9,7 @@ metadata:
 {% endif %}
 {% if state == 'present' %}
 spec:
-  url: https://{{ broker_name }}.{{ broker_namespace }}.svc:1338/{{ broker_namespace }}/
+  url: https://{{ broker_name }}.{{ broker_namespace }}.svc:1338/osb/
   authInfo:
     bearer:
       secretRef:

--- a/docs/config.md
+++ b/docs/config.md
@@ -334,7 +334,6 @@ enable the full functionality.
 | ssl_cert             | Tells the broker where to find the tls crt file. If not set the [apiserver](https://github.com/kubernetes/apiserver) will attempt to create one. | ""                     |     N    |
 | refresh_interval     | The interval to query registries for new image specs                                                                                             | "600s"                 |     N    |
 | auto_escalate        | Allows the broker to escalate the permissions of a user while running the APB [read more](administration.md)                                     | false                  |     N    |
-| cluster_url          | Sets the prefix for the url that the broker is expecting                                                                                         | ansible-service-broker |     N    |
 
 ## Secrets Configuration
 The secrets config section will create associations between secrets in the broker's namespace and apbs the broker runs.

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -59,8 +59,8 @@ var (
 )
 
 const (
-	// defaultClusterURLPreFix - prefix for the ansible service broker.
-	defaultClusterURLPreFix = "/ansible-service-broker"
+	// ClusterURLPreFix - prefix for the ansible service broker.
+	ClusterURLPreFix = "/osb"
 	// MsgBufferSize - The buffer for the message channel.
 	MsgBufferSize = 20
 	// SubscriberTimeout - the amount of time in seconds that subscribers have to complete their action
@@ -375,27 +375,14 @@ func (a *App) Start() {
 	}
 
 	authorizer, err := k8sauthorization.NewAuthorizer("automationbroker.io", "access", "create")
-	var clusterURL string
-	if a.config.GetString("broker.cluster_url") != "" {
-		if !strings.HasPrefix("/", a.config.GetString("broker.cluster_url")) {
-			clusterURL = "/" + a.config.GetString("broker.cluster_url")
-		} else {
-			clusterURL = a.config.GetString("broker.cluster_url")
-		}
-	} else {
-		clusterURL = defaultClusterURLPreFix
-	}
+	var clusterURL = ClusterURLPreFix
 
 	daHandler := prometheus.InstrumentHandler(
 		"ansible-service-broker",
 		handler.NewHandler(a.broker, a.config, clusterURL, providers, authorizer),
 	)
 
-	if clusterURL == "/" {
-		genericserver.Handler.NonGoRestfulMux.HandlePrefix("/", daHandler)
-	} else {
-		genericserver.Handler.NonGoRestfulMux.HandlePrefix(fmt.Sprintf("%v/", clusterURL), daHandler)
-	}
+	genericserver.Handler.NonGoRestfulMux.HandlePrefix(fmt.Sprintf("%v/", clusterURL), daHandler)
 
 	defaultMetrics := routes.DefaultMetrics{}
 	defaultMetrics.Install(genericserver.Handler.NonGoRestfulMux)

--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -99,7 +99,6 @@ type Config struct {
 	SSLCert             string `yaml:"ssl_cert"`
 	RefreshInterval     string `yaml:"refresh_interval"`
 	AutoEscalate        bool   `yaml:"auto_escalate"`
-	ClusterURL          string `yaml:"cluster_url"`
 	DashboardRedirector string `yaml:"dashboard_redirector"`
 }
 
@@ -142,7 +141,6 @@ func NewAnsibleBroker(dao dao.Dao,
 			SSLCert:             brokerConfig.GetString("ssl_cert"),
 			RefreshInterval:     brokerConfig.GetString("refresh_interval"),
 			AutoEscalate:        brokerConfig.GetBool("auto_escalate"),
-			ClusterURL:          brokerConfig.GetString("cluster_url"),
 			DashboardRedirector: brokerConfig.GetString("dashboard_redirector"),
 		},
 		namespace:   namespace,


### PR DESCRIPTION
A lot of the time, the configurability of the `cluster_url` simply causes trouble. This removes that but there are definitely considerations for:

1. python apb tool - https://github.com/ansibleplaybookbundle/ansible-playbook-bundle
1. the other apb tool - https://github.com/automationbroker/apb
1. ansible installer - https://github.com/openshift/openshift-ansible/blob/master/roles/ansible_service_broker/tasks/install.yml#L239
1. Documentation - https://github.com/openshift/openshift-docs/pull/11145
