### PR TITLE
Bug 1727996 - fix pagination url, bump bundle-lib

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -56,7 +56,7 @@
   revision = "bf1c2b52e55d67b4c3a917daaadee9b86a6c66e0"
 
 [[projects]]
-  digest = "1:c24ca1bad344f6b42ff2e0c987f67d76f197f16865a2db62ad407b4bd0b74b87"
+  digest = "1:01e03dc745495965512c97e313dcd8bd9268bec99a6c16bae2a885f620ae09dc"
   name = "github.com/automationbroker/bundle-lib"
   packages = [
     "authorization",
@@ -71,8 +71,8 @@
     "runtime",
   ]
   pruneopts = "NUT"
-  revision = "39b53b83c0acb485daf894f878710337449739f7"
-  version = "0.2.17"
+  revision = "488d938f78590f4b5fbeb7c93078d26468b5c876"
+  version = "0.2.19"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -37,7 +37,7 @@
   version = "~1.3.0"
 
 [[constraint]]
-  version = "~0.2.17"
+  version = "~0.2.19"
   name = "github.com/automationbroker/bundle-lib"
 
 [[constraint]]

--- a/vendor/github.com/automationbroker/bundle-lib/clients/kubernetes.go
+++ b/vendor/github.com/automationbroker/bundle-lib/clients/kubernetes.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 
 	log "github.com/sirupsen/logrus"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -209,8 +210,12 @@ func newKubernetes() (*KubernetesClient, error) {
 	// library
 	clientConfig, err := rest.InClusterConfig()
 	if err != nil {
+		config := os.Getenv("KUBECONFIG")
+		if config == "" {
+			config = homedir.HomeDir() + "/.kube/config"
+		}
 		log.Debug("Checking for a local Cluster Config")
-		clientConfig, err = createClientConfigFromFile(homedir.HomeDir() + "/.kube/config")
+		clientConfig, err = createClientConfigFromFile(config)
 		if err != nil {
 			log.Error("Failed to create LocalClientSet")
 			return nil, err

--- a/vendor/github.com/automationbroker/bundle-lib/registries/adapters/apiv2_adapter.go
+++ b/vendor/github.com/automationbroker/bundle-lib/registries/adapters/apiv2_adapter.go
@@ -230,6 +230,7 @@ func (r APIV2Adapter) getNextImages(url string) (*apiV2CatalogResponse, string, 
 	}
 	log.Debug("Properly unmarshalled image response")
 
+	log.Debugf("link header [%s]", resp.Header.Get("Link"))
 	return &imageList, resp.Header.Get("Link"), nil
 }
 
@@ -240,6 +241,9 @@ func (r APIV2Adapter) getNextImageURL(link string) string {
 		return ""
 	}
 
+	// rudimentary Link header parser
+	// refer to the full RFC5988 spec if you need more functionality
+	// https://tools.ietf.org/html/rfc5988
 	res := strings.Split(link, ";")
 	if len(res[0]) == 0 {
 		log.Errorf("Invalid Link value")

--- a/vendor/github.com/automationbroker/bundle-lib/registries/adapters/oauth/client.go
+++ b/vendor/github.com/automationbroker/bundle-lib/registries/adapters/oauth/client.go
@@ -81,7 +81,16 @@ func (c *Client) NewRequest(path string) (*http.Request, error) {
 	if err != nil {
 		return nil, err
 	}
-	req.URL.Path = path
+
+	// path might be a fully qualified URL and we only want the path
+	// and query bits
+	pathAsURL, err := url.Parse(path)
+	if err != nil {
+		return nil, err
+	}
+
+	req.URL.Path = pathAsURL.Path
+	req.URL.RawQuery = pathAsURL.Query().Encode()
 	if c.token != "" {
 		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.token))
 	}


### PR DESCRIPTION
When using APIV2 registries, if we hit the pagination sequence, the registry code would fail to get the next page and thus not return any images to the broker. If the set of images on the registry is less than the page size, things worked or if the images were listed individually in the configuration.

Fixes: BZ 1727996
