### PR TITLE
Add logic to inject the trusted CA bundle

### DIFF
--- a/operator/roles/ansible-service-broker/tasks/main.yml
+++ b/operator/roles/ansible-service-broker/tasks/main.yml
@@ -76,6 +76,8 @@
           resource_name=dashboard_redirector_route_name).spec.host
         }}"
 
+- import_tasks: trusted_ca_bundle.yml
+
 - name: ConfigMap for Broker
   k8s:
     state: "{{ state }}"
@@ -130,6 +132,15 @@
     - pending_config_changes
     - reconciled_generation != ''
     - pod
+
+- name: Delete the old trusted-ca-bundle if it exists
+  k8s:
+    state: absent
+    api_version: v1
+    kind: ConfigMap
+    namespace: '{{ broker_namespace }}'
+    name: '{{ old_asb_ca_bundle_cm_name }}'
+  when: old_asb_ca_bundle_cm_name is defined
 
 - name: Write generation to status as reconciled generation
   when: pending_config_changes

--- a/operator/roles/ansible-service-broker/tasks/trusted_ca_bundle.yml
+++ b/operator/roles/ansible-service-broker/tasks/trusted_ca_bundle.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: check if trusted CA configmap exists
+- name: Check if trusted CA configmap exists
   k8s_facts:
     api_version: v1
     kind: ConfigMap

--- a/operator/roles/ansible-service-broker/tasks/trusted_ca_bundle.yml
+++ b/operator/roles/ansible-service-broker/tasks/trusted_ca_bundle.yml
@@ -1,0 +1,69 @@
+---
+
+- name: check if trusted CA configmap exists
+  k8s_facts:
+    api_version: v1
+    kind: ConfigMap
+    namespace: "{{ broker_namespace }}"
+    name: asb-trusted-ca
+  register: tcab_ca_bundle_cm
+
+- name: Create the trusted CA configmap
+  k8s:
+    state: '{{ state }}'
+    definition:
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: asb-trusted-ca
+        namespace: '{{ broker_namespace }}'
+        labels:
+          config.openshift.io/inject-trusted-cabundle: "true"
+      data:
+        ca-bundle.crt:
+  when: not tcab_ca_bundle_cm.resources
+
+- name: Get trusted CA configmap
+  k8s_facts:
+    api_version: v1
+    kind: ConfigMap
+    namespace: "{{broker_namespace }}"
+    name: asb-trusted-ca
+  register: tcab_ca_bundle_cm
+
+# Append hash will append the hash of the ConfigMap to metadata.name, forcing
+# dependent deployments to roll out if the ConfigMap has changed
+- name: Create the duplicate bundle CM to be mounted
+  k8s:
+    state: '{{ state }}'
+    append_hash: yes
+    definition:
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: asb-trusted-ca
+        namespace: '{{ broker_namespace }}'
+      data: '{{ tcab_ca_bundle_cm.resources.0.data }}'
+  register: tcab_ca_bundle_update_task
+
+- name: Store ca bundle configmap name
+  set_fact:
+    asb_ca_bundle_cm_name: '{{ tcab_ca_bundle_update_task.result.metadata.name }}'
+
+- name: Get the broker deployment
+  k8s_facts:
+    api_version: '{{ "apps.openshift.io/v1" if "apps.openshift.io" in api_groups else "apps/v1" }}'
+    kind: '{{ "DeploymentConfig" if "apps.openshift.io" in api_groups else "Deployment" }}'
+    namespace: '{{ broker_namespace }}'
+    name: '{{ broker_deployment_name }}'
+  register: tcab_asb_deployment
+
+- name: Store the name of the old ca bundle configmap
+  set_fact:
+    old_asb_ca_bundle_cm_name: '{{ cm_block.configMap.name }}'
+  when: 
+  - tcab_ca_bundle_update_task is changed
+  - tcab_asb_deployment.resources
+  vars:
+    cm_block: '{{ tcab_asb_deployment.resources.0.spec.template.spec.volumes | selectattr("name", "equalto", "trusted-ca-bundle") }}'
+  ignore_errors: yes

--- a/operator/roles/ansible-service-broker/templates/broker.deployment.yaml.j2
+++ b/operator/roles/ansible-service-broker/templates/broker.deployment.yaml.j2
@@ -86,6 +86,8 @@ spec:
               mountPath: /etc/{{ broker_name }}
             - name: broker-tls
               mountPath: /etc/tls/private
+            - name: trusted-ca-bundle
+              mountPath: /etc/pki/ca-trust/extracted/pem/
       volumes:
         - name: config-volume
           configMap:
@@ -96,3 +98,9 @@ spec:
         - name: broker-tls
           secret:
             secretName: {{ broker_tls_name }}
+        - name: trusted-ca-bundle
+          configMap:
+            name: {{ asb_ca_bundle_cm_name }}
+            items:
+            - key: ca-bundle.crt
+              path: "tls-ca-bundle.pem"


### PR DESCRIPTION
#### Describe what this PR does and why we need it:
Properly injects the trusted CA bundle into the ASB deployment managed by the operator. It's a requirement to support this.