### PR TITLE
Fix v3.10 automation-broker-apb Dockerfile

### DIFF
--- a/ansible_role/apb/Dockerfile-v3.10
+++ b/ansible_role/apb/Dockerfile-v3.10
@@ -69,6 +69,6 @@ aW9uOiAoSWYgYXBpdjJ8b3BlbnNoaWZ0KSBsaXN0IG9mIEFQQiBpbWFnZXMKICAgICAgICB0aXRs\
 ZTogUmVnaXN0cnkgSW1hZ2VzIChPbmx5IGZvciBhcGl2MnxvcGVuc2hpZnQpCiAgICAgICAgcmVx\
 dWlyZWQ6IGZhbHNlCiAgICAgICAgdXBkYXRhYmxlOiBmYWxzZQo="
 
-RUN yum -y install automation-broker-apb-role && yum clean all
+RUN yum -y downgrade apb-base-scripts && yum -y install automation-broker-apb-role && yum clean all
 
 USER apb


### PR DESCRIPTION
We need to downgrade apb-base-scripts until https://github.com/openshift/origin/pull/20584 is merged and there is a new 3.10 oc.