### PR TITLE
Bug 1721161: cherry-pick art.yaml to 4.1 release

### DIFF
--- a/operator/deploy/olm-catalog/openshift-ansible-service-broker-manifests/art.yaml
+++ b/operator/deploy/olm-catalog/openshift-ansible-service-broker-manifests/art.yaml
@@ -7,6 +7,8 @@ updates:
     # replace entire version line, otherwise would replace 4.1.0 anywhere
     - search: "version: 4.1.2"
       replace: "version: {FULL_VER}"
+    - search: 'olm.skipRange: ">=4.1.0 <4.1.2"'
+      replace: 'olm.skipRange: ">=4.1.0 <{FULL_VER}"'
   - file: "package.yaml"
     update_list:
     - search: "currentCSV: openshiftansibleservicebroker.v{MAJOR}.{MINOR}.2"

--- a/operator/deploy/olm-catalog/openshift-ansible-service-broker-manifests/art.yaml
+++ b/operator/deploy/olm-catalog/openshift-ansible-service-broker-manifests/art.yaml
@@ -1,0 +1,13 @@
+updates:
+  - file: "{MAJOR}.{MINOR}/openshiftansibleservicebroker.v{MAJOR}.{MINOR}.2.clusterserviceversion.yaml" # relative to this file
+    update_list:
+    # replace metadata.name value
+    - search: "openshiftansibleservicebroker.v{MAJOR}.{MINOR}.2"
+      replace: "openshiftansibleservicebroker.{FULL_VER}"
+    # replace entire version line, otherwise would replace 4.1.0 anywhere
+    - search: "version: 4.1.2"
+      replace: "version: {FULL_VER}"
+  - file: "package.yaml"
+    update_list:
+    - search: "currentCSV: openshiftansibleservicebroker.v{MAJOR}.{MINOR}.2"
+      replace: "currentCSV: openshiftansibleservicebroker.{FULL_VER}"


### PR DESCRIPTION
#### Describe what this PR does and why we need it:
Adding art.yaml file to allow for art to update the csv and package files on builds so that everything is built with the correct versions in the correct places.