### PR TITLE
Update make deploy to use openshift-asbo to match downstream

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ AUTO_ESCALATE    ?= false
 NAMESPACE        ?= openshift-ansible-service-broker
 TEMPLATE_CMD      = sed 's|osb\.openshift\.io\/testing-operator:testing|${OPERATOR_IMAGE}|g; s|{{ namespace }}|${NAMESPACE}|g; s|IfNotPresent|Always|'
 DEPLOY_OBJECTS    = ${OP_DEPLOY_DIR}/namespace.yaml ${OP_DEPLOY_DIR}/service_account.yaml ${OP_DEPLOY_DIR}/role.yaml ${OP_DEPLOY_DIR}/role_binding.yaml
+
 DEPLOY_OPERATOR   = ${OP_DEPLOY_DIR}/operator.yaml
 DEPLOY_CRDS       = ${OP_CRD_DIR}/osb_v1_automationbroker_crd.yaml ${OP_CRD_DIR}/bundlebindings.crd.yaml ${OP_CRD_DIR}/bundle.crd.yaml ${OP_CRD_DIR}/bundleinstances.crd.yaml
 DEPLOY_CRS        = ${OP_CRD_DIR}/osb_v1_automationbroker_cr.yaml
@@ -140,7 +141,17 @@ deploy-cr: ## Create a CR for the operator
 deploy-operator: deploy-objects deploy-crds $(DEPLOY_OPERATOR) deploy-cr ## Deploy everything for the operator in cluster
 
 undeploy-operator: ## Delete everything for the operator from the cluster
-	@${TEMPLATE_CMD} $(DEPLOY_OBJECTS) $(DEPLOY_OPERATOR) $(DEPLOY_CRDS) $(DEPLOY_CRS) | kubectl delete -f - || :
+	@${TEMPLATE_CMD} ${OP_CRD_DIR}/osb_v1_automationbroker_cr.yaml | kubectl delete -f - || :
+	@${TEMPLATE_CMD} ${OP_CRD_DIR}/bundleinstances.crd.yaml | kubectl delete -f - || :
+	@${TEMPLATE_CMD} ${OP_CRD_DIR}/bundle.crd.yaml | kubectl delete -f - || :
+	@${TEMPLATE_CMD} ${OP_CRD_DIR}/bundlebindings.crd.yaml | kubectl delete -f - || :
+	@${TEMPLATE_CMD} ${OP_CRD_DIR}/osb_v1_automationbroker_crd.yaml | kubectl delete -f - || :
+	@${TEMPLATE_CMD} ${OP_DEPLOY_DIR}/operator.yaml | kubectl delete -f - || :
+	@${TEMPLATE_CMD} ${OP_DEPLOY_DIR}/role_binding.yaml | kubectl delete -f - || :
+	@${TEMPLATE_CMD} ${OP_DEPLOY_DIR}/role.yaml | kubectl delete -f - || :
+	@${TEMPLATE_CMD} ${OP_DEPLOY_DIR}/service_account.yaml | kubectl delete -f - || :
+	@${TEMPLATE_CMD} ${OP_DEPLOY_DIR}/namespace.yaml | kubectl delete -f - || :
+
 
 publish: build-image build-apb
 ifdef PUBLISH

--- a/operator/deploy/operator.yaml
+++ b/operator/deploy/operator.yaml
@@ -1,21 +1,21 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: ansible-service-broker-operator
+  name: openshift-ansible-service-broker-operator
   namespace: {{ namespace }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      name: ansible-service-broker-operator
+      name: openshift-ansible-service-broker-operator
   template:
     metadata:
       labels:
-        name: ansible-service-broker-operator
+        name: openshift-ansible-service-broker-operator
     spec:
-      serviceAccountName: ansible-service-broker-operator
+      serviceAccountName: openshift-ansible-service-broker-operator
       containers:
-        - name: ansible-service-broker-operator
+        - name: openshift-ansible-service-broker-operator
           # Replace this with the built image name
           image: "osb.openshift.io/testing-operator:testing"
           ports:
@@ -30,7 +30,7 @@ spec:
             - name: IMAGE
               value: "docker.io/ansibleplaybookbundle/origin-ansible-service-broker:v4.0"
             - name: OPERATOR_NAME
-              value: "ansible-service-broker-operator"
+              value: "openshift-ansible-service-broker-operator"
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/operator/deploy/role_binding.yaml
+++ b/operator/deploy/role_binding.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ansible-service-broker-operator
 subjects:
 - kind: ServiceAccount
-  name: ansible-service-broker-operator
+  name: openshift-ansible-service-broker-operator
   namespace: {{ namespace }}
 roleRef:
   kind: ClusterRole

--- a/operator/deploy/service_account.yaml
+++ b/operator/deploy/service_account.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: ansible-service-broker-operator
+  name: openshift-ansible-service-broker-operator
   namespace: {{ namespace }}


### PR DESCRIPTION
The `make deploy-operator` used `ansible-service-broker-operator` which is fine but doesn't match what the OLM deployed operator would be. This makes it difficult to recreate the production install from the development code. By using `openshift-ansible-service-broker-operator` this will mimic the downstream a little closer. Also, `undeploy-operator` didn't seem to work when it was a single line.