### PR TITLE
Add OLM support to new operator

### DIFF
--- a/operator/deploy/olm-catalog/0.1.0/automationbroker.crd.yaml
+++ b/operator/deploy/olm-catalog/0.1.0/automationbroker.crd.yaml
@@ -1,9 +1,9 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: automationbrokers.automationbroker.io
+  name: automationbrokers.osb.openshift.io
 spec:
-  group: automationbroker.io
+  group: osb.openshift.io
   names:
     kind: AutomationBroker
     listKind: AutomationBrokerList

--- a/operator/deploy/olm-catalog/0.1.0/automationbrokeroperator.v0.1.0.clusterserviceversion.yaml
+++ b/operator/deploy/olm-catalog/0.1.0/automationbrokeroperator.v0.1.0.clusterserviceversion.yaml
@@ -1,10 +1,11 @@
+---
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   name: automationbrokeroperator.v0.1.0
   namespace: placeholder
   annotations:
-    alm-examples: '[{"apiVersion":"automationbroker.io/v1alpha1","kind":"AutomationBroker","metadata":{"name":"automation-broker","namespace":"automation-broker"},"spec":{"createBrokerNamespace":"false","waitForBroker":"false"}}]'
+    alm-examples: '[{"apiVersion":"osb.openshift.io/v1alpha1","kind":"AutomationBroker","metadata":{"name":"ansible-service-broker","namespace":"openshift-ansible-service-broker"},"spec":{"createBrokerNamespace":"false","waitForBroker":"false"}}]'
 spec:
   displayName: Automation Broker Operator
   description: |
@@ -41,13 +42,13 @@ spec:
       mediatype: image/png
   installModes:
   - type: OwnNamespace
-    supported: true
+    supported: false
   - type: SingleNamespace
     supported: true
   - type: MultiNamespace
-    supported: true
+    supported: false
   - type: AllNamespaces
-    supported: true
+    supported: false
   install:
     strategy: deployment
     spec:
@@ -66,7 +67,6 @@ spec:
           - pods
           - configmaps
           - secrets
-          - serviceaccounts
           - services
           verbs:
           - "*"
@@ -88,114 +88,17 @@ spec:
           - deploymentconfigs
           verbs:
           - "*"
-      - serviceAccountName: automation-broker
-        rules:
-        - apiGroups:
-          - ""
-          resources:
-          - configmaps
-          verbs:
-          - get
-          - delete
-        - apiGroups:
-          - ""
-          resources:
-          - secrets
-          verbs:
-          - create
-          - delete
-          - get
-        - apiGroups:
-          - automationbroker.io
-          resources:
-          - bundles
-          - bundleinstances
-          - bundlebindings
-          verbs:
-          - "*"
       clusterPermissions:
       - serviceAccountName: automation-broker-operator
         rules:
         - apiGroups:
-          - servicecatalog.k8s.io
-          resources:
-          - clusterservicebrokers
-          - servicebrokers
-          verbs:
-          - "*"
-        # Must be cluster scoped, since we're expecting a single operator
-        # to be installed into a designated namespace, watching the full
-        # cluster for CRs.
-        - apiGroups:
-          - automationbroker.io
-          resources:
-          - "*"
-          verbs:
-          - "*"
-        ################################################################################
-        # This may be required to allow the operator to create an aggregated ClusterRole
-        # in order to add the rule that is checked by the broker to edit and/or admin.
-        ################################################################################
-        - apiGroups:
-          - rbac.authorization.k8s.io
-          resources:
-          - clusterroles
-          verbs:
-          - create
-          - patch
-        ################################################################################
-        #
-        ################################################################################
-        # Questionable, could maybe pull these?
-        ################################################################################
-        #- nonResourceURLs:
-        #  - /version/openshift
-        #  verbs:
-        #  - get
-        ##Could maybe try this one with just get?
-        #- apiGroups:
-        #  - apiextensions.k8s.io
-        #  resources:
-        #  - customresourcedefinitions
-        #  verbs:
-        #  - get
-        #  - patch
-        #  - update
-        # OLM should be able to handle these instead of the operator's ansible
-        #- apiGroups:
-        #  - rbac.authorization.k8s.io
-        #  resources:
-        #  - clusterrolebindings
-        #  - clusterroles
-        #  verbs:
-        #  - get
-        #  - patch
-        #  - update
-      - serviceAccountName: automation-broker
-        rules:
-        - apiGroups:
-          - ""
-          resources:
-          - namespaces
-          verbs:
-          - get
-          - create
-          - delete
-        - apiGroups:
-          - ""
-          resources:
-          - pods
-          verbs:
-          - create
-          - get
-          - list
-          - watch
-        - apiGroups:
           - ""
           resources:
           - serviceaccounts
+          - namespaces
+          - pods
           verbs:
-          - create
+          - "*"
         - apiGroups:
           - authentication.k8s.io
           resources:
@@ -211,12 +114,22 @@ spec:
         - apiGroups:
           - rbac.authorization.k8s.io
           resources:
+          - clusterroles
+          - clusterrolebindings
           - rolebindings
           verbs:
           - create
           - delete
-        # broker must be able to set up a networkpolicy in the target
-        # namespace to set up a tunnel between the sandbox and the target
+          - patch
+          - get
+          - list
+        - apiGroups:
+          - servicecatalog.k8s.io
+          resources:
+          - clusterservicebrokers
+          - servicebrokers
+          verbs:
+          - "*"
         - apiGroups:
           - networking.k8s.io
           resources:
@@ -224,12 +137,24 @@ spec:
           verbs:
           - create
           - delete
+          - list
+          - get
         - apiGroups:
           - authorization.openshift.io
           resources:
           - subjectrulesreview
           verbs:
           - create
+        - apiGroups:
+          - network.openshift.io
+          - ""
+          resources:
+          - clusternetworks
+          - netnamespaces
+          verbs:
+          - get
+          - update
+          - list
         - apiGroups:
           - image.openshift.io
           - ""
@@ -239,22 +164,17 @@ spec:
           - get
           - list
         - apiGroups:
-          - network.openshift.io
-          - ""
+          - osb.openshift.io
           resources:
-          - clusternetworks
-          - netnamespaces
+          - "*"
           verbs:
-          - get
+          - "*"
         - apiGroups:
-          - network.openshift.io
-          - ""
+          - automationbroker.io
           resources:
-          - netnamespaces
+          - "*"
           verbs:
-          - update
-      - serviceAccountName: automation-broker-client
-        rules:
+          - "*"
         - nonResourceURLs:
           - "/osb"
           - "/osb/*"
@@ -291,7 +211,7 @@ spec:
                       fieldPath: metadata.namespace
   customresourcedefinitions:
     owned:
-    - name: automationbrokers.automationbroker.io
+    - name: automationbrokers.osb.openshift.io
       version: v1alpha1
       kind: AutomationBroker
       displayName: Automation Broker
@@ -311,8 +231,3 @@ spec:
       kind: BundleInstance
       displayName: Automation Broker Bundle Instance
       description: An instance of an application bundle
-status:
-  certsLastUpdated: null
-  certsRotateAt: null
-  lastTransitionTime: null
-  lastUpdateTime: null

--- a/operator/roles/ansible-service-broker/defaults/main.yml
+++ b/operator/roles/ansible-service-broker/defaults/main.yml
@@ -1,59 +1,57 @@
 ---
 
+############################################################
+# Supported public CR API
+############################################################
+# broker_name: Name used to identify the broker instance.
 broker_name: ansible-service-broker
+# broker_namespace - Namespace where the broker resides.
 broker_namespace: openshift-ansible-service-broker
+# broker_image - Fully qualified image used for the broker.
+broker_image: docker.io/ansibleplaybookbundle/origin-ansible-service-broker:v3.11
+# broker_image_pull_policy - Pull policy used for the broker image itself.
+broker_image_pull_policy: "IfNotPresent"
+# broker_node_selector - Node selector string used for the broker's deployment.
+broker_node_selector: ""
+# log_level - Log level used for the broker's logs.
+# accepts: debug, info, warn, error
+log_level: info
+# apb_pull_policy - The pull policy used for apb pods.
+apb_pull_policy: "IfNotPresent"
+# sandbox_role - The role granted to the service account used to execute apbs.
+# accepts: edit, admin
+sandbox_role: "edit"
+# keep_namespace - Controls whether the broker should delete the transient
+# namespace created to run the apb or not after the conclusion of the apb,
+# regardless of the result. Useful for debug purposes.
+keep_namespace: false
+# keep_namespace_on_error - Similar to keep_namespace, but just controls
+# whether or not the namespace is deleted in the event of an error result from
+# the apb. Can be used to say "Only keep the namespace around if something
+# went wrong".
+keep_namespace_on_error: false
+# bootstrap_on_startup - Indicates whether or not the broker should run its
+# bootstrap routine on startup.
+bootstrap_on_startup: true
+# refresh_interval - The interval of time between broker bootstraps, refreshing
+# its inventory of apbs. Defaults to "600s".
+refresh_interval: 600s
+# launch_apb_on_bind - EXPERIMENTAL FEATURE: Enable/disables the broker executing
+# apbs on bind operations.
+launch_apb_on_bind: false
+# auto_escalate - Automatically tells the broker to escalate the permissions of
+# a user while running the apb. This typically should remain false.
+auto_escalate: false
 
+############################################################
+# Private configuration
+############################################################
 # 3.11 compatible names
 broker_deployment_name: asb
 broker_service_name: asb
 broker_route_name: asb-1338
 dashboard_redirector_route_name: dr-1337
 
-broker_image: docker.io/ansibleplaybookbundle/origin-ansible-service-broker:v3.11
-
+# Used to set namespaced broker (ServiceBroker)
 broker_kind: ClusterServiceBroker
-broker_image_pull_policy: "IfNotPresent"
 broker_probe_initial_delay: 120
-broker_node_selector: ""
-broker_basic_auth_enabled: false
-
-_broker_config:
-  registry:
-    - type: dockerhub
-      name: dh
-      url: https://registry.hub.docker.com
-      org: ansibleplaybookbundle
-      tag: latest
-      white_list:
-        - ".*-apb$"
-      black_list:
-        - ".*automation-broker-apb$"
-  dao:
-    type: crd
-  log:
-    logfile: /var/log/ansible-service-broker/asb.log
-    stdout: true
-    level: debug
-    color: true
-  openshift:
-    host: ''
-    ca_file: ''
-    bearer_token_file: ''
-    image_pull_policy: "IfNotPresent"
-    sandbox_role: "edit"
-    namespace: "{{ broker_namespace | quote }}"
-    keep_namespace: "false"
-    keep_namespace_on_error: "false"
-  broker:
-    dev_broker: "true"
-    bootstrap_on_startup: "true"
-    refresh_interval: "600s"
-    launch_apb_on_bind: "false"
-    output_request: "true"
-    recovery: "true"
-    ssl_cert_key: /etc/tls/private/tls.key
-    ssl_cert: /etc/tls/private/tls.crt
-    auto_escalate: "false"
-  auth:
-    - type: basic
-      enabled: false

--- a/operator/roles/ansible-service-broker/defaults/main.yml
+++ b/operator/roles/ansible-service-broker/defaults/main.yml
@@ -13,7 +13,7 @@ broker_image: docker.io/ansibleplaybookbundle/origin-ansible-service-broker:v3.1
 broker_image_pull_policy: "IfNotPresent"
 # broker_node_selector - Node selector string used for the broker's deployment.
 broker_node_selector: ""
-# registires - expressed as a yaml list of broker registry configs, allowing
+# registries - expressed as a yaml list of broker registry configs, allowing
 # the user to configure the image registries the broker will discover and
 # source its apbs from.
 registries:

--- a/operator/roles/ansible-service-broker/defaults/main.yml
+++ b/operator/roles/ansible-service-broker/defaults/main.yml
@@ -13,6 +13,19 @@ broker_image: docker.io/ansibleplaybookbundle/origin-ansible-service-broker:v3.1
 broker_image_pull_policy: "IfNotPresent"
 # broker_node_selector - Node selector string used for the broker's deployment.
 broker_node_selector: ""
+# registires - expressed as a yaml list of broker registry configs, allowing
+# the user to configure the image registries the broker will discover and
+# source its apbs from.
+registries:
+- type: dockerhub
+  name: dh
+  url: https://registry.hub.docker.com
+  org: ansibleplaybookbundle
+  tag: latest
+  white_list:
+    - ".*-apb$"
+  black_list:
+    - ".*automation-broker-apb$"
 # log_level - Log level used for the broker's logs.
 # accepts: debug, info, warn, error
 log_level: info

--- a/operator/roles/ansible-service-broker/tasks/main.yml
+++ b/operator/roles/ansible-service-broker/tasks/main.yml
@@ -27,7 +27,8 @@
       resource_name=broker_name).status.reconciledGeneration | default('')
     }}"
 
-- set_fact:
+- name: Set pending_config_changes fact
+  set_fact:
     pending_config_changes: "{{ generation != reconciled_generation }}"
 
 # Push validation into separate task files

--- a/operator/roles/ansible-service-broker/tasks/main.yml
+++ b/operator/roles/ansible-service-broker/tasks/main.yml
@@ -22,6 +22,7 @@
         definition: "{{ lookup('template', 'broker-redirector.route.yaml.j2') | from_yaml }}"
 
     - name: Set dashboard redirector host
+      when: state != "absent"
       set_fact:
         dashboard_redirector_host: "{{ lookup('k8s', api_version='route.openshift.io/v1', kind='Route', namespace=broker_namespace, resource_name=dashboard_redirector_route_name).spec.host }}"
 

--- a/operator/roles/ansible-service-broker/tasks/main.yml
+++ b/operator/roles/ansible-service-broker/tasks/main.yml
@@ -5,6 +5,31 @@
   set_fact:
     api_groups: "{{ lookup('k8s', cluster_info='api_groups') }}"
 
+# reconciled_generation - the last reconciled spec generation of a given CR
+# generation - the current generation of a given CR
+# These values are useful because if the current generation value is different
+# than the reconciled_generation value, we know that the CR's spec has been
+# changed, requiring a bounce of the broker's pod to accept new configuration.
+- name: Set reconciled_generation and generation facts
+  set_fact:
+    generation: "{{
+      lookup('k8s',
+      api_version='osb.openshift.io/v1alpha1',
+      kind='AutomationBroker',
+      namespace=broker_namespace,
+      resource_name=broker_name).metadata.generation
+    }}"
+    reconciled_generation: "{{
+      lookup('k8s',
+      api_version='osb.openshift.io/v1alpha1',
+      kind='AutomationBroker',
+      namespace=broker_namespace,
+      resource_name=broker_name).status.reconciledGeneration | default('')
+    }}"
+
+- set_fact:
+    pending_config_changes: "{{ generation != reconciled_generation }}"
+
 # Push validation into separate task files
 - name:  Validate pre-requisites for {{ state }}
   import_tasks: "validate_{{ state }}.yml"
@@ -24,7 +49,13 @@
     - name: Set dashboard redirector host
       when: state != "absent"
       set_fact:
-        dashboard_redirector_host: "{{ lookup('k8s', api_version='route.openshift.io/v1', kind='Route', namespace=broker_namespace, resource_name=dashboard_redirector_route_name).spec.host }}"
+        dashboard_redirector_host: "{{
+          lookup('k8s',
+          api_version='route.openshift.io/v1',
+          kind='Route',
+          namespace=broker_namespace,
+          resource_name=dashboard_redirector_route_name).spec.host
+        }}"
 
 - name: ConfigMap for Broker
   k8s:
@@ -52,3 +83,33 @@
     - value: broker-service-ca-bundle.configmap.yaml.j2
     - value: broker.servicecatalog.yaml.j2
       condition: "{{ 'servicecatalog.k8s.io' in api_groups }}"
+
+- name: Redeploy the broker's pod if pending config changes
+  k8s:
+    state: absent
+    kind: Pod
+    api_version: v1
+    namespace: broker_namespace
+    name: pod.metadata.name
+  vars:
+    pod: "{{
+      lookup('k8s',
+      kind='Pod',
+      api_version='v1',
+      namespace=broker_namespace,
+      label_selector=('app=' + broker_name))
+    }}"
+  when:
+    - pending_config_changes
+    - reconciled_generation != ''
+    - pod
+
+- name: Write generation to status as reconciled generation
+  when: pending_config_changes
+  k8s_status:
+    api_version: osb.openshift.io/v1alpha1
+    kind: AutomationBroker
+    namespace: "{{ broker_namespace }}"
+    name: "{{ broker_name }}"
+    status:
+      reconciledGeneration: "{{ generation }}"

--- a/operator/roles/ansible-service-broker/tasks/main.yml
+++ b/operator/roles/ansible-service-broker/tasks/main.yml
@@ -13,7 +13,6 @@
   import_tasks: tls_k8s.yml
   when: "'route.openshift.io' not in api_groups"
 
-
 - name: Dashboard redirector
   when: "'route.openshift.io' in api_groups"
   block:
@@ -22,10 +21,9 @@
         state: "{{ state }}"
         definition: "{{ lookup('template', 'broker-redirector.route.yaml.j2') | from_yaml }}"
 
-    - name: Add redirector to broker config object
-      when: state == "present"
+    - name: Set dashboard redirector host
       set_fact:
-        broker: "{{ broker_config.broker | combine({'dashboard_redirector': dashboard_redirector_url}) }}"
+        dashboard_redirector_host: "{{ lookup('k8s', api_version='route.openshift.io/v1', kind='Route', namespace=broker_namespace, resource_name=dashboard_redirector_route_name).spec.host }}"
 
 - name: ConfigMap for Broker
   k8s:
@@ -40,14 +38,16 @@
     definition: "{{ lookup('template', item.value) | from_yaml }}"
   loop:
     - value: broker.serviceaccount.yaml.j2
+    - value: broker.clusterrole.yaml.j2
     - value: broker.clusterrolebinding.yaml.j2
-    - value: broker-client.serviceaccount.yaml.j2
-    - value: broker-client.clusterrolebinding.yaml.j2
     - value: broker.service.yaml.j2
+    - value: broker.deployment.yaml.j2
     - value: broker.route.yaml.j2
       condition: "{{ 'route.openshift.io' in api_groups }}"
+    - value: broker-client.serviceaccount.yaml.j2
+    - value: broker-client.clusterrole.yaml.j2
+    - value: broker-client.clusterrolebinding.yaml.j2
     - value: broker-client.secret.yaml.j2
     - value: broker-service-ca-bundle.configmap.yaml.j2
-    - value: broker.deployment.yaml.j2
     - value: broker.servicecatalog.yaml.j2
       condition: "{{ 'servicecatalog.k8s.io' in api_groups }}"

--- a/operator/roles/ansible-service-broker/tasks/validate_present.yml
+++ b/operator/roles/ansible-service-broker/tasks/validate_present.yml
@@ -14,14 +14,3 @@
   assert:
     that: "'servicecatalog.k8s.io' in api_groups"
     fail_msg: Service Catalog must be installed
-
-- name: Write default config to CR and exit if not defined
-  when: broker_config is not defined
-  block:
-    - name: Write broker-config into CR
-      k8s:
-        state: "{{ state }}"
-        definition: "{{ lookup('template', 'broker.ansibleservicebroker.yaml.j2' ) | from_yaml }}"
-
-    - name: Exit if broker_config not defined
-      meta: end_play

--- a/operator/roles/ansible-service-broker/templates/broker-client.clusterrole.yaml.j2
+++ b/operator/roles/ansible-service-broker/templates/broker-client.clusterrole.yaml.j2
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: "access-{{ broker_name }}-{{ broker_namespace }}-role"
+rules:
+- nonResourceURLs:
+  - "/osb"
+  - "/osb/*"
+  verbs:
+  - get
+  - post
+  - put
+  - patch
+  - delete

--- a/operator/roles/ansible-service-broker/templates/broker-config.configmap.yaml.j2
+++ b/operator/roles/ansible-service-broker/templates/broker-config.configmap.yaml.j2
@@ -7,10 +7,46 @@ metadata:
   namespace: {{ broker_namespace }}
   labels:
     app: {{ broker_name }}
-{% if state == "present" %}
 data:
   broker-config: |
-{{ broker_config | to_nice_yaml | indent(4, true) }}
-{% else %}
-data: {}
+    registry:
+      - type: dockerhub
+        name: dh
+        url: https://registry.hub.docker.com
+        org: ansibleplaybookbundle
+        tag: latest
+        white_list:
+          - ".*-apb$"
+        black_list:
+          - ".*automation-broker-apb$"
+    dao:
+      type: crd
+    log:
+      logfile: /var/log/ansible-service-broker/asb.log
+      stdout: true
+      level: "{{ log_level }}"
+      color: true
+    openshift:
+      host: ''
+      ca_file: ''
+      bearer_token_file: ''
+      image_pull_policy: "{{ apb_pull_policy }}"
+      sandbox_role: "{{ sandbox_role }}"
+      namespace: "{{ broker_namespace | quote }}"
+      keep_namespace: {{ keep_namespace }}
+      keep_namespace_on_error: {{ keep_namespace_on_error }}
+    broker:
+{% if dashboard_redirector_host is defined %}
+      dashboard_redirector: https://{{ dashboard_redirector_host }}
 {% endif %}
+      bootstrap_on_startup: {{ bootstrap_on_startup }}
+      refresh_interval: "{{ refresh_interval }}"
+      launch_apb_on_bind: {{ launch_apb_on_bind }}
+      output_request: true
+      recovery: true
+      ssl_cert_key: /etc/tls/private/tls.key
+      ssl_cert: /etc/tls/private/tls.crt
+      auto_escalate: {{ auto_escalate }}
+      auth:
+        - type: basic
+          enabled: false

--- a/operator/roles/ansible-service-broker/templates/broker-config.configmap.yaml.j2
+++ b/operator/roles/ansible-service-broker/templates/broker-config.configmap.yaml.j2
@@ -9,16 +9,7 @@ metadata:
     app: {{ broker_name }}
 data:
   broker-config: |
-    registry:
-      - type: dockerhub
-        name: dh
-        url: https://registry.hub.docker.com
-        org: ansibleplaybookbundle
-        tag: latest
-        white_list:
-          - ".*-apb$"
-        black_list:
-          - ".*automation-broker-apb$"
+    registry: {{ registries | to_json }}
     dao:
       type: crd
     log:

--- a/operator/roles/ansible-service-broker/templates/broker.automationbroker.yaml.j2
+++ b/operator/roles/ansible-service-broker/templates/broker.automationbroker.yaml.j2
@@ -1,7 +1,7 @@
 ---
 
 apiVersion: osb.openshift.io/v1alpha1
-kind: AnsibleServiceBroker
+kind: AutomationBroker
 metadata:
   name: {{ broker_name }}
   namespace: {{ broker_namespace }}

--- a/operator/roles/ansible-service-broker/templates/broker.clusterrole.yaml.j2
+++ b/operator/roles/ansible-service-broker/templates/broker.clusterrole.yaml.j2
@@ -1,0 +1,93 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: "{{ broker_name }}-{{ broker_namespace }}"
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - create
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - create
+  - delete
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - delete
+  - list
+  - get
+- apiGroups:
+  - authorization.openshift.io
+  resources:
+  - subjectrulesreview
+  verbs:
+  - create
+- apiGroups:
+  - image.openshift.io
+  - ""
+  resources:
+  - images
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - network.openshift.io
+  - ""
+  resources:
+  - clusternetworks
+  - netnamespaces
+  verbs:
+  - get
+  - update
+  - list
+- apiGroups:
+  - network.openshift.io
+  - ""
+  resources:
+  - netnamespaces
+  verbs:
+  - update
+- apiGroups:
+  - automationbroker.io
+  resources:
+  - "*"
+  verbs:
+  - "*"

--- a/operator/roles/ansible-service-broker/templates/broker.clusterrolebinding.yaml.j2
+++ b/operator/roles/ansible-service-broker/templates/broker.clusterrolebinding.yaml.j2
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: "{{ broker_name }}-{{ broker_namespace }}"
 roleRef:
-  name: admin
+  name: "{{ broker_name }}-{{ broker_namespace }}"
   kind: ClusterRole
   apiGroup: rbac.authorization.k8s.io
 subjects:

--- a/operator/watches.yaml
+++ b/operator/watches.yaml
@@ -1,7 +1,7 @@
 ---
 - version: v1alpha1
   group: osb.openshift.io
-  kind: AnsibleServiceBroker
+  kind: AutomationBroker
   playbook: /opt/ansible/playbook.yaml
   finalizer:
     name: finalizer.osb.openshift.io

--- a/operator/watches.yaml
+++ b/operator/watches.yaml
@@ -3,6 +3,7 @@
   group: osb.openshift.io
   kind: AutomationBroker
   playbook: /opt/ansible/playbook.yaml
+  reconcilePeriod: 0
   finalizer:
     name: finalizer.osb.openshift.io
     vars:


### PR DESCRIPTION
#### Describe what this PR does and why we need it:
This PR continues #1166, adding requirements for deployment via OLM. The key differences between this and the previous operator is:
* APB support has been dropped, in favor of a role that is specifically designed for ansible operator.
* The operator's ansible is responsible for provisioning the application's SA and RBAC, rather than delegating this to OLM.
* The public interface has been simplified with the expectation that users will express their configuration via a limited set of values in their CRs. Legacy operating modes such as basic auth and an etcd based dao have been deprecated.
