### PR TITLE
Use 3.11 instead of latest for ansible-service-broker image

### DIFF
--- a/ansible_role/operator/Dockerfile
+++ b/ansible_role/operator/Dockerfile
@@ -1,9 +1,15 @@
 FROM quay.io/water-hole/ansible-operator
 ARG OLM_MANAGED=false
+ARG VERSION=v3.11
+ARG APB=v3.11
 
 COPY . /opt/ansible/roles/automation-broker
 COPY playbooks/operator.yml /opt/ansible/deploy.yml
 COPY operator/watches.yaml /opt/ansible/watches.yaml
 
-RUN sed -i "s/\(olm_managed:\).*/\1 ${OLM_MANAGED}/" \
+RUN sed -i "s/\(broker_image_tag:\).*/\1 ${VERSION}/" \
+    /opt/ansible/roles/automation-broker/defaults/main.yml && \
+    sed -i "s/\(broker_dockerhub_tag:\).*/\1 ${APB}/" \
+    /opt/ansible/roles/automation-broker/defaults/main.yml && \
+    sed -i "s/\(olm_managed:\).*/\1 ${OLM_MANAGED}/" \
     /opt/ansible/roles/automation-broker/defaults/main.yml


### PR DESCRIPTION
latest is stuck at v3.10 until a new v3.10 oc binary is released (if ever).

Using latest for the image therefore causes a mismatch between the nonResourceUrl's configured in the client access cluster role (/osb) and where the broker image is serving (/ansible-service-broker). Using v3.11 for now should prevent this from happening.