### PR TITLE
Fix canary, use same tag for canary/nightly broker and apb's

### DIFF
--- a/ansible_role/apb/Dockerfile-canary
+++ b/ansible_role/apb/Dockerfile-canary
@@ -1,4 +1,4 @@
-FROM ansibleplaybookbundle/apb-base:latest
+FROM ansibleplaybookbundle/apb-base:canary
 
 LABEL "com.redhat.apb.spec"=\
 "LS0tCgp2ZXJzaW9uOiAxLjAuMApuYW1lOiBhdXRvbWF0aW9uLWJyb2tlci1hcGIKZGVzY3JpcHRp\
@@ -67,8 +67,8 @@ aW9uOiAoSWYgYXBpdjJ8b3BlbnNoaWZ0KSBsaXN0IG9mIEFQQiBpbWFnZXMKICAgICAgICB0aXRs\
 ZTogUmVnaXN0cnkgSW1hZ2VzIChPbmx5IGZvciBhcGl2MnxvcGVuc2hpZnQpCiAgICAgICAgcmVx\
 dWlyZWQ6IGZhbHNlCiAgICAgICAgdXBkYXRhYmxlOiBmYWxzZQo="
 
-ARG VERSION=latest
-ARG APB=latest
+ARG VERSION=canary
+ARG APB=canary
 
 RUN yum -y install epel-release openssl && yum clean all
 

--- a/ansible_role/apb/Dockerfile-nightly
+++ b/ansible_role/apb/Dockerfile-nightly
@@ -69,4 +69,13 @@ dWlyZWQ6IGZhbHNlCiAgICAgICAgdXBkYXRhYmxlOiBmYWxzZQo="
 
 RUN yum -y install automation-broker-apb-role && yum clean all
 
+ARG VERSION=nightly
+ARG APB=nightly
+
+# Replace the broker version and apb tag
+RUN sed -i "s/\(broker_image_tag:\).*/\1 ${VERSION}/" \
+    /opt/ansible/roles/automation-broker-apb/defaults/main.yml
+RUN sed -i "s/\(broker_dockerhub_tag:\).*/\1 ${APB}/" \
+    /opt/ansible/roles/automation-broker-apb/defaults/main.yml
+
 USER apb


### PR DESCRIPTION
Update the canary apb to use the canary apb-base and rename it to be clear which image it is used for.