### PR TITLE
Fix caBundle population for 4.0 deploys

### DIFF
--- a/ansible_role/tasks/main.yml
+++ b/ansible_role/tasks/main.yml
@@ -74,6 +74,8 @@
     - name: broker.route.yaml
       apply: "{{ ('route.openshift.io' in lookup('k8s', cluster_info='api_groups')) | bool }}"
     - name: broker-client.secret.yaml
+    - name: broker-service-ca-bundle.configmap.yaml
+      apply: "{{ ('route.openshift.io' in lookup('k8s', cluster_info='api_groups')) | bool }}"
     - name: broker-auth.secret.yaml
       apply: "{{ (broker_config.broker.auth[0].enabled | default(False)) | bool }}"
     - name: broker.deployment.yaml

--- a/ansible_role/tasks/main.yml
+++ b/ansible_role/tasks/main.yml
@@ -75,7 +75,7 @@
       apply: "{{ ('route.openshift.io' in lookup('k8s', cluster_info='api_groups')) | bool }}"
     - name: broker-client.secret.yaml
     - name: broker-service-ca-bundle.configmap.yaml
-      apply: "{{ ('route.openshift.io' in lookup('k8s', cluster_info='api_groups')) | bool }}"
+      apply: "{{ ('servicecertsigneroperatorconfigs.servicecertsigner.config.openshift.io' in lookup('k8s', cluster_info='api_groups')) | bool }}"
     - name: broker-auth.secret.yaml
       apply: "{{ (broker_config.broker.auth[0].enabled | default(False)) | bool }}"
     - name: broker.deployment.yaml

--- a/ansible_role/tasks/main.yml
+++ b/ansible_role/tasks/main.yml
@@ -75,7 +75,7 @@
       apply: "{{ ('route.openshift.io' in lookup('k8s', cluster_info='api_groups')) | bool }}"
     - name: broker-client.secret.yaml
     - name: broker-service-ca-bundle.configmap.yaml
-      apply: "{{ ('servicecertsigneroperatorconfigs.servicecertsigner.config.openshift.io' in lookup('k8s', cluster_info='api_groups')) | bool }}"
+      apply: "{{ ('servicecertsigner.config.openshift.io' in lookup('k8s', cluster_info='api_groups')) | bool }}"
     - name: broker-auth.secret.yaml
       apply: "{{ (broker_config.broker.auth[0].enabled | default(False)) | bool }}"
     - name: broker.deployment.yaml

--- a/ansible_role/templates/broker-service-ca-bundle.configmap.yaml
+++ b/ansible_role/templates/broker-service-ca-bundle.configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+data:
+  service-ca.crt: ""
+kind: ConfigMap
+metadata:
+  annotations:
+    service.alpha.openshift.io/inject-cabundle: "true"
+  name: broker-service-ca-bundle
+  namespace: {{ broker_namespace }}

--- a/ansible_role/templates/broker.servicecatalog.yaml
+++ b/ansible_role/templates/broker.servicecatalog.yaml
@@ -33,6 +33,16 @@ spec:
       resource_name=broker_tls_name
     ) | json_query('data."tls.crt"')
   }}
+{%   elif 'servicecertsigneroperatorconfigs.servicecertsigner.config.openshift.io' not in lookup('k8s', cluster_info='api_groups') %}
+  caBundle: {{
+    lookup(
+      'k8s',
+      kind='Secret',
+      api_version='v1',
+      namespace=broker_namespace,
+      resource_name=broker_name + '-client'
+    ) | json_query('data."service-ca.crt"')
+  }}
 {%   else %}
   caBundle: {{
     lookup(

--- a/ansible_role/templates/broker.servicecatalog.yaml
+++ b/ansible_role/templates/broker.servicecatalog.yaml
@@ -33,7 +33,7 @@ spec:
       resource_name=broker_tls_name
     ) | json_query('data."tls.crt"')
   }}
-{%   elif 'servicecertsigneroperatorconfigs.servicecertsigner.config.openshift.io' not in lookup('k8s', cluster_info='api_groups') %}
+{%   elif 'servicecertsigner.config.openshift.io' not in lookup('k8s', cluster_info='api_groups') %}
   caBundle: {{
     lookup(
       'k8s',

--- a/ansible_role/templates/broker.servicecatalog.yaml
+++ b/ansible_role/templates/broker.servicecatalog.yaml
@@ -41,7 +41,7 @@ spec:
       api_version='v1',
       namespace=broker_namespace,
       resource_name='broker-service-ca-bundle'
-    ) | json_query('data."service-ca.crt"')
+    ) | json_query('data."service-ca.crt"') | b64encode
   }}
 {%   endif %}
 {% endif %}

--- a/ansible_role/templates/broker.servicecatalog.yaml
+++ b/ansible_role/templates/broker.servicecatalog.yaml
@@ -37,10 +37,10 @@ spec:
   caBundle: {{
     lookup(
       'k8s',
-      kind='Secret',
+      kind='ConfigMap',
       api_version='v1',
       namespace=broker_namespace,
-      resource_name=broker_name + '-client'
+      resource_name='broker-service-ca-bundle'
     ) | json_query('data."service-ca.crt"')
   }}
 {%   endif %}


### PR DESCRIPTION
#### Changes proposed in this pull request
 - Make changes to ansible role so that broker can be deployed onto OpenShift 4.0 and `clusterservicebroker` resource will contain correct `caBundle: <blob>` section which is required for successful communication with the broker.


A build of this is currently pushed to _docker.io/djwhatle/asb-operator:4.0-svcat-cert_

### To test:
 - Create 4.0 cluster including OLM
 - Create `kube-service-catalog` namespace
 - Create Service Catalog subscription [link](https://github.com/djwhatle/stuff/blob/master/olm-svcat-brokers-testing/svcat-subscription.yaml)
 - Create osb-operators configmap [link](https://github.com/djwhatle/stuff/blob/master/olm-svcat-brokers-testing/osb-operators.configmap.upstream.4.0-fixed.yaml) (references my custom image above)
 - Create osb-operators catalogsource [link](https://github.com/djwhatle/stuff/blob/master/olm-svcat-brokers-testing/osb-operators.catalogsource.yaml)
 - Create `automation-broker` namespace
 - Create asb subscription [link](https://github.com/djwhatle/stuff/blob/master/olm-svcat-brokers-testing/asb-subscription.yaml)
 - Create asb CR [link](https://github.com/djwhatle/stuff/blob/master/olm-svcat-brokers-testing/asb-cr.yaml
)
 - Verify that `oc get clusterservicebrokers -o yaml` contains a `caBundle` with b64 content, and that the broker logs contain 200 responses like below

```
10.128.0.48 - - [11/Dec/2018:19:20:09 +0000] "GET /osb/v2/catalog HTTP/1.1" 200 373935
```

 - `oc get clusterservicebrokers` should return a "Ready" status
```
[dwhatley@precision-t olm-svcat-brokers-testing]$ oc get clusterservicebrokers
NAME                URL                                              STATUS    AGE
automation-broker   https://broker.automation-broker.svc:1338/osb/   Ready     17m
```
