### PR TITLE
Fix CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ ci-test-coverage: coverage-all.out ## CI test coverage, upload to coveralls
 	@goveralls -coverprofile=coverage-all.out -service $(COVERAGE_SVC)
 
 vet: ## Run go vet
-	@go tool vet ./cmd ./pkg
+	@go vet $(addprefix ./, $(addsuffix /... , $(SOURCE_DIRS)))
 
 check: fmtcheck vet lint build test ## Pre-flight checks before creating PR
 

--- a/build/custom-ci-build-root.Dockerfile
+++ b/build/custom-ci-build-root.Dockerfile
@@ -1,9 +1,9 @@
-FROM openshift/origin-release:golang-1.10
+FROM openshift/origin-release:golang-1.12
 
 RUN yum install -y epel-release \
     && yum install -y python-devel python-pip gcc
 
-RUN pip install -U setuptools && pip install -U molecule==2.20.0 jmespath openshift
+RUN pip install -U setuptools wheel && pip install -U more-itertools==7.0.0 molecule==2.20.0 jmespath openshift
 
 RUN chmod g+rw /etc/passwd
 


### PR DESCRIPTION
#### Describe what this PR does and why we need it:
- Fix build of the image
- Fix go vet

#### Changes proposed in this pull request

```
$ docker build -f  build/custom-ci-build-root.Dockerfile .
Sending build context to Docker daemon  206.3MB
Step 1/4 : FROM openshift/origin-release:golang-1.12
 ---> c6a41783d3ef
Step 2/4 : RUN yum install -y epel-release     && yum install -y python-devel python-pip gcc
 ---> Using cache
 ---> 3fe44eaf9581
Step 3/4 : RUN pip install -U setuptools wheel && pip install -U more-itertools==7.0.0 molecule==2.20.0 jmespath openshift
 ---> Using cache
 ---> fca57e14583c
Step 4/4 : RUN chmod g+rw /etc/passwd
 ---> Running in d1e6bfdd9884
 ---> 8211e08223d9
Removing intermediate container d1e6bfdd9884
Successfully built 8211e08223d9
```

#### Does this PR depend on another PR (Use this to track when PRs should be merged)
depends-on <PR>

#### Which issue this PR fixes (This will close that issue when PR gets merged)

```
Collecting more-itertools>=4.0.0 (from pytest!=3.0.2->testinfra==1.19.0->molecule==2.20.0)
  Downloading https://files.pythonhosted.org/packages/a0/47/6ff6d07d84c67e3462c50fa33bf649cda859a8773b53dc73842e84455c05/more-itertools-8.2.0.tar.gz (82kB)
    Complete output from command python setup.py egg_info:
    /usr/lib/python2.7/site-packages/pkg_resources/py2_warn.py:21: UserWarning: Setuptools will stop working on Python 2
    ************************************************************
    You are running Setuptools on Python 2, which is no longer
    supported and
    >>> SETUPTOOLS WILL STOP WORKING <<<
    in a subsequent release (no sooner than 2020-04-20).
    Please ensure you are installing
    Setuptools using pip 9.x or later or pin to `setuptools<45`
    in your environment.
    If you have done those things and are still encountering
    this message, please follow up at
    https://bit.ly/setuptools-py2-warning.
    ************************************************************
      sys.version_info < (3,) and warnings.warn(pre + "*" * 60 + msg + "*" * 60)
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-C67ASH/more-itertools/setup.py", line 5, in <module>
        from more_itertools import __version__
      File "more_itertools/__init__.py", line 1, in <module>
        from .more import *  # noqa
      File "more_itertools/more.py", line 480
        yield from iterable
                 ^
    SyntaxError: invalid syntax
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-C67ASH/more-itertools/
You are using pip version 8.1.2, however version 20.0.2 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
subprocess exited with status 1
subprocess exited with status 1
error: build error: error building at STEP "RUN pip install -U setuptools wheel && pip install -U molecule==2.20.0 jmespath openshift": exit status 1
2020/03/27 12:33:42 No custom metadata found and prow metadata already exists. Not updating the metadata.
2020/03/27 12:33:43 Ran for 3m55s
2020/03/27 12:33:43 Submitted failure event to sentry (id=a5d92d21b2b84513b21ff809333b586b)
error: could not run steps: step root failed: could not wait for build: the build root failed after 3m49s with reason DockerBuildFailed: Dockerfile build strategy has failed.

You are using pip version 8.1.2, however version 20.0.2 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
subprocess exited with status 1
subprocess exited with status 1
error: build error: error building at STEP "RUN pip instal...tall -U molecule==2.20.0 jmespath openshift": exit status 1
```
