### PR TITLE
Operator should use meta from AO

### DIFF
--- a/ansible_role/playbooks/operator.yml
+++ b/ansible_role/playbooks/operator.yml
@@ -9,3 +9,5 @@
   - role: automation-broker
   vars:
     state: present
+    broker_name: "{{ meta.name }}"
+    broker_namespace: "{{ meta.namespace }}"


### PR DESCRIPTION
This should make it so that the broker_name and broker_namespace are set by the Ansible Operator passing in the `meta` object as extravars.