### PR TITLE
Disable keeping namespace on error in ASB

### DIFF
--- a/apb/defaults/main.yml
+++ b/apb/defaults/main.yml
@@ -52,7 +52,7 @@ etcd_persist_storage: "true"
 
 # Whether or not to keep the sandbox namespace
 broker_keep_namespace: "false"
-broker_keep_namespace_on_error: "true"
+broker_keep_namespace_on_error: "false"
 
 # Special broker config options
 broker_dev: "true"


### PR DESCRIPTION
This is intended to help mitigate https://bugzilla.redhat.com/show_bug.cgi?id=1618547 in 3.11.