### PR TITLE
Update operator Dockerfile to use AO master, add subresource in CRD

### DIFF
--- a/ansible_role/operator/Dockerfile
+++ b/ansible_role/operator/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/water-hole/ansible-operator
+FROM quay.io/operator-framework/ansible-operator:master
 ARG OLM_MANAGED=true
 ARG VERSION=v3.11
 ARG APB=v3.11

--- a/ansible_role/operator/crd.yaml
+++ b/ansible_role/operator/crd.yaml
@@ -12,3 +12,5 @@ spec:
     singular: automationbroker
   scope: Namespaced
   version: v1alpha1
+  subresources:
+    status: {}


### PR DESCRIPTION
#### Describe what this PR does and why we need it:
Update to use latest Ansible Operator base image, and add required `subresources` field to CRD.
