### PR TITLE
Bug 1721161: Fix typo art.yaml

### DIFF
--- a/operator/deploy/olm-catalog/openshift-ansible-service-broker-manifests/art.yaml
+++ b/operator/deploy/olm-catalog/openshift-ansible-service-broker-manifests/art.yaml
@@ -1,5 +1,5 @@
 updates:
-  - file: "{MAJOR}.{MINOR}/openshiftansibleservicebroker.v{MAJOR}.{MINOR}.2.clusterserviceversion.yaml" # relative to this file
+  - file: "{MAJOR}.{MINOR}/openshiftansibleservicebroker.v{MAJOR}.{MINOR}.0.clusterserviceversion.yaml" # relative to this file
     update_list:
     # replace metadata.name value
     - search: "openshiftansibleservicebroker.v{MAJOR}.{MINOR}.2"


### PR DESCRIPTION
#### Describe what this PR does and why we need it:
Typo in art.yaml. The file name was not updated to a minor version and therefore need to change art.yaml to reflect the actual name of the file. 


