### PR TITLE
Bug 1763005 - add registry-proxy support, bump bundle-lib

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -56,7 +56,7 @@
   revision = "bf1c2b52e55d67b4c3a917daaadee9b86a6c66e0"
 
 [[projects]]
-  digest = "1:01e03dc745495965512c97e313dcd8bd9268bec99a6c16bae2a885f620ae09dc"
+  digest = "1:1aac1ffec5bf049fdd3f37af6761e8a9b5ca6de4065faa0a5da875ef7578c02c"
   name = "github.com/automationbroker/bundle-lib"
   packages = [
     "authorization",
@@ -71,8 +71,8 @@
     "runtime",
   ]
   pruneopts = "NUT"
-  revision = "488d938f78590f4b5fbeb7c93078d26468b5c876"
-  version = "0.2.19"
+  revision = "793517accc64eba83c243aad99f9a6740e27de0f"
+  version = "0.2.20"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -37,7 +37,7 @@
   version = "~1.3.0"
 
 [[constraint]]
-  version = "~0.2.19"
+  version = "~0.2.20"
   name = "github.com/automationbroker/bundle-lib"
 
 [[constraint]]

--- a/vendor/github.com/automationbroker/bundle-lib/registries/registry.go
+++ b/vendor/github.com/automationbroker/bundle-lib/registries/registry.go
@@ -235,6 +235,8 @@ func NewCustomRegistry(configuration Config, adapter adapters.Adapter, asbNamesp
 			adapter = adapters.NewQuayAdapter(c)
 		case "galaxy":
 			adapter = &adapters.GalaxyAdapter{Config: c}
+		case "registry_proxy":
+			adapter, err = adapters.NewRegistryProxyAdapter(c)
 		default:
 			log.Errorf("Unknown registry type - %s", configuration.Type)
 			return Registry{}, errors.New("Unknown registry type")


### PR DESCRIPTION
The registry-proxy GET /v2 returns a WWW-Authenticate header with only a
realm: .../v2/auth the APIV2Adapter simply gets a token for /v2/auth
which is not valid for registry-proxy which seems to require a scoped
token.

In this PR, we added a new RegistryProxyAdapter that now requires the
apbs to be listed in the configuration. For each of those images listed,
we will add them to the scope when we ask for the token. This allows the
broker access to fetch the apb images.

Also, added a test to ensure registry proxy errors when no images are defined
and added a unit test for getTokenWithScope.