### PR TITLE
Bug 1664506 - Update operator resource names to maintain 3.11 backwards compatibility

### DIFF
--- a/ansible_role/defaults/main.yml
+++ b/ansible_role/defaults/main.yml
@@ -9,8 +9,8 @@ cluster: "kubernetes"
 olm_managed: false
 
 # Broker configuration values
-broker_name: automation-broker
-broker_namespace: "{{ namespace | default(broker_name, true) }}"
+broker_name: ansible-service-broker
+broker_namespace: openshift-ansible-service-broker
 
 create_broker_namespace: false
 wait_for_broker: false # By default, we do not wait for the broker to be available

--- a/ansible_role/defaults/main.yml
+++ b/ansible_role/defaults/main.yml
@@ -11,6 +11,7 @@ olm_managed: false
 # Broker configuration values
 broker_name: ansible-service-broker
 broker_namespace: openshift-ansible-service-broker
+broker_deployment_name: asb
 
 create_broker_namespace: false
 wait_for_broker: false # By default, we do not wait for the broker to be available

--- a/ansible_role/defaults/main.yml
+++ b/ansible_role/defaults/main.yml
@@ -12,6 +12,8 @@ olm_managed: false
 broker_name: ansible-service-broker
 broker_namespace: openshift-ansible-service-broker
 broker_deployment_name: asb
+broker_service_name: asb
+broker_route_name: asb
 
 create_broker_namespace: false
 wait_for_broker: false # By default, we do not wait for the broker to be available

--- a/ansible_role/defaults/main.yml
+++ b/ansible_role/defaults/main.yml
@@ -13,7 +13,9 @@ broker_name: ansible-service-broker
 broker_namespace: openshift-ansible-service-broker
 broker_deployment_name: asb
 broker_service_name: asb
-broker_route_name: asb
+broker_route_name: asb-1338
+
+dashboard_redirector_route_name: dr-1337
 
 create_broker_namespace: false
 wait_for_broker: false # By default, we do not wait for the broker to be available

--- a/ansible_role/playbooks/test.yml
+++ b/ansible_role/playbooks/test.yml
@@ -57,6 +57,7 @@
         name: automation-broker-apb
       vars:
         apb_action: provision
+        broker_namespace: test-openshift-ansible-service-broker
         create_broker_namespace: true
         wait_for_broker: true
         broker_dao_type: crd

--- a/ansible_role/tasks/generate_certificate.yml
+++ b/ansible_role/tasks/generate_certificate.yml
@@ -15,7 +15,7 @@
         -keyout {{ broker_tls_cert_dir }}/key.pem
         -out {{ broker_tls_cert_dir }}/cert.pem
         -days 365
-        -subj "/CN=broker.{{ broker_namespace }}.svc"
+        -subj "/CN={{ broker_service_name }}.{{ broker_namespace }}.svc"
       args:
         creates: "{{ broker_tls_cert_dir }}/cert.pem"
 

--- a/ansible_role/templates/broker-redirector.route.yaml
+++ b/ansible_role/templates/broker-redirector.route.yaml
@@ -3,7 +3,7 @@
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
-  name: broker-redirector
+  name: {{ dashboard_redirector_route_name }}
   namespace: {{ broker_namespace }}
   labels:
     app: {{ broker_name }}

--- a/ansible_role/templates/broker-redirector.route.yaml
+++ b/ansible_role/templates/broker-redirector.route.yaml
@@ -7,10 +7,10 @@ metadata:
   namespace: {{ broker_namespace }}
   labels:
     app: {{ broker_name }}
-    service: broker
+    service: {{ broker_service_name }}
 spec:
   to:
     kind: Service
-    name: broker
+    name: {{ broker_service_name }}
   port:
     targetPort: port-1337

--- a/ansible_role/templates/broker.deployment.yaml
+++ b/ansible_role/templates/broker.deployment.yaml
@@ -12,20 +12,20 @@ metadata:
   namespace: {{ broker_namespace }}
   labels:
     app: {{ broker_name }}
-    service: broker
+    service: {{ broker_service_name }}
 spec:
   replicas: 1
 {% if 'apps.openshift.io' in lookup('k8s', cluster_info='api_groups') %}
   selector:
     app: {{ broker_name }}
-    service: broker
+    service: {{ broker_service_name }}
   strategy:
     type: Rolling
 {% else %}
   selector:
     matchLabels:
       app: {{ broker_name }}
-      service: broker
+      service: {{ broker_service_name }}
   strategy:
     type: RollingUpdate
 {% endif %}
@@ -36,7 +36,7 @@ spec:
     metadata:
       labels:
         app: {{ broker_name }}
-        service: broker
+        service: {{ broker_service_name }}
     spec:
       serviceAccount: {{ broker_name }}
       containers:

--- a/ansible_role/templates/broker.deployment.yaml
+++ b/ansible_role/templates/broker.deployment.yaml
@@ -8,7 +8,7 @@ apiVersion: apps/v1
 kind: Deployment
 {% endif %}
 metadata:
-  name: {{ broker_name }}
+  name: {{ broker_deployment_name }}
   namespace: {{ broker_namespace }}
   labels:
     app: {{ broker_name }}

--- a/ansible_role/templates/broker.route.yaml
+++ b/ansible_role/templates/broker.route.yaml
@@ -5,15 +5,15 @@ kind: Route
 metadata:
   annotations:
     haproxy.router.openshift.io/timeout: 300s
-  name: broker
+  name: {{ broker_route_name }}
   namespace: {{ broker_namespace }}
   labels:
     app: {{ broker_name }}
-    service: broker
+    service: {{ broker_service_name }}
 spec:
   to:
     kind: Service
-    name: broker
+    name: {{ broker_service_name }}
   port:
     targetPort: port-1338
   tls:

--- a/ansible_role/templates/broker.service.yaml
+++ b/ansible_role/templates/broker.service.yaml
@@ -3,11 +3,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: broker
+  name: {{ broker_service_name }}
   namespace: {{ broker_namespace }}
   labels:
     app: {{ broker_name }}
-    service: broker
+    service: {{ broker_service_name }}
 {% if 'route.openshift.io' in lookup('k8s', cluster_info='api_groups') %}
   annotations:
     service.alpha.openshift.io/serving-cert-secret-name: {{ broker_tls_name }}
@@ -24,4 +24,4 @@ spec:
       protocol: TCP
   selector:
     app: {{ broker_name }}
-    service: broker
+    service: {{ broker_service_name }}

--- a/ansible_role/templates/broker.servicecatalog.yaml
+++ b/ansible_role/templates/broker.servicecatalog.yaml
@@ -9,7 +9,7 @@ metadata:
 {% endif %}
 {% if state == 'present' %}
 spec:
-  url: https://broker.{{ broker_namespace }}.svc:1338/osb/
+  url: https://{{ broker_service_name }}.{{ broker_namespace }}.svc:1338/osb/
   authInfo:
     bearer:
       secretRef:


### PR DESCRIPTION
#### Describe what this PR does and why we need it:
Updates operator resource names to maintain 3.11 backwards compatibility. Our current defaults are blocking QE testing https://bugzilla.redhat.com/show_bug.cgi?id=1664506

#### Changes proposed in this pull request
 - Use `openshift-ansible-service-broker` ns
 - Use `ansible-service-broker` broker_name
 - Use `asb` for service & route names

#### Does this PR depend on another PR (Use this to track when PRs should be merged)
Related: https://github.com/fusor/catbrokers4/pull/7


