### PR TITLE
Add epoch to rpm spec

### DIFF
--- a/ansible-service-broker.spec
+++ b/ansible-service-broker.spec
@@ -40,6 +40,7 @@
 %define modulename ansible-service-broker
 
 Name: %{repo}
+Epoch: 1
 Version: 1.4.2
 Release: 1%{build_timestamp}%{?dist}
 Summary: Ansible Service Broker


### PR DESCRIPTION
A bad test package with a much higher version number was released downstream. We need to add an epoch to take precedence over it.