### PR TITLE
Add Dockerfile link to prepare for automated downstream builds

### DIFF
--- a/ansible_role/Dockerfile.operator.ocp
+++ b/ansible_role/Dockerfile.operator.ocp
@@ -1,0 +1,1 @@
+operator/Dockerfile


### PR DESCRIPTION
My understanding is the Dockerfile for downstream OCP builds must exist in the build context directory. Essentially what is run is, "docker build -f $DIR/$DOCKERFILE $DIR".

As far as I know it can be a link. If for some reason it can't I can PR a swap of the file and link.