### PR TITLE
Fix 1.1 copr releaser

### DIFF
--- a/.tito/releasers.conf
+++ b/.tito/releasers.conf
@@ -1,6 +1,6 @@
 [asb-copr]
 releaser = tito.release.CoprReleaser
-project_name = @ansible-service-broker/ansible-service-broker-latest
+project_name = @ansible-service-broker/ansible-service-broker-1.1.0-openshift-3.9
 upload_command = scp -4 %(srpm)s $fas_username@fedorapeople.org:/srv/repos/asb
 remote_location = http://repos.fedorapeople.org/asb/
 copr_options = --timeout 600


### PR DESCRIPTION
The release-1.1 broker image built from source is excessively large as well. I want to make sure the upstream rpm is up to date and rebuild that image as well.