### PR TITLE
Prevent deprovision of brokers with instances

### DIFF
--- a/apb/defaults/main.yml
+++ b/apb/defaults/main.yml
@@ -28,6 +28,15 @@ broker_kind: ClusterServiceBroker
 # unintended breakages. Cluster admins can flip this to true and
 # rerun deprovision in order to explicitly clean them up.
 broker_destroy_shared_resources: False
+# Deprovisioning a broker that has outstanding service instances or bindings
+# will leak their underlying services as well as the k8s objects themselves.
+# This effectively throws the related resources into what appears to be a
+# perpetually terminating state that the cluster admin must clean up.
+# By default, the broker's APB will refuse to deprovision a broker that is
+# recognized to have outstanding instances, but switching
+# broker_force_deprovision to true will deprovision the broker regardless
+# of the presence of outstanding instances.
+broker_force_deprovision: False
 broker_clusterrole: admin
 broker_sandbox_role: edit
 

--- a/apb/tasks/main.yml
+++ b/apb/tasks/main.yml
@@ -5,6 +5,15 @@
     msg:
       - "broker_local_openshift_enabled {{ broker_local_openshift_enabled }}"
 
+- name: Verify the broker has no outstanding service instances if deprovisioning
+  assert:
+    that:
+      - "lookup('k8s', kind='BundleInstance', namespace=broker_namespace, api_version='automationbroker.io/v1alpha1') | length == 0"
+    msg: |
+      The requested broker cannot be deprovisioned because it has outstanding service instances.
+      Please deprovision any services originally provisioned by this broker before deprovisioning the broker itself.
+  when: state == 'absent' and not broker_force_deprovision
+
 - name: 'Set broker namespace state={{ state }}'
   k8s:
     state: '{{ state }}'


### PR DESCRIPTION
#### Describe what this PR does and why we need it:
Guards the APB against deprovisioning brokers that have outstanding instances, but adds a switch to allow for a deprovision override.