### PR TITLE
Fix deploy template default value for Broker URL

### DIFF
--- a/templates/deploy-ansible-service-broker.template.yaml
+++ b/templates/deploy-ansible-service-broker.template.yaml
@@ -378,7 +378,7 @@ parameters:
 - description: Service Broker url prefix for the cluster
   displayname: ASB Url Prefix
   name: BROKER_URL_PREFIX
-  value: "/ansible-service-broker"
+  value: "/osb"
 
 - description: Broker Auth Info
   displayname: Broker Auth Info


### PR DESCRIPTION
Fix the default Broker URL Prefix for the 1.3/3.11 deploy template.