### PR TITLE
Check if ca-bundle configmap already exists to avoid contention with cert-signer operator

### DIFF
--- a/ansible_role/tasks/main.yml
+++ b/ansible_role/tasks/main.yml
@@ -75,7 +75,8 @@
       apply: "{{ ('route.openshift.io' in lookup('k8s', cluster_info='api_groups')) | bool }}"
     - name: broker-client.secret.yaml
     - name: broker-service-ca-bundle.configmap.yaml
-      apply: "{{ ('servicecertsigner.config.openshift.io' in lookup('k8s', cluster_info='api_groups')) | bool }}"
+      apply: "{{ (('servicecertsigner.config.openshift.io' in lookup('k8s', cluster_info='api_groups')) | bool )
+                and not (lookup('k8s', api_version='v1', kind='ConfigMap', namespace=broker_namespace,resource_name='broker-service-ca-bundle') | bool) }}"
     - name: broker-auth.secret.yaml
       apply: "{{ (broker_config.broker.auth[0].enabled | default(False)) | bool }}"
     - name: broker.deployment.yaml


### PR DESCRIPTION
#### Changes proposed in this pull request

 - Add check for ca-bundle configmap existence before overwriting
 - Avoid contention between ASB operator and cert-signer operator in modifying the ca-bundle configmap

A build of this is currently pushed to _docker.io/djwhatle/asb-operator:4.0-svcat-cert_

Went with a relatively simplistic implementation of this check so that we can get it in and start testing. I don't think we lose significant value with this approach vs. a smarter approach that would verify the integrity of the structure in the configmap.

### To test:
 - Create 4.0 cluster including OLM
 - Create `kube-service-catalog` namespace
 - Create Service Catalog subscription [link](https://github.com/djwhatle/stuff/blob/master/olm-svcat-brokers-testing/svcat-subscription.yaml)
 - Create osb-operators configmap [link](https://github.com/djwhatle/stuff/blob/master/olm-svcat-brokers-testing/osb-operators.configmap.upstream.4.0-fixed.yaml) (references my custom image above)
 - Create osb-operators catalogsource [link](https://github.com/djwhatle/stuff/blob/master/olm-svcat-brokers-testing/osb-operators.catalogsource.yaml)
 - Create `automation-broker` namespace
 - Create asb subscription [link](https://github.com/djwhatle/stuff/blob/master/olm-svcat-brokers-testing/asb-subscription.yaml)
 - Create asb CR [link](https://github.com/djwhatle/stuff/blob/master/olm-svcat-brokers-testing/asb-cr.yaml)

#### Things to verify
 - Check that clusterservicebroker entries don't disappear mysteriously
 - Check that clusterserviceclasses persist
 - Check that broker-service-ca-bundle configmap always contains caBundle data, and never just a placeholder value
 - Check that ASB operator doesn't freeze up after some time

```
(apbs) [dwhatley@precision-t ansible-service-broker]$ oc get clusterservicebrokers
NAME                URL                                              STATUS    AGE
automation-broker   https://broker.automation-broker.svc:1338/osb/   Ready     2h


(apbs) [dwhatley@precision-t ansible-service-broker]$ oc get clusterserviceclasses
NAME                               EXTERNAL-NAME             BROKER              AGE
08ccf37be271fba38b1a70f87302297f   dh-rhpam-apb              automation-broker   2h
09628db4757fd1a2db85d465106b9f82   dh-gluster-s3-apb         automation-broker   2h
0e991006d21029e47abe71acc255e807   dh-pyzip-demo-apb         automation-broker   2h
135bd0df0401e2fdd52fd136935014fb   dh-nginx-apb              automation-broker   2h
1830d9181b425e281b36efbf22f378a4   dh-proxy-config-apb       automation-broker   2h
1882ffca5d72b1084e9107e3485f5066   dh-eclipse-che-apb        automation-broker   2h
192097962f2955b0582b5d53ddb942e4   dh-galera-apb             automation-broker   2h
[...]


(apbs) [dwhatley@precision-t ansible-service-broker]$ oc get configmap broker-service-ca-bundle -o yaml
apiVersion: v1
data:
  service-ca.crt: |
    -----BEGIN CERTIFICATE-----
    MIIDODCCAiCgAwIBAgIIS5xSkWbh4vYwDQYJKoZIhvcNAQELBQAwJjESMBAGA1UE
    CxMJb3BlbnNoaWZ0MRAwDgYDVQQDEwdyb290LWNhMB4XDTE4MTIxMTE3NTM0N1oX
    [...]
    -----END CERTIFICATE-----
kind: ConfigMap
metadata:
  annotations:
    service.alpha.openshift.io/inject-cabundle: "true"
  creationTimestamp: 2018-12-13T18:33:24Z
  name: broker-service-ca-bundle
  namespace: automation-broker
[...]
(apbs) [dwhatley@precision-t ansible-service-broker]$ 
```