### PR TITLE
Update operator playbook to use IMAGE from environment

### DIFF
--- a/ansible_role/playbooks/operator.yml
+++ b/ansible_role/playbooks/operator.yml
@@ -5,9 +5,22 @@
   become: false
   gather_facts: false
   connection: local
-  roles:
-  - role: automation-broker
   vars:
     state: present
     broker_name: "{{ meta.name }}"
     broker_namespace: "{{ meta.namespace }}"
+    broker_image: "{{ lookup('env', 'IMAGE') }}"
+  tasks:
+    - name: Validation
+      assert:
+        that:
+          - broker_name is defined
+          - broker_namespace is defined
+          - broker_image is defined
+        msg: |
+          broker_name broker_namespace broker_image must be defined
+          The IMAGE environment variable must provide the broker's image name
+          and should be specified in the operator's deployment specification.
+    - name: Run automation-broker role
+      include_role:
+        name: automation-broker


### PR DESCRIPTION
The operator playbook will now enforce `broker_name`, `broker_namespace`, and `broker_image` to be defined with `broker_image` being captured from the operator's environment.