### PR TITLE
Bug 1692281 - operator should deploy a service-monitor

### DIFF
--- a/operator/roles/ansible-service-broker/defaults/main.yml
+++ b/operator/roles/ansible-service-broker/defaults/main.yml
@@ -67,6 +67,8 @@ broker_deployment_name: asb
 broker_service_name: asb
 broker_route_name: asb-1338
 dashboard_redirector_route_name: dr-1337
+broker_service_monitor_name: ansible-service-broker
+broker_service_monitor_namespace: openshift-monitoring
 
 # Used to set namespaced broker (ServiceBroker)
 broker_kind: ClusterServiceBroker

--- a/operator/roles/ansible-service-broker/tasks/main.yml
+++ b/operator/roles/ansible-service-broker/tasks/main.yml
@@ -103,6 +103,12 @@
     - value: broker-user-auth.clusterrole.yaml.j2
     - value: broker.servicecatalog.yaml.j2
       condition: "{{ 'servicecatalog.k8s.io' in api_groups }}"
+    - value: broker.service-monitor.yaml.j2
+      condition: "{{ 'monitoring.coreos.com' in api_groups }}"
+    - value: prometheus.role.yaml.j2
+      condition: "{{ 'monitoring.coreos.com' in api_groups }}"
+    - value: prometheus.role_binding.yaml.j2
+      condition: "{{ 'monitoring.coreos.com' in api_groups }}"
 
 - name: Redeploy the broker's pod if pending config changes
   k8s:

--- a/operator/roles/ansible-service-broker/templates/broker.service-monitor.yaml.j2
+++ b/operator/roles/ansible-service-broker/templates/broker.service-monitor.yaml.j2
@@ -1,0 +1,21 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ broker_service_monitor_name }}
+  namespace: {{ broker_service_monitor_namespace }}
+spec:
+  endpoints:
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    interval: 30s
+    port: port-1338
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: True
+  namespaceSelector:
+    matchNames:
+    - {{ broker_namespace }}
+  selector:
+    matchLabels:
+      app: {{ broker_name }}
+      service: {{ broker_service_name }}

--- a/operator/roles/ansible-service-broker/templates/prometheus.role.yaml.j2
+++ b/operator/roles/ansible-service-broker/templates/prometheus.role.yaml.j2
@@ -1,0 +1,17 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-k8s
+  namespace: {{ broker_namespace }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch

--- a/operator/roles/ansible-service-broker/templates/prometheus.role_binding.yaml.j2
+++ b/operator/roles/ansible-service-broker/templates/prometheus.role_binding.yaml.j2
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-k8s
+  namespace:  {{ broker_namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-k8s
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: {{ broker_service_monitor_namespace }}


### PR DESCRIPTION
#### Describe what this PR does and why we need it:
This makes the Ansible Service Broker Operator deploy a ServiceMonitor for the Ansible Service Broker, allowing it to expose metrics to prometheus.

https://bugzilla.redhat.com/show_bug.cgi?id=1692281