### PR TITLE
Set OLM_MANAGED to true by default in the operator Dockerfile

### DIFF
--- a/ansible_role/operator/Dockerfile
+++ b/ansible_role/operator/Dockerfile
@@ -1,5 +1,5 @@
 FROM quay.io/water-hole/ansible-operator
-ARG OLM_MANAGED=false
+ARG OLM_MANAGED=true
 ARG VERSION=v3.11
 ARG APB=v3.11
 


### PR DESCRIPTION
I am working on submitting a PR to add our operators to the Openshift Prow CI.
https://github.com/openshift/release/pull/2098/files

I don't see that there is a way to submit build-args in the config to build from a Dockerfile. Given we need OLM_MANAGED is required for the operator to work with OLM and that we're not really aware of a real case where someone would use the operator without OLM I think it makes sense to change this to true.