### PR TITLE
bug 1684420: fixing name in the bundlebinding CRD

### DIFF
--- a/operator/deploy/olm-catalog/0.2.0/bundlebindings.crd.yaml
+++ b/operator/deploy/olm-catalog/0.2.0/bundlebindings.crd.yaml
@@ -8,5 +8,5 @@ spec:
   scope: Namespaced
   names:
     plural: bundlebindings
-    singular: bundleebinding
+    singular: bundlebinding
     kind: BundleBinding


### PR DESCRIPTION
#### Describe what this PR does and why we need it:
Fixes typo in the bundlebinding singular name