### PR TITLE
Fix downstream container builds

### DIFF
--- a/ansible_role/operator/Dockerfile
+++ b/ansible_role/operator/Dockerfile
@@ -7,9 +7,11 @@ COPY . /opt/ansible/roles/automation-broker
 COPY playbooks/operator.yml /opt/ansible/deploy.yml
 COPY operator/watches.yaml /opt/ansible/watches.yaml
 
+USER root
 RUN sed -i "s/\(broker_image_tag:\).*/\1 ${VERSION}/" \
     /opt/ansible/roles/automation-broker/defaults/main.yml && \
     sed -i "s/\(broker_dockerhub_tag:\).*/\1 ${APB}/" \
     /opt/ansible/roles/automation-broker/defaults/main.yml && \
     sed -i "s/\(olm_managed:\).*/\1 ${OLM_MANAGED}/" \
     /opt/ansible/roles/automation-broker/defaults/main.yml
+USER ansible-operator


### PR DESCRIPTION
Files are always added to the container owned as root.

When the users group is properly set the commands aren't run with the root group and fail. The upstream image is running commands as ansible-operator:root rather than ansible-operator:ansible-operator so it doesn't see this.