### PR TITLE
Adding ability to deploy ASB with OLM and csv to test.

### DIFF
--- a/operator/deploy/olm-catalog/openshift-ansible-service-broker-manifests/4.1.0/openshiftansibleservicebroker.v4.1.0.clusterserviceversion.yaml
+++ b/operator/deploy/olm-catalog/openshift-ansible-service-broker-manifests/4.1.0/openshiftansibleservicebroker.v4.1.0.clusterserviceversion.yaml
@@ -2,7 +2,7 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
-  name: openshiftansibleservicebroker.v1.0.0
+  name: openshiftansibleservicebroker.v4.1.0
   namespace: placeholder
   annotations:
     alm-examples: '[{"apiVersion":"osb.openshift.io/v1alpha1", "kind":"AutomationBroker", "metadata":{"name":"ansible-service-broker","namespace":"ansible-service-broker"}, "spec":{"createBrokerNamespace":"false","waitForBroker":"false", "registries": [{"type": "rhcc", "name": "rhcc", "url": "https://registry.redhat.io", "white_list": [".*-apb$"], "auth_type": "secret", "auth_name": "asb-registry-auth"}]}}]'
@@ -18,7 +18,7 @@ spec:
     Check out the [Keynote Demo from Red Hat Summit 2017](https://youtu.be/8MCbJmZQM9c?list=PLEGSLwUsxfEh4TE2GDU4oygCB-tmShkSn&t=4732)
 
   keywords: ['ansible', 'automation', 'broker', 'open service broker']
-  version: v4.1.0
+  version: 4.1.0
   maturity: stable
   maintainers:
   - name: Red Hat, Inc.
@@ -87,6 +87,12 @@ spec:
           - apps.openshift.io
           resources:
           - deploymentconfigs
+          verbs:
+          - "*"
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
           verbs:
           - "*"
       clusterPermissions:

--- a/operator/molecule/cluster-olm/e2e-olm.sh
+++ b/operator/molecule/cluster-olm/e2e-olm.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+DIR=$(cd $(dirname "$0")/../../deploy/olm-catalog/openshift-ansible-service-broker-manifests && pwd)
+VERSION=${VERSION:-4.1.0}
+
+NAME=${NAME:-openshift-ansible-broker-operator}
+NAMEDISPLAY=${NAME:-"OpenShift Ansible Broker Operator"}
+
+indent() {
+  INDENT="      "
+  sed "s/^/$INDENT/" | sed "s/^${INDENT}\($1\)/${INDENT:0:-2}- \1/"
+}
+
+CRD=$(cat $(ls $DIR/$VERSION/*crd.yaml) | grep -v -- "---" | indent apiVersion)
+CSV=$(cat $(ls $DIR/$VERSION/*version.yaml) | grep -v -- "---" |  indent apiVersion)
+PKG=$(cat $(ls $DIR/*package.yaml) | indent packageName)
+
+cat <<EOF | sed 's/^  *$//'
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: $NAME
+data:
+  customResourceDefinitions: |-
+$CRD
+  clusterServiceVersions: |-
+$CSV
+  packages: |-
+$PKG
+EOF

--- a/operator/molecule/cluster-olm/molecule.yml
+++ b/operator/molecule/cluster-olm/molecule.yml
@@ -1,0 +1,45 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: delegated
+  options:
+    managed: False
+    ansible_connection_options: {}
+lint:
+  name: yamllint
+  enabled: False
+platforms:
+- name: cluster
+  groups:
+  - k8s
+provisioner:
+  name: ansible
+  inventory:
+    group_vars:
+      all:
+        namespace: ${TEST_NAMESPACE:-osdk-test}
+        csv_version: ${CSV_VERSION:-4.1.0}
+  lint:
+    name: ansible-lint
+    enabled: False
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/roles
+    K8S_AUTH_KUBECONFIG: ${KUBECONFIG}
+scenario:
+  name: cluster-olm
+  test_sequence:
+    - lint
+    - destroy
+    - dependency
+    - syntax
+    - create
+    - prepare
+    - converge
+    - side_effect
+    - verify
+    - destroy
+verifier:
+  name: testinfra
+  lint:
+    name: flake8

--- a/operator/molecule/cluster-olm/playbook.yml
+++ b/operator/molecule/cluster-olm/playbook.yml
@@ -1,0 +1,57 @@
+---
+
+- name: Converge
+  hosts: localhost
+  connection: local
+  vars:
+    ansible_python_interpreter: '{{ ansible_playbook_python }}'
+    deploy_dir: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/deploy"
+    custom_resource: "{{ lookup('file', '/'.join([deploy_dir, 'crds/osb_v1alpha1_automationbroker_cr.yaml'])) | from_yaml }}"
+  tasks:
+  - block:
+    - name: Create the osb.openshift.io/v1alpha1.AnsibleServiceBroker
+      k8s:
+        state: present
+        namespace: '{{ namespace }}'
+        definition: "{{ custom_resource }}"
+
+    - name: Wait 5m for reconciliation to run
+      k8s_facts:
+        api_version: '{{ custom_resource.apiVersion }}'
+        kind: '{{ custom_resource.kind }}'
+        namespace: '{{ namespace }}'
+        name: '{{ custom_resource.metadata.name }}'
+      register: cr
+      until:
+      - "'Successful' in (cr | json_query('resources[].status.conditions[].reason'))"
+      delay: 10
+      retries: 30
+    rescue:
+    - name: debug cr
+      ignore_errors: yes
+      failed_when: false
+      debug:
+        var: debug_cr
+      vars:
+        debug_cr: '{{ lookup("k8s",
+          kind=custom_resource.kind,
+          api_version=custom_resource.apiVersion,
+          namespace=namespace,
+          resource_name=custom_resource.metadata.name
+        )}}'
+    - name: get operator logs
+      ignore_errors: yes
+      failed_when: false
+      command: kubectl logs deployment/{{ definition.metadata.name }} -n {{ namespace }}
+      environment:
+        KUBECONFIG: '{{ lookup("env", "KUBECONFIG") }}'
+      vars:
+        definition: "{{ lookup('template', '/'.join([deploy_dir, 'operator.yaml'])) | from_yaml }}"
+      register: log
+
+    - debug: var=log.stdout_lines
+
+    - fail:
+        msg: "Failed on action: converge"
+
+- import_playbook: "{{ playbook_dir }}/../test-local/verify.yml"

--- a/operator/molecule/cluster-olm/prepare.yml
+++ b/operator/molecule/cluster-olm/prepare.yml
@@ -1,0 +1,141 @@
+---
+
+- name: Prepare operator resources
+  hosts: localhost
+  connection: local
+  vars:
+    ansible_python_interpreter: '{{ ansible_playbook_python }}'
+    deploy_dir: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/deploy"
+  tasks:
+  # need to pull all the info together into a config map
+  - name: Ensure specified namespace is present
+    k8s:
+      api_version: v1
+      kind: Namespace
+      name: '{{ namespace }}'
+      
+  - name: Set operator Image from Format
+    shell: "echo $IMAGE_FORMAT | envsubst '${component}'"
+    environment:
+      component: ansible-service-broker-operator
+    register: operator_image_raw
+    
+  - name: Set operand Image from Format
+    shell: "echo $IMAGE_FORMAT | envsubst '${component}'"
+    environment:
+      component: ansible-service-broker
+    register: operand_image_raw
+  
+  - name:  Add operator image to csv
+    lineinfile:
+      path: "{{ playbook_dir }}/../../deploy/olm-catalog/openshift-ansible-service-broker-manifests/4.1.0/openshiftansibleservicebroker.v{{ csv_version }}.clusterserviceversion.yaml"
+      regexp: "image: registry.access.redhat.com/openshift/ose-ansible-service-broker-operator:v4.0.0"
+      line: "                image: {{ operator_image_raw.stdout }}"
+ 
+  - name:  Add operand image to csv
+    lineinfile:
+      path: "{{ playbook_dir }}/../../deploy/olm-catalog/openshift-ansible-service-broker-manifests/4.1.0/openshiftansibleservicebroker.v{{ csv_version }}.clusterserviceversion.yaml"
+      regexp: "registry.access.redhat.com/openshift/ose-ansible-service-broker:v4.0.0"
+      line: "                  value: {{ operand_image_raw.stdout }}"
+ 
+ 
+  - name: Create catalog source config map
+    shell: "VERSION={{ csv_version }} {{ playbook_dir}}/e2e-olm.sh"
+    register: olm_cf_cs
+ 
+  - debug:
+      var: cm
+    vars:
+      cm: "{{ olm_cf_cs.stdout | from_yaml  }}"
+ 
+  - name: Create config map
+    k8s:
+      namespace: "{{ namespace }}"
+      definition: "{{ olm_cf_cs.stdout | from_yaml }}"
+ 
+  - name: Create catalog source
+    k8s:
+      api_version: operators.coreos.com/v1alpha1
+      definition:
+        kind: CatalogSource
+        metadata:
+          name: openshift-ansible-broker-operator
+          namespace: "{{ namespace }}"
+        spec:
+          name: openshift-ansible-broker-operator
+          sourceType: internal
+          configMap: openshift-ansible-broker-operator
+          displayName: openshift-ansible-broker-operator
+          publisher: Operator Framework
+  
+  - name: Create operator-group
+    k8s:
+      definition:
+        kind: OperatorGroup
+        apiVersion: operators.coreos.com/v1
+        metadata:
+          name: openshift-ansible-broker-operator
+          namespace: "{{ namespace }}"
+        spec:
+          targetNamespaces:
+          - "{{ namespace }}"
+ 
+  - name: Create subscription
+    k8s:
+      definition:
+        apiVersion: operators.coreos.com/v1alpha1
+        kind: Subscription
+        metadata:
+          name: openshiftansibleservicebroker
+          namespace: "{{ namespace }}"
+        spec:
+          source: openshift-ansible-broker-operator
+          sourceNamespace: "{{ namespace }}"
+          name: openshiftansibleservicebroker
+          startingCSV: openshiftansibleservicebroker.v4.1.0
+          channel: stable
+  
+  - name: Create Cluster Role Binding for operator svc account
+    k8s:
+      definition:
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRoleBinding
+        metadata:
+          name: ansible-service-broker-crb
+        roleRef:
+          apiGroup: rbac.authorization.k8s.io 
+          kind: ClusterRole
+          name: admin
+        subjects:
+        - kind: ServiceAccount
+          name: openshift-ansible-service-broker-operator
+          namespace: "{{ namespace }}"
+
+  - name: Create ServiceCatalog ApiServer and ControllerManager
+    k8s:
+      definition:
+        apiVersion: operator.openshift.io/v1
+        kind: '{{ item }}'
+        metadata:
+          name: cluster
+        spec:
+          logLevel: Normal
+          managementState: Managed
+    with_items:
+    - ServiceCatalogAPIServer
+    - ServiceCatalogControllerManager
+  
+  - name: Wait a couple of seconds because of initial conditions on service catalog
+    pause:
+      seconds: 10
+
+  - name: Wait 5m for Service Catalog Controller Manager to be complete
+    k8s_facts:
+      api_version: "operator.openshift.io/v1"
+      kind: "ServiceCatalogControllerManager"
+      name: "cluster"
+    register: svccat_cm
+    until:
+    - "[ \"True\" ] in (svccat_cm | json_query('resources[].status.conditions[?type==`Available`].status'))"
+    delay: 10
+    retries: 30

--- a/operator/molecule/cluster/prepare.yml
+++ b/operator/molecule/cluster/prepare.yml
@@ -52,11 +52,14 @@
     - ServiceCatalogAPIServer
     - ServiceCatalogControllerManager
 
+  - name: Wait a couple of seconds because of initial conditions on service catalog
+    pause:
+      seconds: 10
+
   - name: Wait 5m for Service Catalog Controller Manager to be complete
     k8s_facts:
       api_version: "operator.openshift.io/v1"
       kind: "ServiceCatalogControllerManager"
-      namespace: ""
       name: "cluster"
     register: svccat_cm
     until:


### PR DESCRIPTION
#### Describe what this PR does and why we need it:
Adding ability to CI test installation of the operator with OLM
#### Changes proposed in this pull request
 - Create CSV with IMAGE_FORMAT
 - Create olm resources to deploy the broker in the correct namespace. 
 -

**note**: Want to move from template to lineinfile module so we only need a single CSV. 
