### PR TITLE
use the new osb prefix

### DIFF
--- a/test/bind.sh
+++ b/test/bind.sh
@@ -43,4 +43,4 @@ curl \
     -H "Accept: application/json" \
     -H "X-Broker-API-Originating-Identity: " \
     -d "$req" \
-    "https://broker-automation-broker.$HOSTNAME.nip.io/automation-broker/v2/service_instances/$INSTANCE_ID/service_bindings/$BINDING_ID?accepts_incomplete=true"
+    "https://broker-automation-broker.$HOSTNAME.nip.io/osb/v2/service_instances/$INSTANCE_ID/service_bindings/$BINDING_ID?accepts_incomplete=true"

--- a/test/bootstrap.sh
+++ b/test/bootstrap.sh
@@ -15,4 +15,4 @@ curl \
     -H "Accept: application/json" \
     -H "X-Broker-API-Originating-Identity: " \
     -d "$req" \
-    "https://broker-automation-broker.$HOSTNAME.nip.io/automation-broker/v2/bootstrap"
+    "https://broker-automation-broker.$HOSTNAME.nip.io/osb/v2/bootstrap"

--- a/test/catalog.sh
+++ b/test/catalog.sh
@@ -13,4 +13,4 @@ curl \
     -H "Authorization: bearer $(oc whoami -t)" \
     -H "Content-type: application/json" \
     -H "Accept: application/json" \
-    "https://broker-automation-broker.$HOSTNAME.nip.io/automation-broker/v2/catalog"
+    "https://broker-automation-broker.$HOSTNAME.nip.io/osb/v2/catalog"

--- a/test/deprovision.sh
+++ b/test/deprovision.sh
@@ -22,4 +22,4 @@ curl \
     -H "Content-type: application/json" \
     -H "Accept: application/json" \
     -H "X-Broker-API-Originating-Identity: " \
-    "https://broker-automation-broker.$HOSTNAME.nip.io/automation-broker/v2/service_instances/$INSTANCE_ID"
+    "https://broker-automation-broker.$HOSTNAME.nip.io/osb/v2/service_instances/$INSTANCE_ID"

--- a/test/getbind.sh
+++ b/test/getbind.sh
@@ -42,6 +42,6 @@ curl \
     -H "Content-type: application/json" \
     -H "Accept: application/json" \
     -H "X-Broker-API-Originating-Identity: " \
-    "https://broker-automation-broker.$HOSTNAME.nip.io/automation-broker/v2/service_instances/$INSTANCE_ID/service_bindings/$BINDING_ID"
+    "https://broker-automation-broker.$HOSTNAME.nip.io/osb/v2/service_instances/$INSTANCE_ID/service_bindings/$BINDING_ID"
 
 

--- a/test/getinstance.sh
+++ b/test/getinstance.sh
@@ -26,4 +26,4 @@ curl \
     -H "Content-type: application/json" \
     -H "Accept: application/json" \
     -H "X-Broker-API-Originating-Identity: " \
-    "https://broker-automation-broker.$HOSTNAME.nip.io/automation-broker/v2/service_instances/$INSTANCE_ID"
+    "https://broker-automation-broker.$HOSTNAME.nip.io/osb/v2/service_instances/$INSTANCE_ID"

--- a/test/last_operation.sh
+++ b/test/last_operation.sh
@@ -32,4 +32,4 @@ curl \
     -H "Content-type: application/json" \
     -H "Accept: application/json" \
     -H "X-Broker-API-Originating-Identity: " \
-    "https://broker-automation-broker.$HOSTNAME.nip.io/automation-broker/v2/service_instances/$INSTANCE_ID/last_operation?operation=$OPERATION&service_id=$SERVICE_UUID&plan_id=$PLAN_UUID"
+    "https://broker-automation-broker.$HOSTNAME.nip.io/osb/v2/service_instances/$INSTANCE_ID/last_operation?operation=$OPERATION&service_id=$SERVICE_UUID&plan_id=$PLAN_UUID"

--- a/test/last_operation_bind.sh
+++ b/test/last_operation_bind.sh
@@ -35,4 +35,4 @@ curl \
     -H "Content-type: application/json" \
     -H "Accept: application/json" \
     -H "X-Broker-API-Originating-Identity: " \
-    "https://broker-automation-broker.$HOSTNAME.nip.io/automation-broker/v2/service_instances/$INSTANCE_ID/service_bindings/$BINDING_ID/last_operation?operation=$OPERATION&service_id=$SERVICE_UUID&plan_id=$PLAN_UUID"
+    "https://broker-automation-broker.$HOSTNAME.nip.io/osb/v2/service_instances/$INSTANCE_ID/service_bindings/$BINDING_ID/last_operation?operation=$OPERATION&service_id=$SERVICE_UUID&plan_id=$PLAN_UUID"

--- a/test/provision.sh
+++ b/test/provision.sh
@@ -44,4 +44,4 @@ curl \
     -H "Accept: application/json" \
     -H "X-Broker-API-Originating-Identity: " \
     -d "$req" \
-    "https://broker-automation-broker.$HOSTNAME.nip.io/automation-broker/v2/service_instances/$INSTANCE_ID?accepts_incomplete=true"
+    "https://broker-automation-broker.$HOSTNAME.nip.io/osb/v2/service_instances/$INSTANCE_ID?accepts_incomplete=true"

--- a/test/unbind.sh
+++ b/test/unbind.sh
@@ -40,4 +40,4 @@ curl \
     -H "Content-type: application/json" \
     -H "Accept: application/json" \
     -H "X-Broker-API-Originating-Identity: " \
-    "https://broker-automation-broker.$HOSTNAME.nip.io/automation-broker/v2/service_instances/$INSTANCE_ID/service_bindings/$BINDING_ID?accepts_incomplete=true&plan_id=$PLAN_UUID"
+    "https://broker-automation-broker.$HOSTNAME.nip.io/osb/v2/service_instances/$INSTANCE_ID/service_bindings/$BINDING_ID?accepts_incomplete=true&plan_id=$PLAN_UUID"


### PR DESCRIPTION
PR #1029 standardized the urls to be `osb/` so this updates the test scripts to use the same paths.