### PR TITLE
Bug 1583503 Always run updates

### DIFF
--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -61,8 +61,6 @@ var (
 	ErrorParameterUnknownEnum = errors.New("unknown enum parameter value requested")
 	// ErrorPlanUpdateNotPossible - Error when a Plan Update request cannot be satisfied
 	ErrorPlanUpdateNotPossible = errors.New("plan update not possible")
-	// ErrorNoUpdateRequested - Error for when no valid updates are requested
-	ErrorNoUpdateRequested = errors.New("no valid updates requested")
 	// ErrorUnbindingInProgress - Error when unbind is called that has an unbinding job in progress
 	ErrorUnbindingInProgress = errors.New("unbinding in progress")
 )
@@ -1413,12 +1411,6 @@ func (a AnsibleBroker) Update(instanceUUID uuid.UUID, req *UpdateRequest, async 
 	req.Parameters, err = a.validateRequestedUpdateParams(req.Parameters, toPlan, prevParams, si)
 	if err != nil {
 		return nil, err
-	}
-
-	if fromPlan.Name == toPlan.Name && len(req.Parameters) == 0 {
-		log.Warningf("Returning without running the APB. No changes were actually requested")
-
-		return &UpdateResponse{}, ErrorNoUpdateRequested
 	}
 
 	// Parameters look good, update the ServiceInstance values

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -370,10 +370,6 @@ func (h handler) update(w http.ResponseWriter, r *http.Request, params map[strin
 			writeResponse(w, http.StatusAccepted, resp)
 		case broker.ErrorNotFound:
 			writeResponse(w, http.StatusBadRequest, broker.ErrorResponse{Description: err.Error()})
-		case broker.ErrorNoUpdateRequested:
-			writeResponse(w, http.StatusOK, resp)
-		case broker.ErrorNoUpdateRequested:
-			writeResponse(w, http.StatusOK, resp)
 		case broker.ErrorPlanNotFound,
 			broker.ErrorParameterNotUpdatable,
 			broker.ErrorParameterNotFound,


### PR DESCRIPTION
#### Describe what this PR does and why we need it:
Changes updates to always run, regardless of whether parameters have changed.

This behavior change is in response to BZ 1583503. We previously blindly assumed that if the parameters have not changed since the last request that the last request succeeded, which we simply cannot guarantee.

Since David has done work to ensure our APB updates are idempotent it should be acceptable to rerun updates without changes. But it will probably make it a hard requirement rather than a polite suggestion that update tasks be idempotent.

#### Which issue this PR fixes (This will close that issue when PR gets merged)
fixes BZ 1583503
