### PR TITLE
log was calling function without parens

### DIFF
--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -230,7 +230,7 @@ func (a AnsibleBroker) Bootstrap() (*BootstrapResponse, error) {
 		}
 		if err != nil {
 			log.Warningf("registry: %v was unable to complete bootstrap - %v",
-				r.RegistryName, err)
+				r.RegistryName(), err)
 			registryErrors = append(registryErrors, err)
 		}
 		imageCount += count


### PR DESCRIPTION
Found this while fixing another branch.