### PR TITLE
Bug 1692281 - Adding service monitor permissions if monitoring is installed

### DIFF
--- a/operator/roles/ansible-service-broker/tasks/main.yml
+++ b/operator/roles/ansible-service-broker/tasks/main.yml
@@ -105,6 +105,10 @@
       condition: "{{ 'servicecatalog.k8s.io' in api_groups }}"
     - value: broker.service-monitor.yaml.j2
       condition: "{{ service_monitoring and ('monitoring.coreos.com' in api_groups) }}"
+    - value: broker.monitor-role.yaml.j2
+      condition: "{{ service_monitoring and ('monitoring.coreos.com' in api_groups) }}"
+    - value: broker.monitor-rolebinding.yaml.j2
+      condition: "{{ service_monitoring and ('monitoring.coreos.com' in api_groups) }}"
 
 - name: Redeploy the broker's pod if pending config changes
   k8s:

--- a/operator/roles/ansible-service-broker/templates/broker.monitor-role.yaml.j2
+++ b/operator/roles/ansible-service-broker/templates/broker.monitor-role.yaml.j2
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ broker_name }}-prom-k8s
+  namespace: {{ broker_namespace }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch

--- a/operator/roles/ansible-service-broker/templates/broker.monitor-rolebinding.yaml.j2
+++ b/operator/roles/ansible-service-broker/templates/broker.monitor-rolebinding.yaml.j2
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ broker_name }}-prom-k8s
+  namespace: {{ broker_namespace }}
+roleRef:
+  name: {{ broker_name }}-prom-k8s
+  kind: Role
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring


### PR DESCRIPTION
#### Describe what this PR does and why we need it:
Adding permissions for the service monitor that is created so that it can be used without intervention.
#### Changes proposed in this pull request
 - add service monitor's RBAC permissions

