### PR TITLE
Update operator/role, show error message on misconfigured RBAC

### DIFF
--- a/operator/roles/ansible-service-broker/tasks/main.yml
+++ b/operator/roles/ansible-service-broker/tasks/main.yml
@@ -46,7 +46,11 @@
 
 - fail:
     msg: "Operator does not have sufficient permissions to create RBAC policy for the broker, please check the documentation."
-  when: crb_status.status is defined and crb_status.status == 403
+  when: (not crb_status.failed) and crb_status.status is defined and crb_status != 403
+
+- fail:
+    msg: "Unable to create broker-admin clusterrolebinding"
+  when: crb_status.failed
 
 - name: Set up for TLS in k8s
   import_tasks: tls_k8s.yml

--- a/operator/roles/ansible-service-broker/tasks/main.yml
+++ b/operator/roles/ansible-service-broker/tasks/main.yml
@@ -37,6 +37,17 @@
 - name:  Validate pre-requisites for {{ state }}
   import_tasks: "validate_{{ state }}.yml"
 
+- name: Set broker admin cluster rolebinding state={{ state }}
+  k8s:
+    state: "{{ state }}"
+    definition: "{{ lookup('template', 'broker-admin.clusterrolebinding.yaml.j2') | from_yaml }}"
+  register: crb_status
+  ignore_errors: yes
+
+- fail:
+    msg: "Operator does not have sufficient permissions to create RBAC policy for the broker, please check the documentation."
+  when: crb_status.status is defined and crb_status.status == 403
+
 - name: Set up for TLS in k8s
   import_tasks: tls_k8s.yml
   when: "'route.openshift.io' not in api_groups"
@@ -74,7 +85,6 @@
     definition: "{{ lookup('template', item.value) | from_yaml }}"
   loop:
     - value: broker.serviceaccount.yaml.j2
-    - value: broker-admin.clusterrolebinding.yaml.j2
     - value: broker.clusterrole.yaml.j2
     - value: broker.clusterrolebinding.yaml.j2
     - value: broker.service.yaml.j2


### PR DESCRIPTION
#### Describe what this PR does and why we need it:
The operator needs admin permissions. When the operator is not run with admin permissions, the logs on operator pod should show a proper error message
