### PR TITLE
adding OLM testing file

### DIFF
--- a/operator/build/olm-testing.Dockerfile
+++ b/operator/build/olm-testing.Dockerfile
@@ -1,0 +1,16 @@
+FROM alpine as munger
+
+ARG operator_name
+ARG broker_name
+COPY deploy/olm-catalog manifests
+RUN sed "s,docker.io/automationbroker/automation-broker-operator:v4.0,$operator_name," -i manifests/0.2.0/automationbrokeroperator.v0.2.0.clusterserviceversion.yaml
+RUN sed "s,docker.io/ansibleplaybookbundle/origin-ansible-service-broker:v4.0,$broker_name," -i manifests/0.2.0/automationbrokeroperator.v0.2.0.clusterserviceversion.yaml
+
+FROM quay.io/openshift/origin-operator-registry:latest
+
+COPY --from=munger manifests manifests
+RUN initializer
+
+ENTRYPOINT ["registry-server"]
+CMD ["-t", "/tmp/termination-log.txt"]
+


### PR DESCRIPTION
#### Describe what this PR does and why we need it:
This adds a docker file, that will allow you to use the downstream CSV for an OLM install while changing the images that it creates. You will need to create a new container image and deploy this into the cluster. 


To use this Dockerfile:

1. create a new image from the `operator` directory. Exmaple:
`$ docker build -t quay.io/shawn_hurley/testing-downstream-catalog-source -f build/olm-testing.Dockerfile --build-arg operator_name=quay.io/shawn_hurley/abo:v4.0 --build-arg broker_name=quay.io/shawn_hurley/ab:v4.0 .`

2. Run this image as a catalog source by creating this resource:
```
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: abo-registry
  namespace: openshift-operator-lifecycle-manager
spec:
  sourceType: grpc
  image: quay.io/shawn_hurley/testing-downstream-catalog-source
```

Then follow the same UI steps to install the automation-broker-operator and automation-broker which should use the images that you changed.

**NOTE**: This is only for testing.
