### PR TITLE
Pass *_PROXY envvars on to ASB deployment

### DIFF
--- a/operator/deploy/olm-catalog/openshift-ansible-service-broker-manifests/4.2/openshiftansibleservicebroker.v4.2.0.clusterserviceversion.yaml
+++ b/operator/deploy/olm-catalog/openshift-ansible-service-broker-manifests/4.2/openshiftansibleservicebroker.v4.2.0.clusterserviceversion.yaml
@@ -69,12 +69,15 @@ spec:
           - configmaps
           - secrets
           - services
+          - services/finalizers
           verbs:
           - "*"
         - apiGroups:
           - apps
           resources:
           - deployments
+          - deployments/finalizers
+          - replicasets
           verbs:
           - "*"
         - apiGroups:

--- a/operator/roles/ansible-service-broker/templates/broker.deployment.yaml.j2
+++ b/operator/roles/ansible-service-broker/templates/broker.deployment.yaml.j2
@@ -59,6 +59,12 @@ spec:
           env:
             - name: BROKER_CONFIG
               value: /etc/{{ broker_name }}/config.yaml
+{% for proxy_envvar in ["HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"] %}
+{% if lookup("env", proxy_envvar) != None %}
+            - name: {{ proxy_envvar }}
+              value: '{{ lookup("env", proxy_envvar) }}'
+{% endif %}
+{% endfor %}
           resources: {}
           terminationMessagePath: /tmp/termination-log
           readinessProbe:


### PR DESCRIPTION
#### Describe what this PR does and why we need it:
OLM will be setting these variables on operator deployments and we need to pass them through to deployments created by the operator