### PR TITLE
Explicitly set kubeconfig on lookups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,7 @@ TAG              ?= $(shell git rev-parse --short HEAD)
 BROKER_IMAGE     ?= $(REGISTRY)/$(ORG)/origin-ansible-service-broker:${TAG}
 ANSIBLE_ROLE_DIR ?= ansible_role
 APB_DIR          ?= ${ANSIBLE_ROLE_DIR}/apb
-# TODO: Use previous oeprator dir until the new operator rewrite is stable
-#OPERATOR_DIR     ?= operator
-OPERATOR_DIR     ?= ${ANSIBLE_ROLE_DIR}/operator
+OPERATOR_DIR     ?= operator
 OP_BUILD_DIR     ?= ${OPERATOR_DIR}/build
 OP_DEPLOY_DIR    ?= ${OPERATOR_DIR}/deploy
 OP_CRD_DIR       ?= ${OP_DEPLOY_DIR}/crds
@@ -122,11 +120,7 @@ else
 endif
 
 build-operator: ## Build the broker operator image
-ifeq ($(OPERATOR_OLM),true)
-	docker build -f ${OPERATOR_DIR}/Dockerfile --build-arg OLM_MANAGED=true -t ${OPERATOR_IMAGE} ${ANSIBLE_ROLE_DIR}
-else
-	docker build -f ${OPERATOR_DIR}/Dockerfile -t ${OPERATOR_IMAGE} ${ANSIBLE_ROLE_DIR}
-endif
+	docker build -f ${OP_BUILD_DIR}/Dockerfile -t ${OPERATOR_IMAGE} ${OPERATOR_DIR}
 
 $(DEPLOY_OBJECTS) $(DEPLOY_CRDS) $(DEPLOY_OPERATOR) $(DEPLOY_CRS):
 	@${TEMPLATE_CMD} $@ | kubectl create -f - ||:

--- a/operator/roles/ansible-service-broker/handlers/main.yml
+++ b/operator/roles/ansible-service-broker/handlers/main.yml
@@ -7,5 +7,11 @@
     namespace: '{{ broker_namespace }}'
     name: '{{ pod.metadata.name }}'
   vars:
-    pod: '{{ lookup("k8s", kind="Pod", api_version="v1", namespace=broker_namespace, label_selector=("app=" + broker_name)) }}'
+    pod: '{{
+      lookup("k8s",
+        kind="Pod",
+        api_version="v1",
+        kubeconfig=lookup("env", "K8S_AUTH_KUBECONFIG"),
+        namespace=broker_namespace,
+        label_selector=("app=" + broker_name)) }}'
   when: pod

--- a/operator/roles/ansible-service-broker/tasks/main.yml
+++ b/operator/roles/ansible-service-broker/tasks/main.yml
@@ -3,7 +3,7 @@
 # Only want to do this once per execution of role
 - name: Get cluster api_groups
   set_fact:
-    api_groups: "{{ lookup('k8s', cluster_info='api_groups'), kubeconfig=lookup('env', 'K8S_AUTH_KUBECONFIG') }}"
+    api_groups: "{{ lookup('k8s', cluster_info='api_groups', kubeconfig=lookup('env', 'K8S_AUTH_KUBECONFIG')) }}"
 
 # reconciled_generation - the last reconciled spec generation of a given CR
 # generation - the current generation of a given CR
@@ -16,6 +16,7 @@
       lookup('k8s',
       api_version='osb.openshift.io/v1alpha1',
       kind='AutomationBroker',
+      kubeconfig=lookup('env', 'K8S_AUTH_KUBECONFIG'),
       namespace=broker_namespace,
       resource_name=broker_name).metadata.generation
     }}"
@@ -23,6 +24,7 @@
       lookup('k8s',
       api_version='osb.openshift.io/v1alpha1',
       kind='AutomationBroker',
+      kubeconfig=lookup('env', 'K8S_AUTH_KUBECONFIG'),
       namespace=broker_namespace,
       resource_name=broker_name).status.reconciledGeneration | default('')
     }}"
@@ -54,6 +56,7 @@
           lookup('k8s',
           api_version='route.openshift.io/v1',
           kind='Route',
+          kubeconfig=lookup('env', 'K8S_AUTH_KUBECONFIG'),
           namespace=broker_namespace,
           resource_name=dashboard_redirector_route_name).spec.host
         }}"
@@ -97,6 +100,7 @@
       lookup('k8s',
       kind='Pod',
       api_version='v1',
+      kubeconfig=lookup('env', 'K8S_AUTH_KUBECONFIG'),
       namespace=broker_namespace,
       label_selector=('app=' + broker_name))
     }}"

--- a/operator/roles/ansible-service-broker/tasks/validate_absent.yml
+++ b/operator/roles/ansible-service-broker/tasks/validate_absent.yml
@@ -5,6 +5,7 @@
     that: "lookup(
              'k8s',
              kind='BundleInstance',
+             kubeconfig=lookup('env', 'K8S_AUTH_KUBECONFIG'),
              namespace=broker_namespace,
              api_version='automationbroker.io/v1alpha1'
           ) | length == 0"

--- a/operator/roles/ansible-service-broker/templates/broker.servicecatalog.yaml.j2
+++ b/operator/roles/ansible-service-broker/templates/broker.servicecatalog.yaml.j2
@@ -20,6 +20,7 @@ spec:
             'k8s',
             kind='ServiceAccount',
             namespace=broker_namespace,
+            kubeconfig=lookup('env', 'K8S_AUTH_KUBECONFIG'),
             resource_name=broker_name + '-client'
           ).secrets | map(attribute='name') | select('match', broker_name + '-client-token*') | first
         }}
@@ -30,6 +31,7 @@ spec:
       kind='Secret',
       api_version='v1',
       namespace=broker_namespace,
+      kubeconfig=lookup('env', 'K8S_AUTH_KUBECONFIG'),
       resource_name=broker_tls_name
     ) | json_query('data."tls.crt"')
   }}
@@ -40,6 +42,7 @@ spec:
       kind='Secret',
       api_version='v1',
       namespace=broker_namespace,
+      kubeconfig=lookup('env', 'K8S_AUTH_KUBECONFIG'),
       resource_name=broker_name + '-client'
     ) | json_query('data."service-ca.crt"')
   }}
@@ -50,6 +53,7 @@ spec:
       kind='ConfigMap',
       api_version='v1',
       namespace=broker_namespace,
+      kubeconfig=lookup('env', 'K8S_AUTH_KUBECONFIG'),
       resource_name='broker-service-ca-bundle'
     ) | json_query('data."service-ca.crt"') | b64encode
   }}


### PR DESCRIPTION
Works around an issue with the k8s lookup plugin not loading
auth from the environment, causing ssl failures

Also switches over the Makefile to build from the new operator
location