### PR TITLE
fix ci: master branch custom build image should still using python 2

### DIFF
--- a/build/custom-ci-build-root.Dockerfile
+++ b/build/custom-ci-build-root.Dockerfile
@@ -1,8 +1,8 @@
 FROM openshift/origin-release:golang-1.13
 
 RUN yum install -y epel-release \
-    && yum install -y python36-devel python3-pip gcc
+    && yum install -y python-devel python-pip gcc
 
-RUN pip3 install -U setuptools wheel && pip3 install -U more-itertools==7.0.0 molecule==2.22.0 jmespath openshift
+RUN pip install -U setuptools wheel && pip install -U more-itertools==7.0.0 molecule==2.22.0 jmespath openshift
 
 RUN chmod g+rw /etc/passwd


### PR DESCRIPTION
#### Describe what this PR does and why we need it:
fix ci: master branch custom build image should still using python 2

#### Changes proposed in this pull request

Fix the build with python. We shoud not upgrade it since the https://github.com/openshift/ocp-release-operator-sdk/blob/master/release/ansible/Dockerfile#L21 still using python2. The current molecule impl ocp-release-operator-sdk will not work with python3. It is facing the encoding issue. 

#### Which issue this PR fixes (This will close that issue when PR gets merged)

<img width="810" alt="Screenshot 2020-03-27 at 16 49 47" src="https://user-images.githubusercontent.com/7708031/77779828-02335c80-704b-11ea-9ed5-16cbf5e8a9b5.png">


```
2020/03/25 17:26:07 Container setup in pod operator-molecule-e2e completed successfully
secret/support created
Traceback (most recent call last):
  File "/usr/local/bin/molecule", line 11, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 760, in main
    _verify_python3_env()
  File "/usr/local/lib/python3.6/site-packages/click/_unicodefun.py", line 130, in _verify_python3_env
    " mitigation steps.{}".format(extra)
RuntimeError: Click will abort further execution because Python 3 was configured to use ASCII as encoding for the environment. Consult https://click.palletsprojects.com/python3/ for mitigation steps.

This system lists a couple of UTF-8 supporting locales that you can pick from. The following suitable locales were discovered: en_AG.utf8, en_AU.utf8, en_BW.utf8, en_CA.utf8, en_DK.utf8, en_GB.utf8, en_HK.utf8, en_IE.utf8, en_IN.utf8, en_NG.utf8, en_NZ.utf8, en_PH.utf8, en_SG.utf8, en_US.utf8, en_ZA.utf8, en_ZM.utf8, en_ZW.utf8
2020/03/25 17:26:21 Container test in pod operator-molecule-e2e failed, exit code 1, reason Error
2020/03/25 17:39:57 Copied 56.74MB of artifacts from operator-molecule-e2e to /logs/artifacts/operator-molecule-e2e
2020/03/25 17:39:57 Releasing lease for "aws-quota-slice"
2020/03/25 17:39:58 No custom metadata found and prow metadata already exists. Not updating the metadata.
2020/03/25 17:39:59 Ran for 53m19s
2020/03/25 17:39:59 Submitted failure event to sentry (id=69e8e63c0af54af8b6f195efdbfb31c1)
error: could not run steps: step operator-molecule-e2e failed: template pod "operator-molecule-e2e" failed: the pod ci-op-vc06girj/operator-molecule-e2e failed after 44m47s (failed containers: test): ContainerFailed one or more containers exited

Container test exited with code 1, reason Error
---
secret/support created
Traceback (most recent call last):
  File "/usr/local/bin/molecule", line 11, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 760, in main
    _verify_python3_env()
  File "/usr/local/lib/python3.6/site-packages/click/_unicodefun.py", line 130, in _verify_python3_env
    " mitigation steps.{}".format(extra)
RuntimeError: Click will abort further execution because Python 3 was configured to use ASCII as encoding for the environment. Consult https://click.palletsprojects.com/python3/ for mitigation steps.

This system lists a couple of UTF-8 supporting locales that you can pick from. The following suitable locales were discovered: en_AG.utf8, en_AU.utf8, en_BW.utf8, en_CA.utf8, en_DK.utf8, en_GB.utf8, en_HK.utf8, en_IE.utf8, en_IN.utf8, en_NG.utf8, en_NZ.utf8, en_PH.utf8, en_SG.utf8, en_US.utf8, en_ZA.utf8, en_ZM.utf8, en_ZW.utf8
---
```