### PR TITLE
Default to NOT deleting shared broker resources

### DIFF
--- a/apb/defaults/main.yml
+++ b/apb/defaults/main.yml
@@ -22,6 +22,12 @@ broker_node_selector: ""
 # The kind of broker, useful in the case the service-catalog
 # supports namespaced service brokers
 broker_kind: ClusterServiceBroker
+# Whether or not the APB should destroy cluster level resources
+# that are potentially shared by more than one broker in a cluster.
+# Default behavior is to NOT delete these resources to prevent
+# unintended breakages. Cluster admins can flip this to true and
+# rerun deprovision in order to explicitly clean them up.
+broker_destroy_shared_resources: False
 broker_clusterrole: admin
 broker_sandbox_role: edit
 

--- a/apb/tasks/dao_crd.yaml
+++ b/apb/tasks/dao_crd.yaml
@@ -4,6 +4,7 @@
   k8s:
     state: '{{ state }}'
     definition: "{{ lookup('file', item) | from_yaml }}"
+  when: state == 'present' or (state == 'absent' and broker_destroy_shared_resources)
   with_items:
     - bundle.crd.yaml
     - bundlebindings.crd.yaml

--- a/apb/tasks/main.yml
+++ b/apb/tasks/main.yml
@@ -40,14 +40,17 @@
     - name: broker.clusterrolebinding.yaml
     - name: broker.configmap.yaml
     - name: broker-auth.clusterrole.yaml
+      apply: "{{ state == 'present' or (state == 'absent' and broker_destroy_shared_resources) }}"
     - name: broker-auth.clusterrolebinding.yaml
     - name: broker-client.serviceaccount.yaml
     - name: broker-client.secret.yaml
     - name: broker-client.clusterrolebinding.yaml
     - name: broker-access.clusterrole.yaml
+      apply: "{{ state == 'present' or (state == 'absent' and broker_destroy_shared_resources) }}"
     - name: broker-auth.secret.yaml
       apply: "{{ True if broker_basic_auth_enabled else False }}"
     - name: broker-user-auth.clusterrole.yaml
+      apply: "{{ state == 'present' or (state == 'absent' and broker_destroy_shared_resources) }}"
     - name: broker.deployment.yaml
     # Useful in the case we don't want to require the servicecatalog exist
     - name: broker.servicecatalog.yaml


### PR DESCRIPTION
#### Describe what this PR does and why we need it:

With namespaced brokers now supported, it's likely that there will be multiple brokers deployed simultaneously into a cluster, and there are a set of resources that are potentially shared between all of them. If a cluster admin decides to deprovision one of the brokers with the APB, we want the default behavior to prevent breaking other brokers by pulling down a resource that they depend on. The cluster admin can switch on the new var `broker_destroy_shared_resources` and rerun deprovision to easily clean these up when they are sure it will not interfere with others.