### PR TITLE
Fix RPM build

### DIFF
--- a/ansible-service-broker.spec
+++ b/ansible-service-broker.spec
@@ -195,8 +195,8 @@ install -p -m 755 migration %{buildroot}%{_bindir}/migration
 install -p -m 755 dashboard-redirector %{buildroot}%{_bindir}/dashboard-redirector
 # broker apb
 mkdir -p %{buildroot}/opt/apb/ %{buildroot}/opt/ansible/roles/automation-broker-apb
-mv apb/playbooks %{buildroot}/opt/apb/actions
-mv apb/defaults apb/files apb/tasks apb/templates apb/vars %{buildroot}/opt/ansible/roles/automation-broker-apb
+mv ansible_role/playbooks %{buildroot}/opt/apb/actions
+mv ansible_role/defaults ansible_role/files ansible_role/tasks ansible_role/templates ansible_role/vars %{buildroot}/opt/ansible/roles/automation-broker-apb
 install -p -m 755 build/entrypoint.sh %{buildroot}%{_bindir}/entrypoint.sh
 install -d -p %{buildroot}%{_sysconfdir}/%{name}
 install -p -m 644 etc/example-config.yaml %{buildroot}%{_sysconfdir}/%{name}/config.yaml

--- a/downstream.patch
+++ b/downstream.patch
@@ -1,7 +1,7 @@
-diff --git a/apb/apb.yml b/apb/apb.yml
+diff --git a/ansible_role/apb.yml b/ansible_role/apb.yml
 index c1885a4ae..854b1a4a4 100644
---- a/apb/apb.yml
-+++ b/apb/apb.yml
+--- a/ansible_role/apb.yml
++++ b/ansible_role/apb.yml
 @@ -14,7 +14,7 @@ metadata:
      WARNING!!! Use of this APB through the service-catalog is
      not supported.
@@ -11,10 +11,10 @@ index c1885a4ae..854b1a4a4 100644
    displayName: Automation Broker (APB)
    providerDisplayName: "Red Hat, Inc."
  plans:
-diff --git a/apb/defaults/main.yml b/apb/defaults/main.yml
+diff --git a/ansible_role/defaults/main.yml b/ansible_role/defaults/main.yml
 index 10633c472..8ed478b06 100644
---- a/apb/defaults/main.yml
-+++ b/apb/defaults/main.yml
+--- a/ansible_role/defaults/main.yml
++++ b/ansible_role/defaults/main.yml
 @@ -11,10 +11,10 @@ create_broker_namespace: false
  wait_for_broker: false # By default, we do not wait for the broker to be available
  


### PR DESCRIPTION
#### Describe what this PR does and why we need it:
The operator refactoring moved some paths around (`apb` -> `ansible_role`) and that seems to have broken copr.

#### Changes proposed in this pull request
 - Fix paths in .spec file